### PR TITLE
Don't forget self...  Undefined name: data --> self.data

### DIFF
--- a/impacket/krb5/types.py
+++ b/impacket/krb5/types.py
@@ -161,16 +161,16 @@ class Address(object):
             return socket.AF_INET
         elif self.type == constants.AddressType.IPv4.value:
             return socket.AF_INET6
-            self.address = socket.inet_pton(self.family, data)
+            self.address = socket.inet_pton(self.family, self.data)
         else:
             return None
 
     @property
     def address(self):
         if self.type == constants.AddressType.IPv4.value:
-            return socket.inet_pton(self.family, data)
+            return socket.inet_pton(self.family, self.data)
         elif self.type == constants.AddressType.IPv4.value:
-            return socket.inet_pton(self.family, data)
+            return socket.inet_pton(self.family, self.data)
         else:
             return None
 


### PR DESCRIPTION
Partial fix for #494.  __data__ is an _undefined name_ in this context which will probably raise a NameError at runtime but each __Address__ object has a __self.data__ attribute.