### PR TITLE
Ntlmrelayx ldap attack port to py3

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -29,10 +29,7 @@ from pyasn1.type.univ import Sequence, Integer
 from ldap3.utils.conv import escape_filter_chars
 from ldap3.core.results import RESULT_UNWILLING_TO_PERFORM
 from six import PY3
-if PY3:
-    LOG.error('ldapdomaindump still not support Python3. This attack will not work')
-else:
-    import ldapdomaindump
+import ldapdomaindump
 # This is new from ldap3 v2.5
 try:
     from ldap3.protocol.microsoft import security_descriptor_control
@@ -268,11 +265,11 @@ class LDAPAttack(ProtocolAttack):
                         else:
                             # Could be a different OU where we have access
                             # store it until we find a better place
-                            if privs['createIn'] != 'CN=Users,%s' % domainDumper.root and 'organizationalUnit' in entry['raw_attributes']['objectClass']:
+                            if privs['createIn'] != 'CN=Users,%s' % domainDumper.root and b'organizationalUnit' in entry['raw_attributes']['objectClass']:
                                 privs['create'] = True
                                 privs['createIn'] = dn
                     if can_add_member(ace) or hasFullControl:
-                        if 'group' in entry['raw_attributes']['objectClass']:
+                        if b'group' in entry['raw_attributes']['objectClass']:
                             # We can add members to a group
                             if not hasFullControl:
                                 LOG.debug('Permission found: Add member to %s; Reason: Granted to %s' % (dn, sidmapping[sid]))
@@ -282,7 +279,7 @@ class LDAPAttack(ProtocolAttack):
                         if not hasFullControl:
                             LOG.debug('Permission found: Write Dacl of %s; Reason: Granted to %s' % (dn, sidmapping[sid]))
                         # We can modify the domain Dacl
-                        if 'domain' in entry['raw_attributes']['objectClass']:
+                        if b'domain' in entry['raw_attributes']['objectClass']:
                             privs['aclEscalate'] = True
                             privs['aclEscalateIn'] = dn
 

--- a/impacket/ldap/ldaptypes.py
+++ b/impacket/ldap/ldaptypes.py
@@ -135,7 +135,7 @@ https://msdn.microsoft.com/en-us/library/cc230295.aspx
 """
 class ACE(Structure):
     # Flag constants
-    CONTAINER_INHERIT_ACE       = 0x01
+    CONTAINER_INHERIT_ACE       = 0x02
     FAILED_ACCESS_ACE_FLAG      = 0x80
     INHERIT_ONLY_ACE            = 0x08
     INHERITED_ACE               = 0x10
@@ -484,9 +484,9 @@ Reference:
 Can also be queried from the Schema
 """
 OBJECTTYPE_GUID_MAP = {
-    'group': 'bf967a9c-0de6-11d0-a285-00aa003049e2',
-    'domain': '19195a5a-6da0-11d0-afd3-00c04fd930c9',
-    'organizationalUnit': 'bf967aa5-0de6-11d0-a285-00aa003049e2',
-    'user': 'bf967aba-0de6-11d0-a285-00aa003049e2',
-    'groupPolicyContainer': 'f30e3bc2-9ff0-11d1-b603-0000f80367c1'
+    b'group': 'bf967a9c-0de6-11d0-a285-00aa003049e2',
+    b'domain': '19195a5a-6da0-11d0-afd3-00c04fd930c9',
+    b'organizationalUnit': 'bf967aa5-0de6-11d0-a285-00aa003049e2',
+    b'user': 'bf967aba-0de6-11d0-a285-00aa003049e2',
+    b'groupPolicyContainer': 'f30e3bc2-9ff0-11d1-b603-0000f80367c1'
 }

--- a/impacket/ldap/ldaptypes.py
+++ b/impacket/ldap/ldaptypes.py
@@ -39,7 +39,7 @@ class LDAP_SID(Structure):
     )
 
     def formatCanonical(self):
-        ans = 'S-%d-%d' % (self['Revision'], ord(self['IdentifierAuthority']['Value'][5]))
+        ans = 'S-%d-%d' % (self['Revision'], ord(self['IdentifierAuthority']['Value'][5:6]))
         for i in range(self['SubAuthorityCount']):
             ans += '-%d' % ( unpack('<L',self['SubAuthority'][i*4:i*4+4])[0])
         return ans
@@ -48,9 +48,9 @@ class LDAP_SID(Structure):
         items = canonical.split('-')
         self['Revision'] = int(items[1])
         self['IdentifierAuthority'] = LDAP_SID_IDENTIFIER_AUTHORITY()
-        self['IdentifierAuthority']['Value'] = '\x00\x00\x00\x00\x00' + pack('B',int(items[2]))
+        self['IdentifierAuthority']['Value'] = b'\x00\x00\x00\x00\x00' + pack('B',int(items[2]))
         self['SubAuthorityCount'] = len(items) - 3
-        self['SubAuthority'] = ''
+        self['SubAuthority'] = b''
         for i in range(self['SubAuthorityCount']):
             self['SubAuthority'] += pack('<L', int(items[i+3]))
 
@@ -81,22 +81,22 @@ class SR_SECURITY_DESCRIPTOR(Structure):
         if self['OffsetOwner'] != 0:
             self['OwnerSid'] = LDAP_SID(data=data[self['OffsetOwner']:])
         else:
-            self['OwnerSid'] = ''
+            self['OwnerSid'] = b''
 
         if self['OffsetGroup'] != 0:
             self['GroupSid'] = LDAP_SID(data=data[self['OffsetGroup']:])
         else:
-            self['GroupSid'] = ''
+            self['GroupSid'] = b''
 
         if self['OffsetSacl'] != 0:
             self['Sacl'] = ACL(data=data[self['OffsetSacl']:])
         else:
-            self['Sacl'] = ''
+            self['Sacl'] = b''
 
         if self['OffsetDacl'] != 0:
             self['Dacl'] = ACL(data=data[self['OffsetDacl']:])
         else:
-            self['Sacl'] = ''
+            self['Sacl'] = b''
 
     def getData(self):
         headerlen = 20
@@ -104,25 +104,25 @@ class SR_SECURITY_DESCRIPTOR(Structure):
         # flags are currently not set automatically
         # TODO: do this?
         datalen = 0
-        if self['Sacl'] != '':
+        if self['Sacl'] != b'':
             self['OffsetSacl'] = headerlen + datalen
             datalen += len(self['Sacl'].getData())
         else:
             self['OffsetSacl'] = 0
 
-        if self['Dacl'] != '':
+        if self['Dacl'] != b'':
             self['OffsetDacl'] = headerlen + datalen
             datalen += len(self['Dacl'].getData())
         else:
             self['OffsetDacl'] = 0
 
-        if self['OwnerSid'] != '':
+        if self['OwnerSid'] != b'':
             self['OffsetOwner'] = headerlen + datalen
             datalen += len(self['OwnerSid'].getData())
         else:
             self['OffsetOwner'] = 0
 
-        if self['GroupSid'] != '':
+        if self['GroupSid'] != b'':
             self['OffsetGroup'] = headerlen + datalen
             datalen += len(self['GroupSid'].getData())
         else:
@@ -273,9 +273,9 @@ class ACCESS_ALLOWED_OBJECT_ACE(Structure):
 
     def getData(self):
         # Set the correct flags
-        if self['ObjectType'] != '':
+        if self['ObjectType'] != b'':
             self['Flags'] |= self.ACE_OBJECT_TYPE_PRESENT
-        if self['InheritedObjectType'] != '':
+        if self['InheritedObjectType'] != b'':
             self['Flags'] |= self.ACE_INHERITED_OBJECT_TYPE_PRESENT
         return Structure.getData(self)
 
@@ -470,7 +470,7 @@ class ACL(Structure):
         self['AceCount'] = len(self.aces)
         # We modify the data field to be able to use the
         # parent class parsing
-        self['Data'] = ''.join([ace.getData() for ace in self.aces])
+        self['Data'] = b''.join([ace.getData() for ace in self.aces])
         self['AclSize'] = len(self['Data'])+8 # Header size (8 bytes) is included
         data = Structure.getData(self)
         # Put the ACEs back in data

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ pyasn1>=0.2.3
 pycryptodomex
 pyOpenSSL>=0.16.2
 ldap3>=2.5
-ldapdomaindump
+ldapdomaindump>=0.9.0
 flask>=1.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name = PACKAGE_NAME,
                 'impacket.examples.ntlmrelayx.attacks'],
       scripts = glob.glob(os.path.join('examples', '*.py')),
       data_files = data_files,
-      install_requires=['pyasn1>=0.2.3', 'pycryptodomex', 'pyOpenSSL>=0.13.1', 'six', 'ldap3>=2.5.0', 'ldapdomaindump', 'flask>=1.0'],
+      install_requires=['pyasn1>=0.2.3', 'pycryptodomex', 'pyOpenSSL>=0.13.1', 'six', 'ldap3>=2.5.0', 'ldapdomaindump>=0.9.0', 'flask>=1.0'],
       extras_require={
                       'pyreadline:sys_platform=="win32"': [],
                       ':python_version<"2.7"': [ 'argparse' ],


### PR DESCRIPTION
- ldaptypes py3 and py2 compatible + small flag definition bugfix
- bugfixes in privilege enumeration
- bumped impacket dependency for ldapdomaindump to 0.9.0 (first python3 version)
- ntlmrelayx now should work identical with python 2 and 3