### PR TITLE
GetUserSPNs: you can now specify another base DN

### DIFF
--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -86,7 +86,10 @@ class GetUserSPNs:
             self.__lmhash, self.__nthash = cmdLineOptions.hashes.split(':')
 
         # Create the baseDN
-        domainParts = self.__domain.split('.')
+	if cmdLineOptions.base_dn is not None:
+	    domainParts = cmdLineOptions.base_dn.split('.')
+	else:
+	    domainParts = self.__domain.split('.')
         self.baseDN = ''
         for i in domainParts:
             self.baseDN += 'dc=%s,' % i
@@ -350,6 +353,9 @@ if __name__ == '__main__':
     group.add_argument('-dc-ip', action='store',metavar = "ip address",  help='IP Address of the domain controller. If '
                                                                               'ommited it use the domain part (FQDN) '
                                                                               'specified in the target parameter')
+    group.add_argument('-base-dn', action='store',metavar = "base dn",  help='Base DN of the interogated DC '
+                                                                              '(if different from the one used to authenticate)')
+
 
     if len(sys.argv)==1:
         parser.print_help()

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -392,8 +392,10 @@ def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey):
         return r, cipher, sessionKey, newSessionKey
     else:
         # Let's extract the Ticket, change the domain and keep asking
+        # We also interrogate a new KDC. TODO: how to find the KDC associated
+        # with the new domain. For now, we just try to resolve the new domain.
         domain = spn.components[1]
-        return getKerberosTGS(serverName, domain, kdcHost, r, cipher, newSessionKey)
+        return getKerberosTGS(serverName, domain, domain, r, cipher, newSessionKey)
     
     return r, cipher, sessionKey, newSessionKey
 


### PR DESCRIPTION
Hello @asolino,

I added the possibility to specify another base DN when interrogating the DC. This way, if you have a trust relationship between Domains A and B, you can use a user from domain A to get kerberos tickets from a domain B DC.

Cheers,

Y

[Edit] Hmm, actually this PR only enables you to list SPNs cross-domain, but not to request TGS cross-domain. Right now, you get a `Kerberos SessionError: KDC_ERR_WRONG_REALM(Reserved for future use)` error message. I'll try and fix it!