### PR TITLE
Travis CI: Add flake8 to find syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,22 @@
+group: travis_latest
 language: python
-install:
-  - pip install -r requirements.txt
-  - pip install tox
+cache: pip
+
+matrix:
+  include:
+    - python: 2.7
+      env: NO_REMOTE=true, TOXENV=py27
+    - python: 3.6
+      env: NO_REMOTE=true, TOXENV=py36
+  allow_failures:
+    - python: 3.6
+
+install: pip install flake8 tox -r requirements.txt
+  
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
 script: tox
-env:
-  - NO_REMOTE=true


### PR DESCRIPTION
Test on both Python 2.7 and 3.6 and add flake8 to find find syntax errors and undefined names.  Run the Python 3 tests in __allow_failures__ mode until the __python36__ branch is merged.


__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree