### PR TITLE
Allow smb.get_encryption_key() to retrieve challenge used in login_extended

### DIFF
--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -3281,6 +3281,9 @@ class SMB:
             if ntlmChallenge.fields.has_key('Version'):
                 version = ntlmChallenge['Version']
 
+            if ntlmChallenge.fields.has_key('challenge'):
+                self._dialects_data['Challenge'] = ntlmChallenge["challenge"]
+
                 if len(version) >= 4:
                    self.__server_os_major, self.__server_os_minor, self.__server_os_build = unpack('<BBH',version[:4])
 

--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -3281,11 +3281,11 @@ class SMB:
             if ntlmChallenge.fields.has_key('Version'):
                 version = ntlmChallenge['Version']
 
-            if ntlmChallenge.fields.has_key('challenge'):
-                self._dialects_data['Challenge'] = ntlmChallenge["challenge"]
-
                 if len(version) >= 4:
                    self.__server_os_major, self.__server_os_minor, self.__server_os_build = unpack('<BBH',version[:4])
+
+            if ntlmChallenge.fields.has_key('challenge'):
+                self._dialects_data['Challenge'] = ntlmChallenge["challenge"]
 
             type3, exportedSessionKey = ntlm.getNTLMSSPType3(auth, respToken['ResponseToken'], user, password, domain, lmhash, nthash, use_ntlmv2 = use_ntlmv2)
 


### PR DESCRIPTION
I want to be able to check the NTLM challenge issued by a server from an instance of ```SMBConnection```. In some cases it is available via ```.getSMBServer().get_encryption_key()``` but if authentication goes through the ```smb.login_extended``` method then the return value will be ```None```.

I don't know NTLM/SMB very well. So please excuse my ignorance if I can obtain this information elsewhere or should go about this in a different way.