### PR TITLE
Added option to dump/calculate machine account Kerberos keys to secretsdump

### DIFF
--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -177,8 +177,7 @@ class DumpSecrets:
                         SECURITYFileName = self.__securityHive
 
                     self.__LSASecrets = LSASecrets(SECURITYFileName, bootKey, self.__remoteOps,
-                                                   isRemote=self.__isRemote, history=self.__history,
-                                                   machineKerberos=self.__options.machine_kerberos)
+                                                   isRemote=self.__isRemote, history=self.__history)
                     self.__LSASecrets.dumpCachedHashes()
                     if self.__outputFileName is not None:
                         self.__LSASecrets.exportCached(self.__outputFileName)
@@ -309,7 +308,6 @@ if __name__ == '__main__':
     group.add_argument('-user-status', action='store_true', default=False,
                         help='Display whether or not the user is disabled')
     group.add_argument('-history', action='store_true', help='Dump password history, and LSA secrets OldVal')
-    group.add_argument('-machine-kerberos', action='store_true', help='Dump machine account Kerberos keys (LSA secrets)')
     group = parser.add_argument_group('authentication')
 
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')

--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -21,8 +21,8 @@
 #                   It's copied on the temp dir and parsed remotely.
 #
 #              The script initiates the services required for its working
-#              if they are not available (e.g. Remote Registry, even if it is 
-#              disabled). After the work is done, things are restored to the 
+#              if they are not available (e.g. Remote Registry, even if it is
+#              disabled). After the work is done, things are restored to the
 #              original state.
 #
 # Author:
@@ -177,7 +177,8 @@ class DumpSecrets:
                         SECURITYFileName = self.__securityHive
 
                     self.__LSASecrets = LSASecrets(SECURITYFileName, bootKey, self.__remoteOps,
-                                                   isRemote=self.__isRemote, history=self.__history)
+                                                   isRemote=self.__isRemote, history=self.__history,
+                                                   machineKerberos=self.__options.machine_kerberos)
                     self.__LSASecrets.dumpCachedHashes()
                     if self.__outputFileName is not None:
                         self.__LSASecrets.exportCached(self.__outputFileName)
@@ -308,6 +309,7 @@ if __name__ == '__main__':
     group.add_argument('-user-status', action='store_true', default=False,
                         help='Display whether or not the user is disabled')
     group.add_argument('-history', action='store_true', help='Dump password history, and LSA secrets OldVal')
+    group.add_argument('-machine-kerberos', action='store_true', help='Dump machine account Kerberos keys (LSA secrets)')
     group = parser.add_argument_group('authentication')
 
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
@@ -339,7 +341,7 @@ if __name__ == '__main__':
 
     domain, username, password, remoteName = re.compile('(?:(?:([^/@:]*)/)?([^@:]*)(?::([^@]*))?@)?(.*)').match(
         options.target).groups('')
-        
+
     #In case the password contains '@'
     if '@' in remoteName:
         password = password + '@' + remoteName.rpartition('@')[0]

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1262,7 +1262,7 @@ class LSASecrets(OfflineRegistry):
         LSA_RAW = 2
 
     def __init__(self, securityFile, bootKey, remoteOps=None, isRemote=False, history=False,
-                 perSecretCallback=lambda secretType, secret: _print_helper(secret), machineKerberos=False):
+                 perSecretCallback=lambda secretType, secret: _print_helper(secret)):
         OfflineRegistry.__init__(self, securityFile, isRemote)
         self.__hashedBootKey = b''
         self.__bootKey = bootKey
@@ -1276,7 +1276,6 @@ class LSASecrets(OfflineRegistry):
         self.__secretItems = []
         self.__perSecretCallback = perSecretCallback
         self.__history = history
-        self.__machineKerberos = machineKerberos
 
     def MD5(self, data):
         md5 = hashlib.new('md5')
@@ -1516,13 +1515,12 @@ class LSASecrets(OfflineRegistry):
             else:
                 printname = "$MACHINE.ACC"
                 secret = "$MACHINE.ACC: %s:%s" % (hexlify(ntlm.LMOWFv1('','')).decode('utf-8'), hexlify(md4.digest()).decode('utf-8'))
-            if self.__machineKerberos:
-                # Attempt to calculate and print Kerberos keys
-                if not self.__printMachineKerberos(secretItem, printname):
-                    LOG.debug('Could not calculate machine account Kerberos keys, printing plain password (hex encoded)')
-                    extrasecret = "$MACHINE.ACC:plain_password_hex:%s" % hexlify(secretItem).decode('utf-8')
-                    self.__secretItems.append(extrasecret)
-                    self.__perSecretCallback(LSASecrets.SECRET_TYPE.LSA, extrasecret)
+            # Attempt to calculate and print Kerberos keys
+            if not self.__printMachineKerberos(secretItem, printname):
+                LOG.debug('Could not calculate machine account Kerberos keys, printing plain password (hex encoded)')
+                extrasecret = "$MACHINE.ACC:plain_password_hex:%s" % hexlify(secretItem).decode('utf-8')
+                self.__secretItems.append(extrasecret)
+                self.__perSecretCallback(LSASecrets.SECRET_TYPE.LSA, extrasecret)
         if secret != '':
             printableSecret = secret
             self.__secretItems.append(secret)


### PR DESCRIPTION
Secretsdump can now dump/calculate Kerberos keys for the machine account. Currently only works reliably if it is run remotely since then we know the DNS domain name and computername (in most cases). In other cases it can't determine the Kerberos salt and will dump the raw password as hex-encoded string which the user can then manually combine with the salt to do the key calculation.

```
python secretsdump.py 'testsegment/backupadmin:thisisapassword@w10-outlook.testsegment.local' -machine-kerberos -history 
Impacket v0.9.18-dev - Copyright 2018 SecureAuth Corporation

[*] Service RemoteRegistry is in stopped state
[*] Service RemoteRegistry is disabled, enabling it
[*] Starting service RemoteRegistry
[*] Target system bootKey: 0x35efc771d93710340273c2d7f8c33e94
[*] Dumping local SAM hashes (uid:rid:lmhash:nthash)
[ snip ]
[*] Dumping cached domain logon information (domain/username:hash)
[ snip ]
[*] Dumping LSA Secrets
[*] $MACHINE.ACC 
TESTSEGMENT\W10-OUTLOOK$:aes256-cts-hmac-sha1-96:746f13d51a3859c7e38658b635f0280d24aa73eb3f627dda262ce3c542295a24
TESTSEGMENT\W10-OUTLOOK$:aes128-cts-hmac-sha1-96:0ca65c3ea3cec3a31b70edf6f9c0aa6f
TESTSEGMENT\W10-OUTLOOK$:des-cbc-md5:16911f2cb6b94ce9
TESTSEGMENT\W10-OUTLOOK$:aad3b435b51404eeaad3b435b51404ee:7a99efdea0e03b94db2e54c85911af47:::
[*] $MACHINE.ACC_history 
TESTSEGMENT\W10-OUTLOOK$:aes256-cts-hmac-sha1-96:e02b34c20c96ffe04a46b9717f5e8e851de04d09c75e14c95b9bf3031e262a7e
TESTSEGMENT\W10-OUTLOOK$:aes128-cts-hmac-sha1-96:b45f3df6584115a0dc67127475bc2162
TESTSEGMENT\W10-OUTLOOK$:des-cbc-md5:d08a1c795b9d75a4
TESTSEGMENT\W10-OUTLOOK$:aad3b435b51404eeaad3b435b51404ee:fdc610d1fba86c406fe451d2b6d33c93:::
```

Works in both py2 and py3. I've also fixed some small issues with the empty NT and LM hash not being printed in py3, and with the history flag throwing an exception in py3.