### PR TITLE
Old style exceptions --> new style

### DIFF
--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -154,7 +154,7 @@ class GetUserNoPreAuth:
 
         try:
             r = sendReceive(message, domain, self.__kdcHost)
-        except KerberosError, e:
+        except KerberosError as e:
             if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
                 # RC4 not available, OK, let's ask for newer types
                 supportedCiphers = (int(constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value),
@@ -214,7 +214,7 @@ class GetUserNoPreAuth:
             else:
                 ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
                                              self.__aesKey, kdcHost=self.__kdcHost)
-        except ldap.LDAPSessionError, e:
+        except ldap.LDAPSessionError as e:
             if str(e).find('strongerAuthRequired') >= 0:
                 # We need to try SSL
                 ldapConnection = ldap.LDAPConnection('ldaps://%s' % target, self.baseDN, self.__kdcHost)
@@ -242,7 +242,7 @@ class GetUserNoPreAuth:
                                          attributes=['sAMAccountName',
                                                      'pwdLastSet', 'MemberOf', 'userAccountControl', 'lastLogon'],
                                          sizeLimit=999)
-        except ldap.LDAPSearchError, e:
+        except ldap.LDAPSearchError as e:
             if e.getErrorString().find('sizeLimitExceeded') >= 0:
                 logging.debug('sizeLimitExceeded exception caught, giving up and processing the data received')
                 # We reached the sizeLimit, process the answers we have already and that's it. Until we implement
@@ -285,7 +285,7 @@ class GetUserNoPreAuth:
                             lastLogon = str(datetime.datetime.fromtimestamp(self.getUnixTime(int(str(attribute['vals'][0])))))
                 if mustCommit is True:
                     answers.append([sAMAccountName,memberOf, pwdLastSet, lastLogon, userAccountControl])
-            except Exception, e:
+            except Exception as e:
                 logging.error('Skipping item, cannot process due to error %s' % str(e))
                 pass
 
@@ -303,7 +303,7 @@ class GetUserNoPreAuth:
                     try:
                         entry = self.getTGT(answer[0])
                         self.outputTGT(entry,fd)
-                    except Exception , e:
+                    except Exception as e:
                         logging.error('%s' % str(e))
                 if fd is not None:
                     fd.close()
@@ -392,7 +392,7 @@ if __name__ == '__main__':
     try:
         executer = GetUserNoPreAuth(username, password, domain, options)
         executer.run()
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -158,7 +158,7 @@ class GetUserSPNs:
                                                                 compute_lmhash(self.__password),
                                                                 compute_nthash(self.__password), self.__aesKey,
                                                                 kdcHost=self.__kdcHost)
-            except Exception, e:
+            except Exception as e:
                 logging.debug('TGT: %s' % str(e))
                 tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, self.__password, self.__domain,
                                                                     unhexlify(self.__lmhash),
@@ -239,7 +239,7 @@ class GetUserSPNs:
             try:
                 ccache.fromTGS(tgs, oldSessionKey, sessionKey )
                 ccache.saveFile('%s.ccache' % username)
-            except Exception, e:
+            except Exception as e:
                 logging.error(str(e))
 
     def run(self):
@@ -259,7 +259,7 @@ class GetUserSPNs:
             else:
                 ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
                                              self.__aesKey, kdcHost=self.__kdcHost)
-        except ldap.LDAPSessionError, e:
+        except ldap.LDAPSessionError as e:
             if str(e).find('strongerAuthRequired') >= 0:
                 # We need to try SSL
                 ldapConnection = ldap.LDAPConnection('ldaps://%s' % target, self.baseDN, self.__kdcHost)
@@ -285,7 +285,7 @@ class GetUserSPNs:
                                          attributes=['servicePrincipalName', 'sAMAccountName',
                                                      'pwdLastSet', 'MemberOf', 'userAccountControl', 'lastLogon'],
                                          sizeLimit=999)
-        except ldap.LDAPSearchError, e:
+        except ldap.LDAPSearchError as e:
             if e.getErrorString().find('sizeLimitExceeded') >= 0:
                 logging.debug('sizeLimitExceeded exception caught, giving up and processing the data received')
                 # We reached the sizeLimit, process the answers we have already and that's it. Until we implement
@@ -337,7 +337,7 @@ class GetUserSPNs:
                     else:
                         for spn in SPNs:
                             answers.append([spn, sAMAccountName,memberOf, pwdLastSet, lastLogon])
-            except Exception, e:
+            except Exception as e:
                 logging.error('Skipping item, cannot process due to error %s' % str(e))
                 pass
 
@@ -363,7 +363,7 @@ class GetUserSPNs:
                                                                                 TGT['KDC_REP'], TGT['cipher'],
                                                                                 TGT['sessionKey'])
                         self.outputTGS(tgs, oldSessionKey, sessionKey, user, SPN, fd)
-                    except Exception , e:
+                    except Exception as e:
                         logging.error('SPN: %s - %s' % (SPN,str(e)))
                 if fd is not None:
                     fd.close()
@@ -453,7 +453,7 @@ if __name__ == '__main__':
     try:
         executer = GetUserSPNs(username, password, userDomain, targetDomain, options)
         executer.run()
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/atexec.py
+++ b/examples/atexec.py
@@ -55,7 +55,7 @@ class TSCH_EXEC:
             rpctransport.set_kerberos(self.__doKerberos, self.__kdcHost)
         try:
             self.doStuff(rpctransport)
-        except Exception, e:
+        except Exception as e:
             if logging.getLogger().level == logging.DEBUG:
                 import traceback
                 traceback.print_exc()
@@ -142,7 +142,7 @@ class TSCH_EXEC:
             logging.info('Deleting task \\%s' % tmpName)
             tsch.hSchRpcDelete(dce, '\\%s' % tmpName)
             taskCreated = False
-        except tsch.DCERPCSessionError, e:
+        except tsch.DCERPCSessionError as e:
             logging.error(e)
             e.get_packet().dump()
         finally:
@@ -156,7 +156,7 @@ class TSCH_EXEC:
                 logging.info('Attempting to read ADMIN$\\Temp\\%s' % tmpFileName)
                 smbConnection.getFile('ADMIN$', 'Temp\\%s' % tmpFileName, output_callback)
                 break
-            except Exception, e:
+            except Exception as e:
                 if str(e).find('SHARING') > 0:
                     time.sleep(3)
                 elif str(e).find('STATUS_OBJECT_NAME_NOT_FOUND') >= 0:

--- a/examples/dcomexec.py
+++ b/examples/dcomexec.py
@@ -172,7 +172,7 @@ class DCOMEXEC:
                     self.shell.do_exit('')
             else:
                 self.shell.cmdloop()
-        except  (Exception, KeyboardInterrupt), e:
+        except  (Exception, KeyboardInterrupt) as e:
             if logging.getLogger().level == logging.DEBUG:
                 import traceback
                 traceback.print_exc()
@@ -228,7 +228,7 @@ class RemoteShell(cmd.Cmd):
         else:
             try:
                 os.chdir(s)
-            except Exception, e:
+            except Exception as e:
                 logging.error(str(e))
 
     def do_get(self, src_path):
@@ -241,7 +241,7 @@ class RemoteShell(cmd.Cmd):
             logging.info("Downloading %s\\%s" % (drive, tail))
             self.__transferClient.getFile(drive[:-1]+'$', tail, fh.write)
             fh.close()
-        except Exception, e:
+        except Exception as e:
             logging.error(str(e))
             os.remove(filename)
             pass
@@ -265,7 +265,7 @@ class RemoteShell(cmd.Cmd):
             logging.info("Uploading %s to %s" % (src_file, pathname))
             self.__transferClient.putFile(drive[:-1]+'$', tail, fh.read)
             fh.close()
-        except Exception, e:
+        except Exception as e:
             logging.critical(str(e))
             pass
 
@@ -327,7 +327,7 @@ class RemoteShell(cmd.Cmd):
             try:
                 self.__transferClient.getFile(self._share, self._output, output_callback)
                 break
-            except Exception, e:
+            except Exception as e:
                 if str(e).find('STATUS_SHARING_VIOLATION') >=0:
                     # Output not finished, let's wait
                     time.sleep(1)
@@ -562,7 +562,7 @@ if __name__ == '__main__':
         executer = DCOMEXEC(' '.join(options.command), username, password, domain, options.hashes, options.aesKey,
                             options.share, options.nooutput, options.k, options.dc_ip, options.object)
         executer.run(address)
-    except (Exception, KeyboardInterrupt), e:
+    except (Exception, KeyboardInterrupt) as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/esentutl.py
+++ b/examples/esentutl.py
@@ -99,7 +99,7 @@ def main():
             exportTable(ese, options.table)
         else:
             raise Exception('Unknown action %s ' % options.action)
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/getArch.py
+++ b/examples/getArch.py
@@ -58,7 +58,7 @@ class TARGETARCH:
                 dce.connect()
                 try:
                     dce.bind(MSRPC_UUID_PORTMAP, transfer_syntax=self.NDR64Syntax)
-                except DCERPCException, e:
+                except DCERPCException as e:
                     if str(e).find('syntaxes_not_supported') >= 0:
                         print '%s is 32-bit' % machine
                     else:
@@ -68,7 +68,7 @@ class TARGETARCH:
                     print '%s is 64-bit' % machine
 
                 dce.disconnect()
-            except Exception, e:
+            except Exception as e:
                 #import traceback
                 #traceback.print_exc()
                 logging.error('%s: %s' % (machine, str(e)))
@@ -104,7 +104,7 @@ if __name__ == '__main__':
     try:
         getArch = TARGETARCH(options)
         getArch.run()
-    except (Exception, KeyboardInterrupt), e:
+    except (Exception, KeyboardInterrupt) as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/getPac.py
+++ b/examples/getPac.py
@@ -328,7 +328,7 @@ if __name__ == '__main__':
     try:
         dumper = S4U2SELF(options.targetUser, username, password, domain, options.hashes)
         dumper.dump(address)
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -433,7 +433,7 @@ if __name__ == '__main__':
 
         executer = GETST(username, password, domain, options)
         executer.run()
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/getTGT.py
+++ b/examples/getTGT.py
@@ -110,7 +110,7 @@ if __name__ == '__main__':
 
         executer = GETTGT(username, password, domain, options)
         executer.run()
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -97,7 +97,7 @@ class PSEXEC:
         dce = rpctransport.get_dce_rpc()
         try:
             dce.connect()
-        except Exception, e:
+        except Exception as e:
             logging.critical(str(e))
             sys.exit(1)
 
@@ -115,7 +115,7 @@ class PSEXEC:
             else:
                 try:
                     f = open(self.__exeFile)
-                except Exception, e:
+                except Exception as e:
                     logging.critical(str(e))
                     sys.exit(1)
                 installService = serviceinstall.ServiceInstall(rpctransport.get_smb_connection(), f)
@@ -332,7 +332,7 @@ class RemoteShell(cmd.Cmd):
             logging.info("Downloading %s\%s" % (self.share, src_path))
             self.transferClient.getFile(self.share, src_path, fh.write)
             fh.close()
-        except Exception, e:
+        except Exception as e:
             logging.error(str(e))
             pass
 
@@ -357,7 +357,7 @@ class RemoteShell(cmd.Cmd):
             logging.info("Uploading %s to %s\%s" % (src_file, self.share, dst_path))
             self.transferClient.putFile(self.share, pathname, fh.read)
             fh.close()
-        except Exception, e:
+        except Exception as e:
             logging.error(str(e))
             pass
 
@@ -370,7 +370,7 @@ class RemoteShell(cmd.Cmd):
         else:
             try:
                 os.chdir(s)
-            except Exception, e:
+            except Exception as e:
                 logging.error(str(e))
         self.send_data('\r\n')
 
@@ -894,7 +894,7 @@ class MS14_068:
         self.__domainSid, self.__rid = self.getUserSID()
         try:
             self.__forestSid = self.getForestSid()
-        except Exception, e:
+        except Exception as e:
             # For some reason we couldn't get the forest data. No problem, we can still continue
             # Only drawback is we won't get forest admin if successful
             logging.error('Couldn\'t get forest info (%s), continuing' % str(e))
@@ -916,7 +916,7 @@ class MS14_068:
                     tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, self.__password, self.__domain,
                                                                             self.__lmhash, self.__nthash, None,
                                                                             self.__kdcHost, requestPAC=False)
-                except KerberosError, e:
+                except KerberosError as e:
                     if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
                         # We might face this if the target does not support AES (most probably
                         # Windows XP). So, if that's the case we'll force using RC4 by converting
@@ -971,7 +971,7 @@ class MS14_068:
                     tgsCIFS, cipher, oldSessionKeyCIFS, sessionKeyCIFS = getKerberosTGS(serverName, domain,
                                                                                         self.__kdcHost, tgs, cipher,
                                                                                         sessionKey)
-                except KerberosError, e:
+                except KerberosError as e:
                     if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
                         # We might face this if the target does not support AES (most probably
                         # Windows XP). So, if that's the case we'll force using RC4 by converting
@@ -1125,7 +1125,7 @@ if __name__ == '__main__':
 
     try:
         dumper.exploit()
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/ifmap.py
+++ b/examples/ifmap.py
@@ -329,7 +329,7 @@ def main(args):
     binuuid = uuid.uuidtup_to_bin(tup)
     try:
       dce.bind(binuuid)
-    except rpcrt.DCERPCException, e:
+    except rpcrt.DCERPCException as e:
       if str(e).find('abstract_syntax_not_supported') >= 0:
         listening = False
       else:

--- a/examples/karmaSMB.py
+++ b/examples/karmaSMB.py
@@ -297,7 +297,7 @@ class KarmaSMBServer(Thread):
                    # First time asked, asking for the file
                    infoRecord, errorCode = queryPathInformation(path, self.defaultFile, queryPathInfoParameters['InformationLevel'])
                    connData['MS15011'][os.path.dirname(origPathName)] = infoRecord
-            except Exception, e:
+            except Exception as e:
                #import traceback
                #traceback.print_exc()
                smbServer.log("queryPathInformation: %s" % e,logging.ERROR)
@@ -607,7 +607,7 @@ if __name__ == '__main__':
 
     try:
        options = parser.parse_args()
-    except Exception, e:
+    except Exception as e:
        logging.critical(str(e))
        sys.exit(1)
 

--- a/examples/lookupsid.py
+++ b/examples/lookupsid.py
@@ -65,7 +65,7 @@ class LSALookupSid:
 
         try:
             self.__bruteForce(rpctransport, self.__maxRid)
-        except Exception, e:
+        except Exception as e:
             if logging.getLogger().level == logging.DEBUG:
                 import traceback
                 traceback.print_exc()
@@ -114,7 +114,7 @@ class LSALookupSid:
                 sids.append(domainSid + '-%d' % i)
             try:
                 lsat.hLsarLookupSids(dce, policyHandle, sids,lsat.LSAP_LOOKUP_LEVEL.LsapLookupWksta)
-            except DCERPCException, e:
+            except DCERPCException as e:
                 if str(e).find('STATUS_NONE_MAPPED') >= 0:
                     soFar += SIMULTANEOUS
                     continue

--- a/examples/mimikatz.py
+++ b/examples/mimikatz.py
@@ -94,7 +94,7 @@ class MimikatzShell(cmd.Cmd):
         retVal = False
         try:
            retVal = cmd.Cmd.onecmd(self,s)
-        except Exception, e:
+        except Exception as e:
            #import traceback
            #traceback.print_exc()
            logging.error(e)
@@ -210,7 +210,7 @@ def main():
                 dce.connect()
                 dce.bind(mimilib.MSRPC_UUID_MIMIKATZ)
                 bound = True
-            except Exception, e:
+            except Exception as e:
                 if str(e).find('ept_s_not_registered') >=0:
                     # Let's try ncacn_ip_tcp
                     stringBinding = epm.hept_map(address, mimilib.MSRPC_UUID_MIMIKATZ, protocol = 'ncacn_ip_tcp')
@@ -244,7 +244,7 @@ def main():
                     print line,
         else:
             shell.cmdloop()
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/mqtt_check.py
+++ b/examples/mqtt_check.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
 
     try:
        options = parser.parse_args()
-    except Exception, e:
+    except Exception as e:
        logging.error(str(e))
        sys.exit(1)
 
@@ -90,7 +90,7 @@ if __name__ == '__main__':
     check_mqtt = MQTT_LOGIN(username, password, address, options)
     try:
         check_mqtt.run()
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -176,7 +176,7 @@ if __name__ == '__main__':
         else:
             res = ms_sql.login(options.db, username, password, domain, options.hashes, options.windows_auth)
         ms_sql.printReplies()
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/netview.py
+++ b/examples/netview.py
@@ -83,7 +83,7 @@ def checkMachines(machines, stopEvent, singlePass=False):
                 myIP = s.getsockname()[0]
                 s.close()
                 machinesAliveQueue.put(machine)
-            except Exception, e:
+            except Exception as e:
                 logging.debug('%s: not alive (%s)' % (machine, e))
                 pass
             else:
@@ -157,7 +157,7 @@ class USERENUM:
                 try:
                     resp = samr.hSamrEnumerateUsersInDomain(dce, domainHandle, samr.USER_WORKSTATION_TRUST_ACCOUNT,
                                                             enumerationContext=enumerationContext)
-                except DCERPCException, e:
+                except DCERPCException as e:
                     if str(e).find('STATUS_MORE_ENTRIES') < 0:
                         raise
                     resp = e.get_packet()
@@ -168,7 +168,7 @@ class USERENUM:
 
                 enumerationContext = resp['EnumerationContext'] 
                 status = resp['ErrorCode']
-        except Exception, e:
+        except Exception as e:
             raise e
 
         dce.disconnect()
@@ -229,7 +229,7 @@ class USERENUM:
                 try:
                     self.getSessions(target)
                     self.getLoggedIn(target) 
-                except (SessionError, DCERPCException), e:
+                except (SessionError, DCERPCException) as e:
                     # We will silently pass these ones, might be issues with Kerberos, or DCE
                     if str(e).find('LOGON_FAILURE') >=0:
                         # For some reason our credentials don't work there, 
@@ -247,7 +247,7 @@ class USERENUM:
                     pass 
                 except KeyboardInterrupt:
                     raise
-                except Exception, e:
+                except Exception as e:
                     #import traceback
                     #traceback.print_exc()
                     if str(e).find('timed out') >=0:
@@ -287,7 +287,7 @@ class USERENUM:
 
         try:
             resp = srvs.hNetrSessionEnum(dce, '\x00', NULL, 10)
-        except Exception, e:
+        except Exception as e:
             if str(e).find('Broken pipe') >= 0:
                 # The connection timed-out. Let's try to bring it back next round
                 self.__targets[target]['SRVS'] = None
@@ -366,7 +366,7 @@ class USERENUM:
 
         try:
             resp = wkst.hNetrWkstaUserEnum(dce,1)
-        except Exception, e:
+        except Exception as e:
             if str(e).find('Broken pipe') >= 0:
                 # The connection timed-out. Let's try to bring it back next round
                 self.__targets[target]['WKST'] = None
@@ -494,7 +494,7 @@ if __name__ == '__main__':
 
         executer = USERENUM(username, password, domain, options.hashes, options.aesKey, options.k, options)
         executer.run()
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/ntfs-read.py
+++ b/examples/ntfs-read.py
@@ -672,7 +672,7 @@ class INODE:
             try:
 #                print "%d - %s %s %s " %( self.INodeNumber, self.getPrintableAttributes(), self.LastDataChangeTime.isoformat(' '), self.FileName)
                 print "%s %s %15d %s " %( self.getPrintableAttributes(), self.LastDataChangeTime.isoformat(' '), self.FileSize, self.FileName)
-            except Exception, e:
+            except Exception as e:
                 logging.error('Exception when trying to display inode %d: %s' % (self.INodeNumber,str(e)))
 
     def getPrintableAttributes(self):
@@ -1033,7 +1033,7 @@ class MiniShell(cmd.Cmd):
         retVal = False
         try:
            retVal = cmd.Cmd.onecmd(self,s)
-        except Exception, e:
+        except Exception as e:
            logging.error(str(e))
 
         return retVal

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -95,7 +95,7 @@ class MiniShell(cmd.Cmd):
             r = opener.open(response)
             result = r.read()
             items = json.loads(result)
-        except Exception, e:
+        except Exception as e:
             logging.error("ERROR: %s" % str(e))
         else:
             if len(items) > 0:

--- a/examples/opdump.py
+++ b/examples/opdump.py
@@ -52,7 +52,7 @@ def main(args):
     dce.call(i, "")
     try:
       dce.recv()
-    except Exception, e:
+    except Exception as e:
       result = str(e)
     else:
       result = "success"

--- a/examples/psexec.py
+++ b/examples/psexec.py
@@ -113,7 +113,7 @@ class PSEXEC:
         dce = rpctransport.get_dce_rpc()
         try:
             dce.connect()
-        except Exception, e:
+        except Exception as e:
             if logging.getLogger().level == logging.DEBUG:
                 import traceback
                 traceback.print_exc()
@@ -134,7 +134,7 @@ class PSEXEC:
             else:
                 try:
                     f = open(self.__exeFile)
-                except Exception, e:
+                except Exception as e:
                     logging.critical(str(e))
                     sys.exit(1)
                 installService = serviceinstall.ServiceInstall(rpctransport.get_smb_connection(), f)
@@ -346,7 +346,7 @@ class RemoteShell(cmd.Cmd):
             logging.info("Downloading %s\%s" % (self.share, src_path))
             self.transferClient.getFile(self.share, src_path, fh.write)
             fh.close()
-        except Exception, e:
+        except Exception as e:
             logging.critical(str(e))
             pass
 
@@ -371,7 +371,7 @@ class RemoteShell(cmd.Cmd):
             logging.info("Uploading %s to %s\%s" % (src_file, self.share, dst_path))
             self.transferClient.putFile(self.share, pathname.decode(sys.stdin.encoding), fh.read)
             fh.close()
-        except Exception, e:
+        except Exception as e:
             logging.error(str(e))
             pass
 

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -139,7 +139,7 @@ class PSEXEC:
         dce = rpctransport.get_dce_rpc()
         try:
             dce.connect()
-        except Exception, e:
+        except Exception as e:
             logging.critical(str(e))
             sys.exit(1)
 
@@ -157,7 +157,7 @@ class PSEXEC:
             else:
                 try:
                     f = open(self.__exeFile)
-                except Exception, e:
+                except Exception as e:
                     logging.critical(str(e))
                     sys.exit(1)
                 installService = serviceinstall.ServiceInstall(rpctransport.get_smb_connection(), f)
@@ -280,7 +280,7 @@ class Pipes(Thread):
             self.server.waitNamedPipe(self.tid, self.pipe)
             self.fid = self.server.openFile(self.tid,self.pipe,self.permissions, creationOption = 0x40, fileAttributes = 0x80)
             self.server.setTimeout(1000000)
-        except Exception, e:
+        except Exception as e:
             logging.critical("Something wen't wrong connecting the pipes(%s), try again" % self.__class__)
 
 class RemoteStdOutPipe(Pipes):
@@ -373,7 +373,7 @@ class RemoteShell(cmd.Cmd):
             logging.info("Downloading %s\%s" % (self.share, src_path))
             self.transferClient.getFile(self.share, src_path, fh.write)
             fh.close()
-        except Exception, e:
+        except Exception as e:
             logging.error(str(e))
             pass
 
@@ -398,7 +398,7 @@ class RemoteShell(cmd.Cmd):
             logging.info("Uploading %s to %s\%s" % (src_file, self.share, dst_path))
             self.transferClient.putFile(self.share, pathname, fh.read)
             fh.close()
-        except Exception, e:
+        except Exception as e:
             logging.error(str(e))
             pass
 
@@ -411,7 +411,7 @@ class RemoteShell(cmd.Cmd):
         else:
             try:
                 os.chdir(s)
-            except Exception, e:
+            except Exception as e:
                 logging.error(str(e))
         self.send_data('\r\n')
 
@@ -538,7 +538,7 @@ class RAISECHILD:
         s = SMBConnection(machineIP, machineIP)
         try:
             s.login('','')
-        except Exception, e:
+        except Exception as e:
             logging.debug('Error while anonymous logging into %s' % machineIP)
         else:
             s.logoff()
@@ -549,7 +549,7 @@ class RAISECHILD:
         s = SMBConnection(machineIP, machineIP)
         try:
             s.login('','')
-        except Exception, e:
+        except Exception as e:
             logging.debug('Error while anonymous logging into %s' % machineIP)
         else:
             s.logoff()
@@ -679,7 +679,7 @@ class RAISECHILD:
             try:
                 attId = drsuapi.OidFromAttid(prefixTable, attr['attrTyp'])
                 LOOKUP_TABLE = self.ATTRTYP_TO_ATTID
-            except Exception, e:
+            except Exception as e:
                 logging.debug('Failed to execute OidFromAttid with error %s' % e)
                 # Fallbacking to fixed table and hope for the best
                 attId = attr['attrTyp']
@@ -728,7 +728,7 @@ class RAISECHILD:
             try:
                 attId = drsuapi.OidFromAttid(prefixTable, attr['attrTyp'])
                 LOOKUP_TABLE = self.ATTRTYP_TO_ATTID
-            except Exception, e:
+            except Exception as e:
                 logging.debug('Failed to execute OidFromAttid with error %s, fallbacking to fixed table' % e)
                 # Fallbacking to fixed table and hope for the best
                 attId = attr['attrTyp']
@@ -825,7 +825,7 @@ class RAISECHILD:
 
             rid, lmhash, nthash = self.__decryptHash(userRecord, userRecord['pmsgOut']['V6']['PrefixTableSrc']['pPrefixEntry'])
             aesKey = self.__decryptSupplementalInfo(userRecord, userRecord['pmsgOut']['V6']['PrefixTableSrc']['pPrefixEntry'])
-        except Exception, e:
+        except Exception as e:
             if logging.getLogger().level == logging.DEBUG:
                 import traceback
                 traceback.print_exc()
@@ -1090,7 +1090,7 @@ class RAISECHILD:
                 tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, childCreds['password'],
                                                                         childCreds['domain'], childCreds['lmhash'],
                                                                         childCreds['nthash'], None, self.__kdcHost)
-            except KerberosError, e:
+            except KerberosError as e:
                 if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
                     # We might face this if the target does not support AES (most probably
                     # Windows XP). So, if that's the case we'll force using RC4 by converting
@@ -1131,7 +1131,7 @@ class RAISECHILD:
                 TGS['oldSessionKey'] = oldSessionKeyCIFS
                 TGS['sessionKey'] = sessionKeyCIFS
                 break
-            except KerberosError, e:
+            except KerberosError as e:
                 if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
                     # We might face this if the target does not support AES (most probably
                     # Windows XP). So, if that's the case we'll force using RC4 by converting
@@ -1279,11 +1279,11 @@ if __name__ == '__main__':
     try:
         pacifier = RAISECHILD(options.target_exec, username, password, domain, options, commands)
         pacifier.exploit()
-    except SessionError, e:
+    except SessionError as e:
         logging.critical(str(e))
         if e.getErrorCode() == STATUS_NO_LOGON_SERVERS:
             logging.info('Try using Kerberos authentication (-k switch). That might help solving the STATUS_NO_LOGON_SERVERS issue')
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/rdp_check.py
+++ b/examples/rdp_check.py
@@ -485,7 +485,7 @@ if __name__ == '__main__':
            # anything. So, I'm sending garbage so the server returns an error. 
            # Luckily, it's a different error so we can determine whether or not auth worked ;)
            buff = tls.recv(1024)
-       except Exception, err:
+       except Exception as err:
            if str(err).find("denied") > 0:
                logging.error("Access Denied")
            else:

--- a/examples/reg.py
+++ b/examples/reg.py
@@ -158,7 +158,7 @@ class RegHandler:
 
         try:
             self.__remoteOps.enableRegistry()
-        except Exception, e:
+        except Exception as e:
             logging.debug(str(e))
             logging.warning('Cannot check RemoteRegistry status. Hoping it is started...')
             self.__remoteOps.connectWinReg()
@@ -170,7 +170,7 @@ class RegHandler:
                 self.query(dce, self.__options.keyName)
             else:
                 logging.error('Method %s not implemented yet!' % self.__action)
-        except (Exception, KeyboardInterrupt), e:
+        except (Exception, KeyboardInterrupt) as e:
             # import traceback
             # traceback.print_exc()
             logging.critical(str(e))
@@ -237,7 +237,7 @@ class RegHandler:
                 print '\t' + lp_value_name + '\t' + self.__regValues.get(lp_type, 'KEY_NOT_FOUND') + '\t',
                 self.__parse_lp_data(lp_type, lp_data)
                 i += 1
-            except rrp.DCERPCSessionError, e:
+            except rrp.DCERPCSessionError as e:
                 if e.get_error_code() == ERROR_NO_MORE_ITEMS:
                     break
 
@@ -253,10 +253,10 @@ class RegHandler:
                 print newKeyName
                 self.__print_key_values(rpc, ans['phkResult'])
                 self.__print_all_subkeys_and_entries(rpc, newKeyName, ans['phkResult'], 0)
-            except rrp.DCERPCSessionError, e:
+            except rrp.DCERPCSessionError as e:
                 if e.get_error_code() == ERROR_NO_MORE_ITEMS:
                     break
-            except rpcrt.DCERPCException, e:
+            except rpcrt.DCERPCException as e:
                 if str(e).find('access_denied') >= 0:
                     logging.error('Cannot access subkey %s, bypassing it' % subkey['lpNameOut'][:-1])
                     continue
@@ -294,7 +294,7 @@ class RegHandler:
             else:
                 print "Unknown Type 0x%x!" % valueType
                 hexdump(valueData)
-        except Exception, e:
+        except Exception as e:
             logging.debug('Exception thrown when printing reg value %s', str(e))
             print 'Invalid data'
             pass
@@ -424,5 +424,5 @@ if __name__ == '__main__':
     regHandler = RegHandler(username, password, domain, options)
     try:
         regHandler.run(remoteName, options.target_ip)
-    except Exception, e:
+    except Exception as e:
         logging.error(str(e))

--- a/examples/rpcdump.py
+++ b/examples/rpcdump.py
@@ -65,7 +65,7 @@ class RPCDump:
 
         try:
             entries = self.__fetchList(rpctransport)
-        except Exception, e:
+        except Exception as e:
             logging.critical('Protocol failed: %s' % e)
 
         # Display results.

--- a/examples/sambaPipe.py
+++ b/examples/sambaPipe.py
@@ -54,14 +54,14 @@ class PIPEDREAM:
         try:
             logging.debug('Connecting to share %s' % shareName)
             tid = self.__smbClient.connectTree(shareName)
-        except Exception, e:
+        except Exception as e:
             logging.debug(str(e))
             return False
 
         try:
             self.__smbClient.openFile(tid, '\\', FILE_WRITE_DATA, creationOption=FILE_DIRECTORY_FILE)
             writable = True
-        except Exception, e:
+        except Exception as e:
             writable = False
             pass
 
@@ -185,7 +185,7 @@ class PIPEDREAM:
         logging.info('Share path is %s' % sharePath)
         try:
             self.openPipe(sharePath, fileName)
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_OBJECT_NAME_NOT_FOUND') >= 0:
                 logging.info('Expected STATUS_OBJECT_NAME_NOT_FOUND received, doesn\'t mean the exploit worked tho')
             else:
@@ -283,7 +283,7 @@ if __name__ == '__main__':
             smbClient._SMBConnection._Session['SessionFlags'] &=  ~SMB2_SESSION_FLAG_ENCRYPT_DATA
         pipeDream = PIPEDREAM(smbClient, options)
         pipeDream.run()
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/samrdump.py
+++ b/examples/samrdump.py
@@ -79,7 +79,7 @@ class SAMRDump:
 
         try:
             entries = self.__fetchList(rpctransport)
-        except Exception, e:
+        except Exception as e:
             logging.critical(str(e))
 
         # Display results.
@@ -163,7 +163,7 @@ class SAMRDump:
             while status == STATUS_MORE_ENTRIES:
                 try:
                     resp = samr.hSamrEnumerateUsersInDomain(dce, domainHandle, enumerationContext = enumerationContext)
-                except DCERPCException, e:
+                except DCERPCException as e:
                     if str(e).find('STATUS_MORE_ENTRIES') < 0:
                         raise 
                     resp = e.get_packet()
@@ -179,7 +179,7 @@ class SAMRDump:
                 enumerationContext = resp['EnumerationContext'] 
                 status = resp['ErrorCode']
 
-        except ListUsersException, e:
+        except ListUsersException as e:
             logging.critical("Error listing users: %s" % e)
 
         dce.disconnect()

--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -123,7 +123,7 @@ class DumpSecrets:
                 try:
                     try:
                         self.connect()
-                    except Exception, e:
+                    except Exception as e:
                         if os.getenv('KRB5CCNAME') is not None and self.__doKerberos is True:
                             # SMBConnection failed. That might be because there was no way to log into the
                             # target system. We just have a last resort. Hope we have tickets cached and that they
@@ -140,7 +140,7 @@ class DumpSecrets:
                         bootKey             = self.__remoteOps.getBootKey()
                         # Let's check whether target system stores LM Hashes
                         self.__noLMHash = self.__remoteOps.checkNoLMHashPolicy()
-                except Exception, e:
+                except Exception as e:
                     self.__canProcessSAMLSA = False
                     if str(e).find('STATUS_USER_SESSION_DELETED') and os.getenv('KRB5CCNAME') is not None \
                         and self.__doKerberos is True:
@@ -162,7 +162,7 @@ class DumpSecrets:
                     self.__SAMHashes.dump()
                     if self.__outputFileName is not None:
                         self.__SAMHashes.export(self.__outputFileName)
-                except Exception, e:
+                except Exception as e:
                     logging.error('SAM hashes extraction failed: %s' % str(e))
 
                 try:
@@ -179,7 +179,7 @@ class DumpSecrets:
                     self.__LSASecrets.dumpSecrets()
                     if self.__outputFileName is not None:
                         self.__LSASecrets.exportSecrets(self.__outputFileName)
-                except Exception, e:
+                except Exception as e:
                     if logging.getLogger().level == logging.DEBUG:
                         import traceback
                         traceback.print_exc()
@@ -202,7 +202,7 @@ class DumpSecrets:
                                            printUserStatus= self.__printUserStatus)
             try:
                 self.__NTDSHashes.dump()
-            except Exception, e:
+            except Exception as e:
                 if logging.getLogger().level == logging.DEBUG:
                     import traceback
                     traceback.print_exc()
@@ -220,7 +220,7 @@ class DumpSecrets:
                 elif self.__useVSSMethod is False:
                     logging.info('Something wen\'t wrong with the DRSUAPI approach. Try again with -use-vss parameter')
             self.cleanup()
-        except (Exception, KeyboardInterrupt), e:
+        except (Exception, KeyboardInterrupt) as e:
             if logging.getLogger().level == logging.DEBUG:
                 import traceback
                 traceback.print_exc()
@@ -385,7 +385,7 @@ if __name__ == '__main__':
     dumper = DumpSecrets(remoteName, username, password, domain, options)
     try:
         dumper.dump()
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/services.py
+++ b/examples/services.py
@@ -352,7 +352,7 @@ if __name__ == '__main__':
     services = SVCCTL(username, password, domain, options, int(options.port))
     try:
         services.run(remoteName, options.target_ip)
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -87,7 +87,7 @@ class SMBServer(Thread):
         logging.info('Creating tmp directory')
         try:
             os.mkdir(SMBSERVER_DIR)
-        except Exception, e:
+        except Exception as e:
             logging.critical(str(e))
             pass
         logging.info('Setting up SMB Server')
@@ -148,7 +148,7 @@ class CMDEXEC:
             self.shell.cmdloop()
             if self.__mode == 'SERVER':
                 serverThread.stop()
-        except  (Exception, KeyboardInterrupt), e:
+        except  (Exception, KeyboardInterrupt) as e:
             if logging.getLogger().level == logging.DEBUG:
                 import traceback
                 traceback.print_exc()
@@ -175,7 +175,7 @@ class RemoteShell(cmd.Cmd):
         self.__scmr = rpc.get_dce_rpc()
         try:
             self.__scmr.connect()
-        except Exception, e:
+        except Exception as e:
             logging.critical(str(e))
             sys.exit(1)
 
@@ -347,7 +347,7 @@ if __name__ == '__main__':
         executer = CMDEXEC(username, password, domain, options.hashes, options.aesKey, options.k,
                            options.dc_ip, options.mode, options.share, int(options.port))
         executer.run(remoteName, options.target_ip)
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/smbrelayx.py
+++ b/examples/smbrelayx.py
@@ -121,7 +121,7 @@ class doAttack(Thread):
 
                 remoteOps  = RemoteOperations(self.__SMBConnection, False)
                 remoteOps.enableRegistry()
-            except Exception, e:
+            except Exception as e:
                 if logging.getLogger().level == logging.DEBUG:
                     import traceback
                     traceback.print_exc()
@@ -140,7 +140,7 @@ class doAttack(Thread):
 
                     try:
                         print self.__answerTMP.decode(CODEC)
-                    except UnicodeDecodeError, e:
+                    except UnicodeDecodeError as e:
                         logging.error('Decoding error detected, consider running chcp.com at the target,\nmap the result with '
                                       'https://docs.python.org/2.4/lib/standard-encodings.html\nand then execute wmiexec.py '
                                   'again with -codec and the corresponding codec')
@@ -154,7 +154,7 @@ class doAttack(Thread):
                     samHashes = SAMHashes(samFileName, bootKey, isRemote = True)
                     samHashes.dump()
                     logging.info("Done dumping SAM hashes for host: %s", self.__SMBConnection.getRemoteHost())
-            except Exception, e:
+            except Exception as e:
                 if logging.getLogger().level == logging.DEBUG:
                     import traceback
                     traceback.print_exc()
@@ -167,7 +167,7 @@ class doAttack(Thread):
                     remoteOps.finish()
             try:
                 ATTACKED_HOSTS.remove(self.__SMBConnection.getRemoteHost())
-            except Exception, e:
+            except Exception as e:
                 logging.error(str(e))
                 pass
 
@@ -320,7 +320,7 @@ class SMBClient(SMB):
         try:
             resp = dce.request(request)
             #resp.dump()
-        except DCERPCException, e:
+        except DCERPCException as e:
             if logging.getLogger().level == logging.DEBUG:
                 import traceback
                 traceback.print_exc()
@@ -546,7 +546,7 @@ class HTTPRelayServer(Thread):
                     self.client = SMBClient(self.target, extended_security = True)
                     self.client.setDomainAccount(self.machineAccount, self.machineHashes, self.domainIp)
                     self.client.set_timeout(60)
-                except Exception, e:
+                except Exception as e:
                    logging.error("Connection against target %s FAILED" % self.target)
                    logging.error(str(e))
 
@@ -755,7 +755,7 @@ class SMBRelayServer(Thread):
             client = SMBClient(self.target, extended_security = extSec)
             client.setDomainAccount(self.machineAccount, self.machineHashes, self.domainIp)
             client.set_timeout(60)
-        except Exception, e:
+        except Exception as e:
             logging.error("Connection against target %s FAILED" % self.target)
             logging.error(str(e))
         else: 
@@ -1139,7 +1139,7 @@ if __name__ == '__main__':
 
     try:
        options = parser.parse_args()
-    except Exception, e:
+    except Exception as e:
        logging.error(str(e))
        sys.exit(1)
 

--- a/examples/smbserver.py
+++ b/examples/smbserver.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
 
     try:
        options = parser.parse_args()
-    except Exception, e:
+    except Exception as e:
        logging.critical(str(e))
        sys.exit(1)
 

--- a/examples/split.py
+++ b/examples/split.py
@@ -108,7 +108,7 @@ class Decoder:
             print "Found a new connection, storing into:", fn
             try:
                 dumper = self.pcap.dump_open(fn)
-            except pcapy.PcapError, e:
+            except pcapy.PcapError as e:
                 print "Can't write packet to:", fn
                 return
             self.connections[con] = dumper

--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -789,7 +789,7 @@ if __name__ == '__main__':
     try:
         executer = TICKETER(options.target, password, options.domain, options)
         executer.run()
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -92,7 +92,7 @@ class WMIEXEC:
                 self.shell.onecmd(self.__command)
             else:
                 self.shell.cmdloop()
-        except  (Exception, KeyboardInterrupt), e:
+        except  (Exception, KeyboardInterrupt) as e:
             if logging.getLogger().level == logging.DEBUG:
                 import traceback
                 traceback.print_exc()
@@ -145,7 +145,7 @@ class RemoteShell(cmd.Cmd):
         else:
             try:
                 os.chdir(s)
-            except Exception, e:
+            except Exception as e:
                 logging.error(str(e))
 
     def do_get(self, src_path):
@@ -160,7 +160,7 @@ class RemoteShell(cmd.Cmd):
             self.__transferClient.getFile(drive[:-1]+'$', tail, fh.write)
             fh.close()
 
-        except Exception, e:
+        except Exception as e:
             logging.error(str(e))
 
             if os.path.exists(filename):
@@ -187,7 +187,7 @@ class RemoteShell(cmd.Cmd):
             logging.info("Uploading %s to %s" % (src_file, pathname))
             self.__transferClient.putFile(drive[:-1]+'$', tail, fh.read)
             fh.close()
-        except Exception, e:
+        except Exception as e:
             logging.critical(str(e))
             pass
 
@@ -233,7 +233,7 @@ class RemoteShell(cmd.Cmd):
         def output_callback(data):
             try:
                 self.__outputBuffer += data.decode(CODEC)
-            except UnicodeDecodeError, e:
+            except UnicodeDecodeError as e:
                 logging.error('Decoding error detected, consider running chcp.com at the target,\nmap the result with '
                               'https://docs.python.org/2.4/lib/standard-encodings.html\nand then execute wmiexec.py '
                               'again with -codec and the corresponding codec')
@@ -247,7 +247,7 @@ class RemoteShell(cmd.Cmd):
             try:
                 self.__transferClient.getFile(self.__share, self.__output, output_callback)
                 break
-            except Exception, e:
+            except Exception as e:
                 if str(e).find('STATUS_SHARING_VIOLATION') >=0:
                     # Output not finished, let's wait
                     time.sleep(1)
@@ -406,9 +406,9 @@ if __name__ == '__main__':
         executer = WMIEXEC(' '.join(options.command), username, password, domain, options.hashes, options.aesKey,
                            options.share, options.nooutput, options.k, options.dc_ip)
         executer.run(address)
-    except KeyboardInterrupt, e:
+    except KeyboardInterrupt as e:
         logging.error(str(e))
-    except Exception, e:
+    except Exception as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/wmipersist.py
+++ b/examples/wmipersist.py
@@ -229,7 +229,7 @@ if __name__ == '__main__':
 
         executer = WMIPERSISTENCE(username, password, domain, options)
         executer.run(address)
-    except (Exception, KeyboardInterrupt), e:
+    except (Exception, KeyboardInterrupt) as e:
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()

--- a/examples/wmiquery.py
+++ b/examples/wmiquery.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
                 iObject, _ = self.iWbemServices.GetObject(sClass)
                 iObject.printInformation()
                 iObject.RemRelease()
-            except Exception, e:
+            except Exception as e:
                 if logging.getLogger().level == logging.DEBUG:
                     import traceback
                     traceback.print_exc()
@@ -91,7 +91,7 @@ if __name__ == '__main__':
                         else:
                             print '%s |' % record[key]['value'],
                     print 
-                except Exception, e:
+                except Exception as e:
                     if logging.getLogger().level == logging.DEBUG:
                         import traceback
                         traceback.print_exc()
@@ -109,7 +109,7 @@ if __name__ == '__main__':
                 iEnumWbemClassObject = self.iWbemServices.ExecQuery(line.strip('\n'))
                 self.printReply(iEnumWbemClassObject)
                 iEnumWbemClassObject.RemRelease()
-            except Exception, e:
+            except Exception as e:
                 logging.error(str(e))
          
         def emptyline(self):
@@ -206,7 +206,7 @@ if __name__ == '__main__':
 
         iWbemServices.RemRelease()
         dcom.disconnect()
-    except Exception, e:
+    except Exception as e:
         logging.error(str(e))
         try:
             dcom.disconnect()

--- a/impacket/IP6_Address.py
+++ b/impacket/IP6_Address.py
@@ -243,7 +243,7 @@ class IP6_Address():
             #Capitalize on the constructor's ability to detect invalid text representations of an IP6 address            
             ip6_address = IP6_Address(text_representation)
             return True
-        except Exception, e:
+        except Exception as e:
             return False
                 
     def __is_a_scoped_address(self, text_representation):

--- a/impacket/dcerpc/v5/dcom/scmp.py
+++ b/impacket/dcerpc/v5/dcom/scmp.py
@@ -301,7 +301,7 @@ class IVssSnapshotMgmt(IRemUnknown2):
         req['ProviderId'] = providerId
         try:
             resp = self.request(req, self._iid, uuid = self.get_iPid())
-        except DCERPCException, e:
+        except DCERPCException as e:
             print e
             from impacket.winregistry import hexdump
             data = e.get_packet()

--- a/impacket/dcerpc/v5/dcom/vds.py
+++ b/impacket/dcerpc/v5/dcom/vds.py
@@ -198,7 +198,7 @@ class IEnumVdsObject(IRemUnknown2):
         request['celt'] = celt
         try:
             resp = self.request(request, uuid = self.get_iPid())
-        except Exception, e:
+        except Exception as e:
             resp = e.get_packet()
             # If it is S_FALSE(1) means less items were returned
             if resp['ErrorCode'] != 1:
@@ -238,7 +238,7 @@ class IVdsService(IRemUnknown2):
         request['ORPCthis']['flags'] = 0
         try:
             resp = self.request(request, uuid = self.get_iPid())
-        except Exception, e:
+        except Exception as e:
             resp = e.get_packet()
         return resp 
 

--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -2729,7 +2729,7 @@ class IWbemClassObject(IRemUnknown):
                 return self.__iWbemServices.ExecMethod(classOrInstance, methodDefinition['name'], pInParams = objRefCustomIn )
                 #return self.__iWbemServices.ExecMethod('Win32_Process.Handle="436"', methodDefinition['name'],
                 #                                       pInParams=objRefCustomIn).getObject().ctCurrent['properties']
-            except Exception, e:
+            except Exception as e:
                 if LOG.level == logging.DEBUG:
                     import traceback
                     traceback.print_exc()

--- a/impacket/dcerpc/v5/dcomrt.py
+++ b/impacket/dcerpc/v5/dcomrt.py
@@ -1012,7 +1012,7 @@ class DCOMConnection:
                     DCOMConnection.OID_SET[target]['setid'] = resp['pSetId']
                 else:
                     objExporter.SimplePing(DCOMConnection.OID_SET[target]['setid'])
-        except Exception, e:
+        except Exception as e:
             # There might be exceptions when sending packets 
             # We should try to continue tho.
             LOG.error(str(e))
@@ -1021,7 +1021,7 @@ class DCOMConnection:
         DCOMConnection.PINGTIMER = Timer(120,DCOMConnection.pingServer)
         try:
             DCOMConnection.PINGTIMER.start()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('threads can only be started once') < 0:
                 raise e
 
@@ -1031,7 +1031,7 @@ class DCOMConnection:
                 DCOMConnection.PINGTIMER = Timer(120, DCOMConnection.pingServer)
             try:
                 DCOMConnection.PINGTIMER.start()
-            except Exception, e:
+            except Exception as e:
                 if str(e).find('threads can only be started once') < 0:
                     raise e
 
@@ -1308,7 +1308,7 @@ class INTERFACE:
         dce = self.get_dce_rpc()
         try:
             resp = dce.request(req, uuid)
-        except Exception, e:
+        except Exception as e:
             if str(e).find('RPC_E_DISCONNECTED') >= 0:
                 msg = str(e) + '\n'
                 msg += "DCOM keep-alive pinging it might not be working as expected. You can't be idle for more than 14 minutes!\n"

--- a/impacket/dcerpc/v5/dhcpm.py
+++ b/impacket/dcerpc/v5/dhcpm.py
@@ -815,7 +815,7 @@ def hDhcpGetOptionValue(dce, optionID, scopetype=DHCP_OPTION_SCOPE_TYPE.DhcpDefa
     while status == system_errors.ERROR_MORE_DATA:
         try:
             resp = dce.request(request)
-        except DCERPCException, e:
+        except DCERPCException as e:
             if str(e).find('ERROR_NO_MORE_ITEMS') < 0:
                 raise
             resp = e.get_packet()
@@ -842,7 +842,7 @@ def hDhcpEnumOptionValues(dce, scopetype=DHCP_OPTION_SCOPE_TYPE.DhcpDefaultOptio
     while status == system_errors.ERROR_MORE_DATA:
         try:
             resp = dce.request(request)
-        except DCERPCException, e:
+        except DCERPCException as e:
             if str(e).find('ERROR_NO_MORE_ITEMS') < 0:
                 raise
             resp = e.get_packet()
@@ -872,7 +872,7 @@ def hDhcpEnumOptionValuesV5(dce, flags=DHCP_FLAGS_OPTION_DEFAULT, classname=NULL
     while status == system_errors.ERROR_MORE_DATA:
         try:
             resp = dce.request(request)
-        except DCERPCException, e:
+        except DCERPCException as e:
             if str(e).find('ERROR_NO_MORE_ITEMS') < 0:
                 raise
             resp = e.get_packet()
@@ -900,7 +900,7 @@ def hDhcpGetOptionValueV5(dce, option_id, flags=DHCP_FLAGS_OPTION_DEFAULT, class
     while status == system_errors.ERROR_MORE_DATA:
         try:
             resp = dce.request(request)
-        except DCERPCException, e:
+        except DCERPCException as e:
             if str(e).find('ERROR_NO_MORE_ITEMS') < 0:
                 raise
             resp = e.get_packet()
@@ -924,7 +924,7 @@ def hDhcpGetAllOptionValues(dce, scopetype=DHCP_OPTION_SCOPE_TYPE.DhcpDefaultOpt
     while status == system_errors.ERROR_MORE_DATA:
         try:
             resp = dce.request(request)
-        except DCERPCException, e:
+        except DCERPCException as e:
             if str(e).find('ERROR_NO_MORE_ITEMS') < 0:
                 raise
             resp = e.get_packet()
@@ -940,7 +940,7 @@ def hDhcpEnumSubnets(dce, preferredMaximum=0xffffffff):
     while status == system_errors.ERROR_MORE_DATA:
         try:
             resp = dce.request(request)
-        except DCERPCException, e:
+        except DCERPCException as e:
             if str(e).find('STATUS_MORE_ENTRIES') < 0:
                 raise
             resp = e.get_packet()
@@ -957,7 +957,7 @@ def hDhcpEnumSubnetClientsVQ(dce, preferredMaximum=0xffffffff):
     while status == system_errors.ERROR_MORE_DATA:
         try:
             resp = dce.request(request)
-        except DCERPCException, e:
+        except DCERPCException as e:
             if str(e).find('STATUS_MORE_ENTRIES') < 0:
                 raise
             resp = e.get_packet()
@@ -974,7 +974,7 @@ def hDhcpEnumSubnetClientsV4(dce, preferredMaximum=0xffffffff):
     while status == system_errors.ERROR_MORE_DATA:
         try:
             resp = dce.request(request)
-        except DCERPCException, e:
+        except DCERPCException as e:
             if str(e).find('STATUS_MORE_ENTRIES') < 0:
                 raise
             resp = e.get_packet()
@@ -991,7 +991,7 @@ def hDhcpEnumSubnetClientsV5(dce, subnetAddress=0, preferredMaximum=0xffffffff):
     while status == system_errors.ERROR_MORE_DATA:
         try:
             resp = dce.request(request)
-        except DCERPCSessionError, e:
+        except DCERPCSessionError as e:
             if str(e).find('STATUS_MORE_ENTRIES') < 0:
                 raise
             resp = e.get_packet()
@@ -1010,7 +1010,7 @@ def hDhcpEnumSubnetElementsV5(dce, subnet_address, element_type=DHCP_SUBNET_ELEM
     while status == system_errors.ERROR_MORE_DATA:
         try:
             resp = dce.request(request)
-        except DCERPCException, e:
+        except DCERPCException as e:
             if str(e).find('ERROR_NO_MORE_ITEMS') < 0:
                 raise
             resp = e.get_packet()

--- a/impacket/dcerpc/v5/even6.py
+++ b/impacket/dcerpc/v5/even6.py
@@ -315,7 +315,7 @@ def hEvtRpcQueryNext(dce, handle, numRequestedRecords, timeOutEnd=1000):
     while status == system_errors.ERROR_MORE_DATA:
         try:
             resp = dce.request(request)
-        except DCERPCException, e:
+        except DCERPCException as e:
             if str(e).find('ERROR_NO_MORE_ITEMS') < 0:
                 raise
             elif str(e).find('ERROR_TIMEOUT') < 0:

--- a/impacket/dcerpc/v5/ndr.py
+++ b/impacket/dcerpc/v5/ndr.py
@@ -228,7 +228,7 @@ class NDR(object):
 
                 data += res
                 soFar += len(res)
-            except Exception, e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error packing field '%s | %s' in %s" % (fieldName, fieldTypeOrClass, self.__class__))
                 raise
@@ -257,7 +257,7 @@ class NDR(object):
 
                 data = data[size:]
                 soFar += size
-            except Exception,e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[:256]))
                 raise
@@ -544,7 +544,7 @@ class NDRCONSTRUCTEDTYPE(NDR):
                     data += self.fields[fieldName].getDataReferent(soFar0 + len(data))
                 soFar = soFar0 + len(data)
 
-            except Exception, e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error packing field '%s | %s' in %s" % (fieldName, fieldTypeOrClass, self.__class__))
                 raise
@@ -653,7 +653,7 @@ class NDRCONSTRUCTEDTYPE(NDR):
                     size += self.fields[fieldName].fromStringReferent(data[size:], soFar + size)
                 data = data[size:]
                 soFar += size
-            except Exception,e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[:256]))
                 raise
@@ -736,7 +736,7 @@ class NDRArray(NDRCONSTRUCTEDTYPE):
                 res = self.pack(fieldName, fieldTypeOrClass, soFar)
                 data += res
                 soFar = soFar0 + len(data)
-            except Exception, e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error packing field '%s | %s' in %s" % (fieldName, fieldTypeOrClass, self.__class__))
                 raise
@@ -799,7 +799,7 @@ class NDRArray(NDRCONSTRUCTEDTYPE):
 
                 data = data[size:]
                 soFar += size
-            except Exception,e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[:256]))
                 raise
@@ -958,7 +958,7 @@ class NDRUniConformantVaryingArray(NDRArray):
                 res = self.pack(fieldName, fieldTypeOrClass, soFar)
                 data += res
                 soFar = soFar0 + len(data)
-            except Exception, e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error packing field '%s | %s' in %s" % (fieldName, fieldTypeOrClass, self.__class__))
                 raise
@@ -1063,7 +1063,7 @@ class NDRSTRUCT(NDRCONSTRUCTEDTYPE):
                     res = self.pack(fieldName, fieldTypeOrClass, soFar)
                 data += res
                 soFar = soFar0 + len(data) + len(arrayPadding) + arrayItemSize
-            except Exception, e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error packing field '%s | %s' in %s" % (fieldName, fieldTypeOrClass, self.__class__))
                 raise
@@ -1159,7 +1159,7 @@ class NDRSTRUCT(NDRCONSTRUCTEDTYPE):
 
                 data = data[size:]
                 soFar += size
-            except Exception,e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[:256]))
                 raise
@@ -1297,7 +1297,7 @@ class NDRUNION(NDRCONSTRUCTEDTYPE):
                 res = self.pack(fieldName, fieldTypeOrClass, soFar)
                 data += res
                 soFar = soFar0 + len(data)
-            except Exception, e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error packing field '%s | %s' in %s" % (fieldName, fieldTypeOrClass, self.__class__))
                 raise
@@ -1333,7 +1333,7 @@ class NDRUNION(NDRCONSTRUCTEDTYPE):
                 res = self.pack(fieldName, fieldTypeOrClass, soFar)
                 data += res
                 soFar = soFar0 + len(data)
-            except Exception, e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error packing field '%s | %s' in %s" % (fieldName, fieldTypeOrClass, self.__class__))
                 raise
@@ -1384,7 +1384,7 @@ class NDRUNION(NDRCONSTRUCTEDTYPE):
 
                 data = data[size:]
                 soFar += size
-            except Exception,e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[:256]))
                 raise
@@ -1421,7 +1421,7 @@ class NDRUNION(NDRCONSTRUCTEDTYPE):
 
                 data = data[size:]
                 soFar += size
-            except Exception,e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[:256]))
                 raise
@@ -1692,7 +1692,7 @@ class NDRCALL(NDRCONSTRUCTEDTYPE):
                     soFar = soFar0 + len(data)
                     data += self.fields[fieldName].getDataReferent(soFar)
                     soFar = soFar0 + len(data)
-            except Exception, e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error packing field '%s | %s' in %s" % (fieldName, fieldTypeOrClass, self.__class__))
                 raise
@@ -1720,7 +1720,7 @@ class NDRCALL(NDRCONSTRUCTEDTYPE):
                     size += self.fields[fieldName].fromStringReferent(data[size:], soFar + size)
                 data = data[size:]
                 soFar += size
-            except Exception,e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[:256]))
                 raise

--- a/impacket/dcerpc/v5/rrp.py
+++ b/impacket/dcerpc/v5/rrp.py
@@ -813,7 +813,7 @@ def hBaseRegEnumValue(dce, hKey, dwIndex, dataLen=256):
             request['lpcbData'] = dataLen
             request['lpcbLen'] = dataLen
             resp = dce.request(request)
-        except DCERPCSessionError, e:
+        except DCERPCSessionError as e:
             if retries > 1:
                 LOG.debug('Too many retries when calling hBaseRegEnumValue, aborting')
                 raise
@@ -886,7 +886,7 @@ def hBaseRegQueryValue(dce, hKey, lpValueName, dataLen=512):
             request['lpcbData'] = dataLen
             request['lpcbLen'] = dataLen
             resp = dce.request(request)
-        except DCERPCSessionError, e:
+        except DCERPCSessionError as e:
             if retries > 1:
                 LOG.debug('Too many retries when calling hBaseRegQueryValue, aborting')
                 raise

--- a/impacket/dcerpc/v5/scmr.py
+++ b/impacket/dcerpc/v5/scmr.py
@@ -1282,7 +1282,7 @@ def hREnumServicesStatusW(dce, hSCManager, dwServiceType=SERVICE_WIN32_OWN_PROCE
 
     try:
         resp = dce.request(enumServicesStatus)
-    except DCERPCSessionError, e:
+    except DCERPCSessionError as e:
         if e.get_error_code() == system_errors.ERROR_MORE_DATA:
             resp = e.get_packet()
             enumServicesStatus['cbBufSize'] = resp['pcbBytesNeeded']
@@ -1332,7 +1332,7 @@ def hRQueryServiceConfigW(dce, hService):
     queryService['cbBufSize'] = 0
     try:
         resp = dce.request(queryService)
-    except DCERPCSessionError, e:
+    except DCERPCSessionError as e:
         if e.get_error_code() == system_errors.ERROR_INSUFFICIENT_BUFFER:
             resp = e.get_packet()
             queryService['cbBufSize'] = resp['pcbBytesNeeded']

--- a/impacket/dcerpc/v5/transport.py
+++ b/impacket/dcerpc/v5/transport.py
@@ -256,7 +256,7 @@ class UDPTransport(DCERPCTransport):
             af, socktype, proto, canonname, sa = socket.getaddrinfo(self.getRemoteHost(), self.get_dport(), 0, socket.SOCK_DGRAM)[0]
             self.__socket = socket.socket(af, socktype, proto)
             self.__socket.settimeout(self.get_connect_timeout())
-        except socket.error, msg:
+        except socket.error as msg:
             self.__socket = None
             raise DCERPCException("Could not connect: %s" % msg)
 
@@ -297,7 +297,7 @@ class TCPTransport(DCERPCTransport):
         try:
             self.__socket.settimeout(self.get_connect_timeout())
             self.__socket.connect(sa)
-        except socket.error, msg:
+        except socket.error as msg:
             self.__socket.close()
             raise DCERPCException("Could not connect: %s" % msg)
         return 1
@@ -305,7 +305,7 @@ class TCPTransport(DCERPCTransport):
     def disconnect(self):
         try:
             self.__socket.close()
-        except socket.error, msg:
+        except socket.error as msg:
             self.__socket = None
             return 0
         return 1

--- a/impacket/examples/ntlmrelayx/attacks/__init__.py
+++ b/impacket/examples/ntlmrelayx/attacks/__init__.py
@@ -59,7 +59,7 @@ for file in pkg_resources.resource_listdir('impacket.examples.ntlmrelayx', 'atta
             else:
                 # Single class
                 pluginClasses.add(getattr(module, getattr(module, 'PROTOCOL_ATTACK_CLASS')))
-        except Exception, e:
+        except Exception as e:
             LOG.debug(e)
             pass
 
@@ -67,6 +67,6 @@ for file in pkg_resources.resource_listdir('impacket.examples.ntlmrelayx', 'atta
             for pluginName in pluginClass.PLUGIN_NAMES:
                 LOG.debug('Protocol Attack %s loaded..' % pluginName)
                 PROTOCOL_ATTACKS[pluginName] = pluginClass
-    except Exception, e:
+    except Exception as e:
         LOG.debug(str(e))
 

--- a/impacket/examples/ntlmrelayx/attacks/smbattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/smbattack.py
@@ -79,7 +79,7 @@ class SMBAttack(ProtocolAttack):
 
                 remoteOps  = RemoteOperations(self.__SMBConnection, False)
                 remoteOps.enableRegistry()
-            except Exception, e:
+            except Exception as e:
                 if "rpc_s_access_denied" in str(e): # user doesn't have correct privileges
                     if self.config.enumLocalAdmins:
                         LOG.info(u"Relayed user doesn't have admin on {}. Attempting to enumerate users who do...".format(self.__SMBConnection.getRemoteHost().encode(self.config.encoding)))
@@ -89,7 +89,7 @@ class SMBAttack(ProtocolAttack):
                             LOG.info(u"Host {} has the following local admins (hint: try relaying one of them here...)".format(self.__SMBConnection.getRemoteHost().encode(self.config.encoding)))
                             for name in localAdminNames:
                                 LOG.info(u"Host {} local admin member: {} ".format(self.__SMBConnection.getRemoteHost().encode(self.config.encoding), name))
-                        except DCERPCException, e:
+                        except DCERPCException as e:
                             LOG.info("SAMR access denied")
                         return
                 # Something else went wrong. aborting
@@ -112,7 +112,7 @@ class SMBAttack(ProtocolAttack):
                     samHashes.dump()
                     samHashes.export(self.__SMBConnection.getRemoteHost()+'_samhashes')
                     LOG.info("Done dumping SAM hashes for host: %s", self.__SMBConnection.getRemoteHost())
-            except Exception, e:
+            except Exception as e:
                 LOG.error(str(e))
             finally:
                 if samHashes is not None:

--- a/impacket/examples/ntlmrelayx/clients/__init__.py
+++ b/impacket/examples/ntlmrelayx/clients/__init__.py
@@ -89,13 +89,13 @@ for file in pkg_resources.resource_listdir('impacket.examples.ntlmrelayx', 'clie
                     pluginClasses.add(getattr(module, pluginClass))
             else:
                 pluginClasses.add(getattr(module, getattr(module, 'PROTOCOL_CLIENT_CLASS')))
-        except Exception, e:
+        except Exception as e:
             LOG.debug(e)
             pass
 
         for pluginClass in pluginClasses:
             LOG.info('Protocol Client %s loaded..' % pluginClass.PLUGIN_NAME)
             PROTOCOL_CLIENTS[pluginClass.PLUGIN_NAME] = pluginClass
-    except Exception, e:
+    except Exception as e:
         LOG.debug(str(e))
 

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -61,7 +61,7 @@ class HTTPRelayServer(Thread):
                 LOG.info("HTTPD: Received connection from %s, attacking target %s://%s" % (client_address[0] ,self.target.scheme, self.target.netloc))
             try:
                 SimpleHTTPServer.SimpleHTTPRequestHandler.__init__(self,request, client_address, server)
-            except Exception, e:
+            except Exception as e:
                 LOG.error(str(e))
                 LOG.debug(traceback.format_exc())
 
@@ -70,7 +70,7 @@ class HTTPRelayServer(Thread):
                 SimpleHTTPServer.SimpleHTTPRequestHandler.handle_one_request(self)
             except KeyboardInterrupt:
                 raise
-            except Exception, e:
+            except Exception as e:
                 LOG.error('Exception in HTTP request handler: %s' % e)
                 LOG.debug(traceback.format_exc())
 

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -125,7 +125,7 @@ class SMBRelayServer(Thread):
                 extSec = True
             # Init the correct client for our target
             client = self.init_client(extSec)
-        except Exception, e:
+        except Exception as e:
             LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
             self.targetprocessor.logTarget(self.target)
         else:
@@ -258,7 +258,7 @@ class SMBRelayServer(Thread):
             client = smbData[self.target]['SMBClient']
             try:
                 challengeMessage = self.do_ntlm_negotiate(client, token)
-            except Exception, e:
+            except Exception as e:
                 # Log this target as processed for this client
                 self.targetprocessor.logTarget(self.target)
                 # Raise exception again to pass it on to the SMB server
@@ -398,7 +398,7 @@ class SMBRelayServer(Thread):
 
             #Init the correct client for our target
             client = self.init_client(extSec)
-        except Exception, e:
+        except Exception as e:
             LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
             self.targetprocessor.logTarget(self.target)
         else:
@@ -457,7 +457,7 @@ class SMBRelayServer(Thread):
                 client = smbData[self.target]['SMBClient']
                 try:
                     challengeMessage = self.do_ntlm_negotiate(client,token)
-                except Exception, e:
+                except Exception as e:
                     # Log this target as processed for this client
                     self.targetprocessor.logTarget(self.target)
                     # Raise exception again to pass it on to the SMB server

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/imap.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/imap.py
@@ -120,7 +120,7 @@ class IMAPSocksRelay(SocksRelay):
         while True:
             try:
                 data = self.socksSocket.recv(self.packetSize)
-            except Exception, e:
+            except Exception as e:
                 # Socks socket (client) closed connection or something else. Not fatal for killing the existing relay
                 print keyword, tag
                 LOG.debug('IMAP: sockSocket recv(): %s' % (str(e)))
@@ -216,14 +216,14 @@ class IMAPSocksRelay(SocksRelay):
         while keyword != tag and keyword != '+':
             try:
                 data = self.relaySocketFile.readline()
-            except Exception, e:
+            except Exception as e:
                 # This didn't break the connection to the server, don't make it fatal
                 LOG.debug("IMAP relaySocketFile: %s" % str(e))
                 return False
             keyword = data.split(' ', 2)[0]
             try:
                 self.socksSocket.sendall(data)
-            except Exception, e:
+            except Exception as e:
                 LOG.debug("IMAP socksSocket: %s" % str(e))
                 return False
 

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/imaps.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/imaps.py
@@ -43,7 +43,7 @@ class IMAPSSocksRelay(SSLServerMixin, IMAPSocksRelay):
                 # Shut down TLS connection
                 self.socksSocket.shutdown()
                 return False
-        except Exception, e:
+        except Exception as e:
             LOG.debug('IMAPS: %s' % str(e))
             return False
         # Change our outgoing socket to the SSL object of IMAP4_SSL

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/mssql.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/mssql.py
@@ -152,7 +152,7 @@ class MSSQLSocksRelay(SocksRelay):
                 tds = self.session.recvTDS()
                 # 4. Send it back to the client
                 self.sendTDS(tds['Type'], tds['Data'], 0)
-        except Exception, e:
+        except Exception as e:
             # Probably an error here
             if LOG.level == logging.DEBUG:
                 import traceback

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/smb.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/smb.py
@@ -135,7 +135,7 @@ class SMBSocksRelay(SocksRelay):
                                 data2 = self.clientConnection.getSMBServer()._sess.recv_packet(timeout=1).get_trailer()
                                 self.__NBSession.send_packet(str(data))
                                 data = data2
-                        except Exception, e:
+                        except Exception as e:
                             if str(e).find('timed out') > 0:
                                 pass
                             else:
@@ -183,12 +183,12 @@ class SMBSocksRelay(SocksRelay):
         try:
             packet = NewSMBPacket(data=data.get_trailer())
             smbCommand = SMBCommand(packet['Data'][0])
-        except Exception, e:
+        except Exception as e:
             # Maybe a SMB2 packet?
             try:
                 packet = SMB2Packet(data = data.get_trailer())
                 smbCommand = None
-            except Exception, e:
+            except Exception as e:
                 LOG.error('SOCKS: %s' % str(e))
 
         return packet, smbCommand

--- a/impacket/examples/ntlmrelayx/servers/socksserver.py
+++ b/impacket/examples/ntlmrelayx/servers/socksserver.py
@@ -187,7 +187,7 @@ def keepAliveTimer(server):
                         LOG.debug('Calling keepAlive() for %s@%s:%s' % (user, target, port))
                         try:
                             server.activeRelays[target][port][user]['protocolClient'].keepAlive()
-                        except Exception, e:
+                        except Exception as e:
                             LOG.debug('SOCKS: %s' % str(e))
                             if str(e).find('Broken pipe') >= 0 or str(e).find('reset by peer') >=0 or \
                                             str(e).find('Invalid argument') >= 0 or str(e).find('Server not connected') >=0:
@@ -342,7 +342,7 @@ class SocksRequestHandler(SocketServer.BaseRequestHandler):
             try:
                 LOG.debug('SOCKS: Connecting to %s(%s)' %(self.targetHost, self.targetPort))
                 s.connect((self.targetHost, self.targetPort))
-            except Exception, e:
+            except Exception as e:
                 if LOG.level == logging.DEBUG:
                     import traceback
                     traceback.print_exc()
@@ -368,7 +368,7 @@ class SocksRequestHandler(SocketServer.BaseRequestHandler):
                     s.sendall(data)
                     data = s.recv(8192)
                     self.__connSocket.sendall(data)
-                except Exception, e:
+                except Exception as e:
                     if LOG.level == logging.DEBUG:
                         import traceback
                         traceback.print_exc()
@@ -410,7 +410,7 @@ class SocksRequestHandler(SocketServer.BaseRequestHandler):
                 self.__socksServer.activeRelays[self.targetHost][self.targetPort][relay.username]['inUse'] = True
 
                 relay.tunnelConnection()
-            except Exception, e:
+            except Exception as e:
                 if LOG.level == logging.DEBUG:
                     import traceback
                     traceback.print_exc()
@@ -435,7 +435,7 @@ class SocksRequestHandler(SocketServer.BaseRequestHandler):
         LOG.debug('SOCKS: Shutting down connection')
         try:
             self.sendReplyError(replyField.CONNECTION_REFUSED)
-        except Exception, e:
+        except Exception as e:
             LOG.debug('SOCKS END: %s' % str(e))
 
 

--- a/impacket/examples/ntlmrelayx/utils/targetsutils.py
+++ b/impacket/examples/ntlmrelayx/utils/targetsutils.py
@@ -79,7 +79,7 @@ class TargetsProcessor:
                     target = line.strip()
                     if target is not None:
                         self.originalTargets.extend(self.processTarget(target, self.protocolClients))
-        except IOError, e:
+        except IOError as e:
             LOG.error("Could not open file: %s - " % (self.filename, str(e)))
 
         if len(self.originalTargets) == 0:

--- a/impacket/examples/os_ident.py
+++ b/impacket/examples/os_ident.py
@@ -1972,7 +1972,7 @@ class NMAP2_Fingerprint:
     def parse_int(self, field, value):
         try:
             return int(value, 16)
-        except ValueError, err:
+        except ValueError as err:
             if NMAP2_Fingerprint.literal_conv.has_key( field ):
                 if NMAP2_Fingerprint.literal_conv[field].has_key(value):
                     return NMAP2_Fingerprint.literal_conv[field][value]
@@ -2057,7 +2057,7 @@ class NMAP2_Fingerprint_Matcher:
                                     fp.get_os_class().get_device_type())))
 
             infile.close()
-        except IOError, err:
+        except IOError as err:
             print "IOError: %s", err
 
         return output

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -302,7 +302,7 @@ class RemoteFile:
             try:
                 self.__fid = self.__smbConnection.openFile(self.__tid, self.__fileName, desiredAccess=FILE_READ_DATA,
                                                    shareMode=FILE_SHARE_READ)
-            except Exception, e:
+            except Exception as e:
                 if str(e).find('STATUS_SHARING_VIOLATION') >=0:
                     if tries >= 3:
                         raise e
@@ -560,7 +560,7 @@ class RemoteOperations:
                                                                        samr.USER_SERVER_TRUST_ACCOUNT |\
                                                                        samr.USER_INTERDOMAIN_TRUST_ACCOUNT,
                                                     enumerationContext=enumerationContext)
-        except DCERPCException, e:
+        except DCERPCException as e:
             if str(e).find('STATUS_MORE_ENTRIES') < 0:
                 raise
             resp = e.get_packet()
@@ -631,7 +631,7 @@ class RemoteOperations:
             if account.startswith('.\\'):
                 account = account[2:]
             return account
-        except Exception, e:
+        except Exception as e:
             # Don't log if history service is not found, that should be normal
             if serviceName.endswith("_history") is False:
                 LOG.error(e)
@@ -705,7 +705,7 @@ class RemoteOperations:
                 scmr.hRCloseServiceHandle(self.__scmr, self.__serviceHandle)
                 scmr.hRCloseServiceHandle(self.__scmr, self.__scManagerHandle)
                 rpc.disconnect()
-            except Exception, e:
+            except Exception as e:
                 # If service is stopped it'll trigger an exception
                 # If service does not exist it'll trigger an exception
                 # So. we just wanna be sure we delete it, no need to
@@ -723,7 +723,7 @@ class RemoteOperations:
         if self.__scmr is not None:
             try:
                 self.__scmr.disconnect()
-            except Exception, e:
+            except Exception as e:
                 if str(e).find('STATUS_INVALID_PARAMETER') >=0:
                     pass
                 else:
@@ -941,7 +941,7 @@ class RemoteOperations:
             try:
                 self.__smbConnection.getFile('ADMIN$', 'Temp\\__output', self.__answer)
                 break
-            except Exception, e:
+            except Exception as e:
                 if tries > 30:
                     # We give up
                     raise Exception('Too many tries trying to list vss shadows')
@@ -1022,7 +1022,7 @@ class RemoteOperations:
             try:
                 self.__smbConnection.deleteFile('ADMIN$', 'Temp\\__output')
                 break
-            except Exception, e:
+            except Exception as e:
                 if tries >= 30:
                     raise e
                 if str(e).find('STATUS_OBJECT_NAME_NOT_FOUND') >= 0 or str(e).find('STATUS_SHARING_VIOLATION') >=0:
@@ -1668,7 +1668,7 @@ class ResumeSessionMgrInFile(object):
     def getResumeData(self):
         try:
             self.__resumeFile = open(self.__resumeFileName,'rb')
-        except Exception, e:
+        except Exception as e:
             raise Exception('Cannot open resume session file name %s' % str(e))
         resumeSid = self.__resumeFile.read()
         self.__resumeFile.close()
@@ -1686,7 +1686,7 @@ class ResumeSessionMgrInFile(object):
         if not self.__resumeFile:
             try:
                 self.__resumeFile = open(self.__resumeFileName, 'wb+')
-            except Exception, e:
+            except Exception as e:
                 raise Exception('Cannot create "%s" resume session file: %s' % (self.__resumeFileName, str(e)))
 
     def endTransaction(self):
@@ -1959,7 +1959,7 @@ class NTDSHashes:
                 try:
                     attId = drsuapi.OidFromAttid(prefixTable, attr['attrTyp'])
                     LOOKUP_TABLE = self.ATTRTYP_TO_ATTID
-                except Exception, e:
+                except Exception as e:
                     LOG.debug('Failed to execute OidFromAttid with error %s' % e)
                     # Fallbacking to fixed table and hope for the best
                     attId = attr['attrTyp']
@@ -2165,7 +2165,7 @@ class NTDSHashes:
                 try:
                     attId = drsuapi.OidFromAttid(prefixTable, attr['attrTyp'])
                     LOOKUP_TABLE = self.ATTRTYP_TO_ATTID
-                except Exception, e:
+                except Exception as e:
                     LOG.debug('Failed to execute OidFromAttid with error %s, fallbacking to fixed table' % e)
                     # Fallbacking to fixed table and hope for the best
                     attId = attr['attrTyp']
@@ -2302,7 +2302,7 @@ class NTDSHashes:
                                 raise
                     else:
                         raise Exception('No remote Operations available')
-                except Exception, e:
+                except Exception as e:
                     LOG.debug('Exiting NTDSHashes.dump() because %s' % e)
                     # Target's not a DC
                     return
@@ -2335,7 +2335,7 @@ class NTDSHashes:
                             self.__decryptHash(record, outputFile=hashesOutputFile)
                             if self.__justNTLM is False:
                                 self.__decryptSupplementalInfo(record, None, keysOutputFile, clearTextOutputFile)
-                        except Exception, e:
+                        except Exception as e:
                             if LOG.level == logging.DEBUG:
                                 import traceback
                                 traceback.print_exc()
@@ -2364,7 +2364,7 @@ class NTDSHashes:
                                 self.__decryptHash(record, outputFile=hashesOutputFile)
                                 if self.__justNTLM is False:
                                     self.__decryptSupplementalInfo(record, None, keysOutputFile, clearTextOutputFile)
-                        except Exception, e:
+                        except Exception as e:
                             if LOG.level == logging.DEBUG:
                                 import traceback
                                 traceback.print_exc()
@@ -2430,7 +2430,7 @@ class NTDSHashes:
                             self.__decryptSupplementalInfo(userRecord, userRecord['pmsgOut'][replyVersion]['PrefixTableSrc'][
                                 'pPrefixEntry'], keysOutputFile, clearTextOutputFile)
 
-                    except Exception, e:
+                    except Exception as e:
                         #import traceback
                         #traceback.print_exc()
                         LOG.error("Error while processing user!")
@@ -2483,7 +2483,7 @@ class NTDSHashes:
                                     self.__decryptSupplementalInfo(userRecord, userRecord['pmsgOut'][replyVersion]['PrefixTableSrc'][
                                         'pPrefixEntry'], keysOutputFile, clearTextOutputFile)
 
-                            except Exception, e:
+                            except Exception as e:
                                 if LOG.level == logging.DEBUG:
                                     import traceback
                                     traceback.print_exc()
@@ -2538,7 +2538,7 @@ class NTDSHashes:
     def __writeOutput(cls, fd, data):
         try:
             fd.write(data)
-        except Exception, e:
+        except Exception as e:
             LOG.error("Error writing entry, skipping (%s)" % str(e))
             pass
 

--- a/impacket/examples/serviceinstall.py
+++ b/impacket/examples/serviceinstall.py
@@ -65,7 +65,7 @@ class ServiceInstall:
         # First we try to open the service in case it exists. If it does, we remove it.
         try:
             resp =  scmr.hROpenServiceW(self.rpcsvc, handle, self.__service_name+'\x00')
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_SERVICE_DOES_NOT_EXIST') >= 0:
                 # We're good, pass the exception
                 pass
@@ -181,7 +181,7 @@ class ServiceInstall:
                         scmr.hRCloseServiceHandle(self.rpcsvc, service)
                     scmr.hRCloseServiceHandle(self.rpcsvc, svcManager)
                     return True
-            except Exception, e:
+            except Exception as e:
                 LOG.critical("Error performing the installation, cleaning up: %s" %e)
                 try:
                     scmr.hRControlService(self.rpcsvc, service, scmr.SERVICE_CONTROL_STOP)

--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -69,7 +69,7 @@ class MiniImpacketShell(cmd.Cmd):
         retVal = False
         try:
            retVal = cmd.Cmd.onecmd(self,s)
-        except Exception, e:
+        except Exception as e:
            #import traceback
            #traceback.print_exc()
            LOG.error(e)

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -57,7 +57,7 @@ def sendReceive(data, host, kdcHost):
         af, socktype, proto, canonname, sa = socket.getaddrinfo(targetHost, 88, 0, socket.SOCK_STREAM)[0]
         s = socket.socket(af, socktype, proto)
         s.connect(sa)
-    except socket.error, e:
+    except socket.error as e:
         raise socket.error("Connection error (%s:%s)" % (targetHost, 88), e)
 
     s.sendall(messageLen + data)
@@ -146,7 +146,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
 
     try:
         r = sendReceive(message, domain, kdcHost)
-    except KerberosError, e:
+    except KerberosError as e:
         if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
             if supportedCiphers[0] in (constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value) and aesKey is '':
                 supportedCiphers = (int(constants.EncryptionTypes.rc4_hmac.value),)
@@ -188,7 +188,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
                         salt = ''
                     else:
                         salt = str(etype2['salt'])
-                except PyAsn1Error, e:
+                except PyAsn1Error as e:
                     salt = ''
 
                 encryptionTypesData[etype2['etype']] = salt
@@ -200,7 +200,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
                         salt = ''
                     else:
                         salt = str(etype['salt'])
-                except PyAsn1Error, e:
+                except PyAsn1Error as e:
                     salt = ''
 
                 encryptionTypesData[etype['etype']] = salt
@@ -279,7 +279,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
 
         try:
             tgt = sendReceive(encoder.encode(asReq), domain, kdcHost)
-        except Exception, e:
+        except Exception as e:
             if str(e).find('KDC_ERR_ETYPE_NOSUPP') >= 0:
                 if lmhash is '' and nthash is '' and (aesKey is '' or aesKey is None):
                     from impacket.ntlm import compute_lmhash, compute_nthash
@@ -304,7 +304,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
     # (Section 5.4.2)
     try:
         plainText = cipher.decrypt(key, 3, str(cipherText))
-    except InvalidChecksum, e:
+    except InvalidChecksum as e:
         # probably bad password if preauth is disabled
         if preAuth is False:
             error_msg = "failed to decrypt session key: %s" % str(e)
@@ -449,7 +449,7 @@ def getKerberosType3(cipher, sessionKey, auth_data):
     #ap_rep = decoder.decode(negTokenResp['ResponseToken'][16:], asn1Spec=AP_REP())[0]
     try:
         krbError = KerberosError(packet = decoder.decode(negTokenResp['ResponseToken'][15:], asn1Spec = KRB_ERROR())[0])
-    except Exception, e:
+    except Exception as e:
         pass
     else:
         raise krbError
@@ -496,7 +496,7 @@ def getKerberosType1(username, password, domain, lmhash, nthash, aesKey='', TGT 
         if useCache is True:
             try:
                 ccache = CCache.loadFile(os.getenv('KRB5CCNAME'))
-            except Exception, e:
+            except Exception as e:
                 # No cache present
                 pass
             else:
@@ -535,7 +535,7 @@ def getKerberosType1(username, password, domain, lmhash, nthash, aesKey='', TGT 
             if TGS is None:
                 try:
                     tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, password, domain, lmhash, nthash, aesKey, kdcHost)
-                except KerberosError, e:
+                except KerberosError as e:
                     if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
                         # We might face this if the target does not support AES 
                         # So, if that's the case we'll force using RC4 by converting
@@ -563,7 +563,7 @@ def getKerberosType1(username, password, domain, lmhash, nthash, aesKey='', TGT 
             serverName = Principal('host/%s' % targetName, type=constants.PrincipalNameType.NT_SRV_INST.value)
             try:
                 tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey)
-            except KerberosError, e:
+            except KerberosError as e:
                 if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
                     # We might face this if the target does not support AES 
                     # So, if that's the case we'll force using RC4 by converting

--- a/impacket/mqtt.py
+++ b/impacket/mqtt.py
@@ -270,7 +270,7 @@ class MQTTConnection:
             try:
                 message = MQTT_Packet(data)
                 remaining = data[len(message):]
-            except Exception, e:
+            except Exception as e:
                 # We need more data
                 remaining = data + self._socket.recv(REQUEST_SIZE)
             else:
@@ -347,7 +347,7 @@ class MQTTConnection:
 
         try:
             data = self.sendReceive(subscribePacket)[0]
-        except Exception, e:
+        except Exception as e:
             raise MQTTSessionError(errorString=str(e))
 
         subAck = MQTT_SubscribeACK(str(data))

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1430,7 +1430,7 @@ class SMB3:
                         files.append(smb.SharedFile(fileInfo['CreationTime'],fileInfo['LastAccessTime'],fileInfo['LastChangeTime'],fileInfo['EndOfFile'],fileInfo['AllocationSize'],fileInfo['ExtFileAttributes'],fileInfo['FileName'].decode('utf-16le'), fileInfo['FileName'].decode('utf-16le')))
                         nextOffset = fileInfo['NextEntryOffset']
                         res = res[nextOffset:]
-                except SessionError, e:
+                except SessionError as e:
                     if (e.get_error_code()) != STATUS_NO_MORE_FILES:
                         raise
                     break 

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -261,7 +261,7 @@ class SMBConnection:
                 return self._SMBConnection.login(user, password, domain, lmhash, nthash, ntlmFallback)
             else:
                 return self._SMBConnection.login(user, password, domain, lmhash, nthash)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
     def kerberosLogin(self, user, password, domain='', lmhash='', nthash='', aesKey='', kdcHost=None, TGT=None,
@@ -337,9 +337,9 @@ class SMBConnection:
                                                               TGT, TGS)
                 return self._SMBConnection.kerberosLogin(user, password, domain, lmhash, nthash, aesKey, kdcHost, TGT,
                                                          TGS)
-            except (smb.SessionError, smb3.SessionError), e:
+            except (smb.SessionError, smb3.SessionError) as e:
                 raise SessionError(e.get_error_code(), e.get_error_packet())
-            except KerberosError, e:
+            except KerberosError as e:
                 if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
                     # We might face this if the target does not support AES
                     # So, if that's the case we'll force using RC4 by converting
@@ -357,13 +357,13 @@ class SMBConnection:
     def isGuestSession(self):
         try:
             return self._SMBConnection.isGuestSession()
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
     def logoff(self):
         try:
             return self._SMBConnection.logoff()
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
 
@@ -376,14 +376,14 @@ class SMBConnection:
                 share = '\\\\' + self.getRemoteHost() + '\\' + share
         try:
             return self._SMBConnection.connect_tree(share)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
 
     def disconnectTree(self, treeId):
         try:
             return self._SMBConnection.disconnect_tree(treeId)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
 
@@ -416,7 +416,7 @@ class SMBConnection:
 
         try:
             return self._SMBConnection.list_path(shareName, path, password)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
     def createFile(self, treeId, pathName, desiredAccess=GENERIC_ALL,
@@ -460,14 +460,14 @@ class SMBConnection:
 
             try:
                 return self._SMBConnection.nt_create_andx(treeId, pathName, cmd = ntCreate)
-            except (smb.SessionError, smb3.SessionError), e:
+            except (smb.SessionError, smb3.SessionError) as e:
                 raise SessionError(e.get_error_code(), e.get_error_packet())
         else:
             try:
                 return self._SMBConnection.create(treeId, pathName, desiredAccess, shareMode, creationOption,
                                                   creationDisposition, fileAttributes, impersonationLevel,
                                                   securityFlags, oplockLevel, createContexts)
-            except (smb.SessionError, smb3.SessionError), e:
+            except (smb.SessionError, smb3.SessionError) as e:
                 raise SessionError(e.get_error_code(), e.get_error_packet())
 
     def openFile(self, treeId, pathName, desiredAccess=FILE_READ_DATA | FILE_WRITE_DATA, shareMode=FILE_SHARE_READ,
@@ -510,14 +510,14 @@ class SMBConnection:
 
             try:
                 return self._SMBConnection.nt_create_andx(treeId, pathName, cmd = ntCreate)
-            except (smb.SessionError, smb3.SessionError), e:
+            except (smb.SessionError, smb3.SessionError) as e:
                 raise SessionError(e.get_error_code(), e.get_error_packet())
         else:
             try:
                 return self._SMBConnection.create(treeId, pathName, desiredAccess, shareMode, creationOption,
                                                   creationDisposition, fileAttributes, impersonationLevel,
                                                   securityFlags, oplockLevel, createContexts)
-            except (smb.SessionError, smb3.SessionError), e:
+            except (smb.SessionError, smb3.SessionError) as e:
                 raise SessionError(e.get_error_code(), e.get_error_packet())
 
     def writeFile(self, treeId, fileId, data, offset=0):
@@ -533,7 +533,7 @@ class SMBConnection:
         """
         try:
             return self._SMBConnection.writeFile(treeId, fileId, data, offset)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
 
@@ -560,7 +560,7 @@ class SMBConnection:
                 toRead = remainingBytesToRead
             try:
                 bytesRead = self._SMBConnection.read_andx(treeId, fileId, offset, toRead)
-            except (smb.SessionError, smb3.SessionError), e:
+            except (smb.SessionError, smb3.SessionError) as e:
                 if e.get_error_code() == nt_errors.STATUS_END_OF_FILE:
                     toRead = ''
                     break
@@ -593,7 +593,7 @@ class SMBConnection:
         """
         try:
             return self._SMBConnection.close(treeId, fileId)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
     def deleteFile(self, shareName, pathName):
@@ -608,7 +608,7 @@ class SMBConnection:
         """
         try:
             return self._SMBConnection.remove(shareName, pathName)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
     def queryInfo(self, treeId, fileId):
@@ -627,7 +627,7 @@ class SMBConnection:
             else:
                 res = self._SMBConnection.queryInfo(treeId, fileId)
             return smb.SMBQueryFileStandardInfo(res)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
     def createDirectory(self, shareName, pathName ):
@@ -642,7 +642,7 @@ class SMBConnection:
         """
         try:
             return self._SMBConnection.mkdir(shareName, pathName)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
     def deleteDirectory(self, shareName, pathName):
@@ -657,7 +657,7 @@ class SMBConnection:
         """
         try:
             return self._SMBConnection.rmdir(shareName, pathName)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
     def waitNamedPipe(self, treeId, pipeName, timeout = 5):
@@ -673,7 +673,7 @@ class SMBConnection:
         """
         try:
             return self._SMBConnection.waitNamedPipe(treeId, pipeName, timeout = timeout)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
     def transactNamedPipe(self, treeId, fileId, data, waitAnswer = True):
@@ -690,7 +690,7 @@ class SMBConnection:
         """
         try:
             return self._SMBConnection.TransactNamedPipe(treeId, fileId, data, waitAnswer = waitAnswer)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
 
@@ -703,7 +703,7 @@ class SMBConnection:
         """
         try:
             return self._SMBConnection.TransactNamedPipeRecv()
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
     def writeNamedPipe(self, treeId, fileId, data, waitAnswer = True):
@@ -723,7 +723,7 @@ class SMBConnection:
                 return self._SMBConnection.write_andx(treeId, fileId, data, wait_answer = waitAnswer, write_pipe_mode = True)
             else:
                 return self.writeFile(treeId, fileId, data, 0)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
 
@@ -741,7 +741,7 @@ class SMBConnection:
 
         try:
             return self.readFile(treeId, fileId, bytesToRead = bytesToRead, singleCall = True)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
 
@@ -762,7 +762,7 @@ class SMBConnection:
                 return self._SMBConnection.retr_file(shareName, pathName, callback)
             else:
                 return self._SMBConnection.retr_file(shareName, pathName, callback, shareAccessMode=shareAccessMode)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
     def putFile(self, shareName, pathName, callback, shareAccessMode = None):
@@ -782,7 +782,7 @@ class SMBConnection:
                 return self._SMBConnection.stor_file(shareName, pathName, callback)
             else:
                 return self._SMBConnection.stor_file(shareName, pathName, callback, shareAccessMode)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
     def rename(self, shareName, oldPath, newPath):
@@ -799,7 +799,7 @@ class SMBConnection:
 
         try:
             return self._SMBConnection.rename(shareName, oldPath, newPath)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
     def reconnect(self):
@@ -823,7 +823,7 @@ class SMBConnection:
     def setTimeout(self, timeout):
         try:
             return self._SMBConnection.set_timeout(timeout)
-        except (smb.SessionError, smb3.SessionError), e:
+        except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
     def getSessionKey(self):

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -144,7 +144,7 @@ def outputToJohnFormat(challenge, username, domain, lmresponse, ntresponse):
             else:
                 # NTLMv1
                 ret_value = {'hash_string':'%s::%s:%s:%s:%s' % (username, domain, hexlify(lmresponse), hexlify(ntresponse), hexlify(challenge)), 'hash_version':'ntlm'}
-        except Exception, e:
+        except Exception as e:
             LOG.error("outputToJohnFormat: %s" % e)
             pass
 
@@ -247,7 +247,7 @@ def openFile(path,fileName, accessMode, fileAttributes, openMode):
         if sys.platform == 'win32':
             mode |= os.O_BINARY
         fid = os.open(pathName, mode)
-    except Exception, e:
+    except Exception as e:
         LOG.error("openFile: %s,%s" % (pathName, mode) ,e)
         fid = 0
         errorCode = STATUS_ACCESS_DENIED
@@ -506,7 +506,7 @@ def queryPathInformation(path, filename, level):
     else:
         # NOT FOUND
         return None, STATUS_OBJECT_NAME_NOT_FOUND
-  except Exception, e:
+  except Exception as e:
       LOG.error('queryPathInfo: %s' % e)
       raise
 
@@ -772,7 +772,7 @@ class TRANS2Commands:
             path = connData['ConnectedShares'][recvPacket['Tid']]['path']
             try:
                infoRecord, errorCode = queryPathInformation(path, decodeSMBString(recvPacket['Flags2'], queryPathInfoParameters['FileName']), queryPathInfoParameters['InformationLevel'])
-            except Exception, e:
+            except Exception as e:
                smbServer.log("queryPathInformation: %s" % e,logging.ERROR)
 
             if infoRecord is not None:
@@ -957,7 +957,7 @@ class SMBCommands:
                                 transData['Trans_Parameters'], 
                                 transData['Trans_Data'],
                                 transParameters['MaxDataCount'])
-               except Exception, e:
+               except Exception as e:
                    #print 'Transaction: %s' % e,e
                    smbServer.log('Transaction: (%r,%s)' % (command, e), logging.ERROR)
                    errorCode = STATUS_ACCESS_DENIED
@@ -1094,7 +1094,7 @@ class SMBCommands:
                                 NTTransData['NT_Trans_Parameters'], 
                                 NTTransData['NT_Trans_Data'],
                                 NTTransParameters['MaxDataCount'])
-               except Exception, e:
+               except Exception as e:
                    smbServer.log('NTTransaction: (0x%x,%s)' % (command, e), logging.ERROR)
                    errorCode = STATUS_ACCESS_DENIED
                    #raise
@@ -1230,7 +1230,7 @@ class SMBCommands:
                                 trans2Data['Trans_Parameters'], 
                                 trans2Data['Trans_Data'],
                                 trans2Parameters['MaxDataCount'])
-               except Exception, e:
+               except Exception as e:
                    smbServer.log('Transaction2: (0x%x,%s)' % (command, e), logging.ERROR)
                    #import traceback
                    #traceback.print_exc()
@@ -1354,7 +1354,7 @@ class SMBCommands:
                      connData['OpenedFiles'][comClose['FID']]['Socket'].close()
                  elif fileHandle != VOID_FILE_DESCRIPTOR:
                      os.close(fileHandle)
-             except Exception, e:
+             except Exception as e:
                  smbServer.log("comClose %s" % e, logging.ERROR)
                  errorCode = STATUS_ACCESS_DENIED
              else:
@@ -1362,7 +1362,7 @@ class SMBCommands:
                  if connData['OpenedFiles'][comClose['FID']]['DeleteOnClose'] is True:
                      try:
                          os.remove(connData['OpenedFiles'][comClose['FID']]['FileName'])
-                     except Exception, e:
+                     except Exception as e:
                          smbServer.log("comClose %s" % e, logging.ERROR)
                          errorCode = STATUS_ACCESS_DENIED
                  del(connData['OpenedFiles'][comClose['FID']])
@@ -1404,7 +1404,7 @@ class SMBCommands:
                      sock = connData['OpenedFiles'][comWriteParameters['Fid']]['Socket']
                      sock.send(comWriteData['Data'])
                  respParameters['Count']    = comWriteParameters['Count']
-             except Exception, e:
+             except Exception as e:
                  smbServer.log('smbComWrite: %s' % e, logging.ERROR)
                  errorCode = STATUS_ACCESS_DENIED
         else:
@@ -1436,7 +1436,7 @@ class SMBCommands:
              fileHandle = connData['OpenedFiles'][comFlush['FID']]['FileHandle']
              try:
                  os.fsync(fileHandle)
-             except Exception, e:
+             except Exception as e:
                  smbServer.log("comFlush %s" % e, logging.ERROR)
                  errorCode = STATUS_ACCESS_DENIED
         else:
@@ -1481,7 +1481,7 @@ class SMBCommands:
              else:
                  try:
                      os.mkdir(pathName)
-                 except Exception, e:
+                 except Exception as e:
                      smbServer.log("smbComCreateDirectory: %s" % e, logging.ERROR)
                      errorCode = STATUS_ACCESS_DENIED
         else:
@@ -1530,7 +1530,7 @@ class SMBCommands:
              else:
                  try:
                      os.rename(oldPathName,newPathName)
-                 except OSError, e:
+                 except OSError as e:
                      smbServer.log("smbComRename: %s" % e, logging.ERROR)
                      errorCode = STATUS_ACCESS_DENIED
         else:
@@ -1574,7 +1574,7 @@ class SMBCommands:
              else:
                  try:
                      os.remove(pathName)
-                 except OSError, e:
+                 except OSError as e:
                      smbServer.log("smbComDelete: %s" % e, logging.ERROR)
                      errorCode = STATUS_ACCESS_DENIED
         else:
@@ -1618,7 +1618,7 @@ class SMBCommands:
              else:
                  try:
                      os.rmdir(pathName)
-                 except OSError, e:
+                 except OSError as e:
                      smbServer.log("smbComDeleteDirectory: %s" % e,logging.ERROR)
                      if e.errno == errno.ENOTEMPTY:
                          errorCode = STATUS_DIRECTORY_NOT_EMPTY
@@ -1675,7 +1675,7 @@ class SMBCommands:
 
                  respParameters['Count']    = writeAndX['DataLength']
                  respParameters['Available']= 0xff
-             except Exception, e:
+             except Exception as e:
                  smbServer.log('smbComWriteAndx: %s' % e, logging.ERROR)
                  errorCode = STATUS_ACCESS_DENIED
         else:
@@ -1715,7 +1715,7 @@ class SMBCommands:
                  respParameters['Count']    = len(content)
                  respData['DataLength']     = len(content)
                  respData['Data']           = content
-             except Exception, e:
+             except Exception as e:
                  smbServer.log('smbComRead: %s ' % e, logging.ERROR)
                  errorCode = STATUS_ACCESS_DENIED
         else:
@@ -1762,7 +1762,7 @@ class SMBCommands:
                  respParameters['DataOffset']   = 59
                  respParameters['DataCount_Hi'] = 0
                  respData = content
-             except Exception, e:
+             except Exception as e:
                  smbServer.log('smbComReadAndX: %s ' % e, logging.ERROR)
                  errorCode = STATUS_ACCESS_DENIED
         else:
@@ -1938,7 +1938,7 @@ class SMBCommands:
                  if os.path.isfile(pathName):
                      attribs = smb.SMB_FILE_ATTRIBUTE_NORMAL
                  respParameters['FileAttributes'] = attribs
-             except Exception, e:
+             except Exception as e:
                  smbServer.log('smbComQueryInformation2 %s' % e,logging.ERROR)
                  errorCode = STATUS_ACCESS_DENIED
 
@@ -2034,7 +2034,7 @@ class SMBCommands:
                              # Let's create the directory
                              os.mkdir(pathName)
                              mode = os.O_RDONLY
-                         except Exception, e:
+                         except Exception as e:
                              smbServer.log("NTCreateAndX: %s,%s,%s" % (pathName,mode,e),logging.ERROR)
                              errorCode = STATUS_ACCESS_DENIED
                  if createOptions & smb.FILE_NON_DIRECTORY_FILE == smb.FILE_NON_DIRECTORY_FILE:
@@ -2060,7 +2060,7 @@ class SMBCommands:
                                 sock.connect(smbServer.getRegisteredNamedPipes()[unicode(pathName)])
                             else:
                                 fid = os.open(pathName, mode)
-                     except Exception, e:
+                     except Exception as e:
                          smbServer.log("NTCreateAndX: %s,%s,%s" % (pathName,mode,e),logging.ERROR)
                          #print e
                          fid = 0
@@ -2558,7 +2558,7 @@ class SMBCommands:
            connData['_dialects_data']       = _dialects_data
            connData['_dialects_parameters'] = _dialects_parameters
 
-        except Exception, e:
+        except Exception as e:
            # No NTLM throw an error
            smbServer.log('smbComNegotiate: %s' % e, logging.ERROR)
            respSMBCommand['Data'] = struct.pack('<H',0xffff) 
@@ -2975,7 +2975,7 @@ class SMB2Commands:
                              # Let's create the directory
                              os.mkdir(pathName)
                              mode = os.O_RDONLY
-                         except Exception, e:
+                         except Exception as e:
                              smbServer.log("SMB2_CREATE: %s,%s,%s" % (pathName,mode,e),logging.ERROR)
                              errorCode = STATUS_ACCESS_DENIED
                  if createOptions & smb2.FILE_NON_DIRECTORY_FILE == smb2.FILE_NON_DIRECTORY_FILE:
@@ -3001,7 +3001,7 @@ class SMB2Commands:
                                 sock.connect(smbServer.getRegisteredNamedPipes()[unicode(pathName)])
                             else:
                                 fid = os.open(pathName, mode)
-                     except Exception, e:
+                     except Exception as e:
                          smbServer.log("SMB2_CREATE: %s,%s,%s" % (pathName,mode,e),logging.ERROR)
                          #print e
                          fid = 0
@@ -3090,7 +3090,7 @@ class SMB2Commands:
                  elif fileHandle != VOID_FILE_DESCRIPTOR:
                      os.close(fileHandle)
                      infoRecord, errorCode = queryFileInformation(os.path.dirname(pathName), os.path.basename(pathName), smb2.SMB2_FILE_NETWORK_OPEN_INFO)
-             except Exception, e:
+             except Exception as e:
                  smbServer.log("SMB2_CLOSE %s" % e, logging.ERROR)
                  errorCode = STATUS_INVALID_HANDLE
              else:
@@ -3101,7 +3101,7 @@ class SMB2Commands:
                              shutil.rmtree(connData['OpenedFiles'][fileID]['FileName'])
                          else:
                              os.remove(connData['OpenedFiles'][fileID]['FileName'])
-                     except Exception, e:
+                     except Exception as e:
                          smbServer.log("SMB2_CLOSE %s" % e, logging.ERROR)
                          errorCode = STATUS_ACCESS_DENIED
     
@@ -3237,7 +3237,7 @@ class SMB2Commands:
                         try:
                              os.rename(pathName,newPathName)
                              connData['OpenedFiles'][fileID]['FileName'] = newPathName
-                        except Exception, e:
+                        except Exception as e:
                              smbServer.log("smb2SetInfo: %s" % e, logging.ERROR)
                              errorCode = STATUS_ACCESS_DENIED
                     else:
@@ -3301,7 +3301,7 @@ class SMB2Commands:
 
                  respSMBCommand['Count']    = writeRequest['Length']
                  respSMBCommand['Remaining']= 0xff
-             except Exception, e:
+             except Exception as e:
                  smbServer.log('SMB2_WRITE: %s' % e, logging.ERROR)
                  errorCode = STATUS_ACCESS_DENIED
         else:
@@ -3344,7 +3344,7 @@ class SMB2Commands:
                  respSMBCommand['DataLength']   = len(content)
                  respSMBCommand['DataRemaining']= 0
                  respSMBCommand['Buffer']       = content
-             except Exception, e:
+             except Exception as e:
                  smbServer.log('SMB2_READ: %s ' % e, logging.ERROR)
                  errorCode = STATUS_ACCESS_DENIED
         else:
@@ -3365,7 +3365,7 @@ class SMB2Commands:
              errorCode = STATUS_SUCCESS
              try:
                  os.fsync(fileHandle)
-             except Exception, e:
+             except Exception as e:
                  smbServer.log("SMB2_FLUSH %s" % e, logging.ERROR)
                  errorCode = STATUS_ACCESS_DENIED
         else:
@@ -3619,7 +3619,7 @@ class Ioctls:
                      sock = connData['OpenedFiles'][str(ioctlRequest['FileID'])]['Socket']
                      sock.sendall(ioctlRequest['Buffer'])
                      ioctlResponse = sock.recv(ioctlRequest['MaxOutputResponse'])
-             except Exception, e:
+             except Exception as e:
                  smbServer.log('fsctlPipeTransceive: %s ' % e, logging.ERROR)
                  errorCode = STATUS_ACCESS_DENIED
         else:
@@ -3687,7 +3687,7 @@ class SMBSERVERHandler(SocketServer.BaseRequestHandler):
                    # a single packet
                    for i in resp:
                        session.send_packet(str(i))
-            except Exception, e:
+            except Exception as e:
                 self.__SMB.log("Handle: %s" % e)
                 #import traceback
                 #traceback.print_exc()
@@ -4164,7 +4164,7 @@ smb.SMB.TRANS_TRANSACT_NMPIPE          :self.__smbTransHandler.transactNamedPipe
                                    try:
                                        respCommands, respPackets, errorCode = self.__smb2Commands[smb2.SMB2_NEGOTIATE](connId, self, packet, True)
                                        isSMB2 = True
-                                   except Exception, e:
+                                   except Exception as e:
                                        self.log('SMB2_NEGOTIATE: %s' % e, logging.ERROR)
                                        # If something went wrong, let's fallback to SMB1
                                        respCommands, respPackets, errorCode = self.__smbCommands[packet['Command']](
@@ -4223,7 +4223,7 @@ smb.SMB.TRANS_TRANSACT_NMPIPE          :self.__smbTransHandler.transactNamedPipe
                         else:
                             done = True
 
-        except Exception, e:
+        except Exception as e:
             #import traceback
             #traceback.print_exc()
             # Something wen't wrong, defaulting to Bad user ID

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -767,7 +767,7 @@ class MSSQL:
                 if TGS is None:
                     try:
                         tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, password, domain, lmhash, nthash, aesKey, kdcHost)
-                    except KerberosError, e:
+                    except KerberosError as e:
                         if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
                             # We might face this if the target does not support AES
                             # So, if that's the case we'll force using RC4 by converting
@@ -802,7 +802,7 @@ class MSSQL:
                 serverName = Principal('MSSQLSvc/%s.%s:%d' % (self.server.split('.')[0], domain, self.port), type=constants.PrincipalNameType.NT_SRV_INST.value)
                 try:
                     tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey)
-                except KerberosError, e:
+                except KerberosError as e:
                     if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
                         # We might face this if the target does not support AES
                         # So, if that's the case we'll force using RC4 by converting

--- a/tests/ImpactPacket/test_TCP_bug_issue7.py
+++ b/tests/ImpactPacket/test_TCP_bug_issue7.py
@@ -29,7 +29,7 @@ class TestTCP(unittest.TestCase):
 			#	print "aaaaaaaaaaaaaaa"
 			#	print e
 			#except Exception,e:
-			except ImpactPacketException,e:
+			except ImpactPacketException as e:
 				if str(e) != "'TCP Option length is too low'":
 					raise e
 			except:

--- a/tests/SMB_RPC/test_dhcpm.py
+++ b/tests/SMB_RPC/test_dhcpm.py
@@ -59,7 +59,7 @@ class DHCPMTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             # For now we'e failing. This is not supported in W2k8r2
             if str(e).find('nca_s_op_rng_error') >= 0:
                 pass
@@ -98,7 +98,7 @@ class DHCPMTests(unittest.TestCase):
         try:
             resp = dhcpm.hDhcpGetClientInfoV4(dce, dhcpm.DHCP_SEARCH_INFO_TYPE.DhcpClientName, 'PEPA\x00')
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('0x4e2d') >= 0:
                 pass
 
@@ -108,7 +108,7 @@ class DHCPMTests(unittest.TestCase):
 
         try:
             resp = dhcpm.hDhcpEnumSubnetClientsV5(dce)
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NO_MORE_ITEMS') >=0:
                 pass
             else:

--- a/tests/SMB_RPC/test_drsuapi.py
+++ b/tests/SMB_RPC/test_drsuapi.py
@@ -220,7 +220,7 @@ class DRSRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NOT_SUPPORTED') <0:
                 raise
 

--- a/tests/SMB_RPC/test_even.py
+++ b/tests/SMB_RPC/test_even.py
@@ -49,7 +49,7 @@ class RRPTests(unittest.TestCase):
         request['MinorVersion'] = 1
         try:
             resp = dce.request(request)
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_OBJECT_NAME_NOT_FOUND') < 0:
                 raise
             resp = e.get_packet()
@@ -59,7 +59,7 @@ class RRPTests(unittest.TestCase):
         dce, rpctransport = self.connect()
         try:
             resp = even.hElfrOpenBELW(dce, NULL, '\\??\\BETO')
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_OBJECT_NAME_NOT_FOUND') < 0:
                 raise
             resp = e.get_packet()
@@ -92,7 +92,7 @@ class RRPTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_ACCESS_DENIED') < 0:
                 raise
 
@@ -101,7 +101,7 @@ class RRPTests(unittest.TestCase):
         try:
             resp = even.hElfrRegisterEventSourceW(dce, NULL, 'Security', '')
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_ACCESS_DENIED') < 0:
                 raise
 
@@ -134,7 +134,7 @@ class RRPTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_OBJECT_NAME_INVALID') < 0:
                 raise
 
@@ -145,7 +145,7 @@ class RRPTests(unittest.TestCase):
         try:
             resp = even.hElfrClearELFW(dce, resp['LogHandle'], '\\??\\c:\\beto2')
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_OBJECT_NAME_INVALID') < 0:
                 raise
 
@@ -159,7 +159,7 @@ class RRPTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_OBJECT_NAME_INVALID') < 0:
                 raise
 
@@ -170,7 +170,7 @@ class RRPTests(unittest.TestCase):
         try:
             resp = even.hElfrBackupELFW(dce, resp['LogHandle'], '\\??\\c:\\beto2')
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_OBJECT_NAME_INVALID') < 0:
                 raise
 
@@ -198,7 +198,7 @@ class RRPTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_ACCESS_DENIED') < 0:
                 raise
 

--- a/tests/SMB_RPC/test_even6.py
+++ b/tests/SMB_RPC/test_even6.py
@@ -48,7 +48,7 @@ class EVEN6Tests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             return
 
         log_handle = resp['Handle']
@@ -62,7 +62,7 @@ class EVEN6Tests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             return
 
         for i in range(resp['NumActualRecords']):
@@ -78,7 +78,7 @@ class EVEN6Tests(unittest.TestCase):
         try:
             resp = even6.hEvtRpcRegisterLogQuery(dce, 'Security\x00', '*\x00', even6.EvtQueryChannelName | even6.EvtReadNewestToOldest)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             return
 
         log_handle = resp['Handle']
@@ -86,7 +86,7 @@ class EVEN6Tests(unittest.TestCase):
         try:
             resp = even6.EvtRpcQueryNext(dce, log_handle, 5, 1000, 0)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             return
 
         for i in range(resp['NumActualRecords']):

--- a/tests/SMB_RPC/test_lsad.py
+++ b/tests/SMB_RPC/test_lsad.py
@@ -245,7 +245,7 @@ class LSADTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_INVALID_PARAMETER') < 0:
                 raise
 
@@ -253,7 +253,7 @@ class LSADTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_OBJECT_NAME_NOT_FOUND') < 0:
                 raise
 
@@ -261,7 +261,7 @@ class LSADTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_OBJECT_NAME_NOT_FOUND') < 0:
                 raise
 
@@ -270,21 +270,21 @@ class LSADTests(unittest.TestCase):
         try:
             resp = lsad.hLsarQueryDomainInformationPolicy(dce, policyHandle, lsad.POLICY_DOMAIN_INFORMATION_CLASS.PolicyDomainQualityOfServiceInformation)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_INVALID_PARAMETER') < 0:
                 raise
 
         try:
             resp = lsad.hLsarQueryDomainInformationPolicy(dce, policyHandle, lsad.POLICY_DOMAIN_INFORMATION_CLASS.PolicyDomainEfsInformation)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_OBJECT_NAME_NOT_FOUND') < 0:
                 raise
 
         try:
             resp = lsad.hLsarQueryDomainInformationPolicy(dce, policyHandle, lsad.POLICY_DOMAIN_INFORMATION_CLASS.PolicyDomainKerberosTicketInformation)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_OBJECT_NAME_NOT_FOUND') < 0:
                 raise
 
@@ -327,7 +327,7 @@ class LSADTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_MORE_ENTRIES') < 0:
                 raise
 
@@ -336,7 +336,7 @@ class LSADTests(unittest.TestCase):
         try:
             resp = lsad.hLsarEnumerateTrustedDomainsEx(dce, policyHandle)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_MORE_ENTRIES') < 0:
                 raise
 
@@ -349,7 +349,7 @@ class LSADTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_MORE_ENTRIES') < 0:
                 raise
 
@@ -358,7 +358,7 @@ class LSADTests(unittest.TestCase):
         try:
             resp = lsad.hLsarEnumerateTrustedDomains(dce, policyHandle)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_MORE_ENTRIES') < 0:
                 raise
 
@@ -831,7 +831,7 @@ class LSADTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_SUCH_DOMAIN') < 0:
                 raise
 

--- a/tests/SMB_RPC/test_lsat.py
+++ b/tests/SMB_RPC/test_lsat.py
@@ -86,7 +86,7 @@ class LSATTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             # The RPC server MUST ensure that the RPC_C_AUTHN_NETLOGON security provider 
             # (as specified in [MS-RPCE] section 2.2.1.1.7) and at least 
             # RPC_C_AUTHN_LEVEL_PKT_INTEGRITY authentication level (as specified in 
@@ -102,7 +102,7 @@ class LSATTests(unittest.TestCase):
         try:
             resp = lsat.hLsarLookupNames4(dce, ('Administrator', 'Guest'))
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             # The RPC server MUST ensure that the RPC_C_AUTHN_NETLOGON security provider 
             # (as specified in [MS-RPCE] section 2.2.1.1.7) and at least 
             # RPC_C_AUTHN_LEVEL_PKT_INTEGRITY authentication level (as specified in 
@@ -215,7 +215,7 @@ class LSATTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             # The RPC server MUST ensure that the RPC_C_AUTHN_NETLOGON security provider 
             # (as specified in [MS-RPCE] section 2.2.1.1.7) and at least 
             # RPC_C_AUTHN_LEVEL_PKT_INTEGRITY authentication level (as specified in 
@@ -294,7 +294,7 @@ class LSATTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_SOME_NOT_MAPPED') < 0:
                 raise
             else:
@@ -314,7 +314,7 @@ class LSATTests(unittest.TestCase):
         try:
             resp = lsat.hLsarLookupSids(dce, policyHandle, sids )
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_SOME_NOT_MAPPED') < 0:
                 raise
             else:

--- a/tests/SMB_RPC/test_mgmt.py
+++ b/tests/SMB_RPC/test_mgmt.py
@@ -81,7 +81,7 @@ class MGMTTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') < 0:
                 raise
 
@@ -91,7 +91,7 @@ class MGMTTests(unittest.TestCase):
         try:
             resp = mgmt.hstop_server_listening(dce)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') < 0:
                 raise
 

--- a/tests/SMB_RPC/test_nrpc.py
+++ b/tests/SMB_RPC/test_nrpc.py
@@ -94,7 +94,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = nrpc.hNetrServerAuthenticate3(dce, NULL, self.username + '\x00', nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel,self.serverName + '\x00',ppp, 0x600FFFFF )
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_DOWNGRADE_DETECTED') < 0:
                 raise
 
@@ -190,7 +190,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NO_SUCH_DOMAIN') < 0:
                 raise
 
@@ -199,7 +199,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = nrpc.hNetrGetAnyDCName(dce, '\x00'*20, self.domain + '\x00')
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NO_SUCH_DOMAIN') < 0:
                 raise
 
@@ -295,7 +295,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') < 0:
                 raise
 
@@ -429,7 +429,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_DOWNGRADE_DETECTED') < 0:
                 raise
 
@@ -452,7 +452,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = nrpc.hNetrServerAuthenticate(dce, NULL,self.username + '\x00', nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel ,self.serverName + '\x00', ppp)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_DOWNGRADE_DETECTED') < 0:
                 raise
 
@@ -468,7 +468,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_ACCESS_DENIED') < 0:
                 raise
 
@@ -477,7 +477,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = nrpc.hNetrServerPasswordGet(dce, NULL, self.username + '\x00', nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel ,self.serverName + '\x00', self.update_authenticator())
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_ACCESS_DENIED') < 0:
                 raise
 
@@ -616,7 +616,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_SUCH_USER') < 0:
                 raise
 
@@ -659,7 +659,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_SUCH_USER') < 0:
                 raise
 
@@ -677,7 +677,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NOT_SUPPORTED') < 0:
                 raise
 
@@ -696,7 +696,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NOT_SUPPORTED') < 0:
                 raise
 
@@ -714,7 +714,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NOT_SUPPORTED') < 0:
                 raise
 
@@ -731,7 +731,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NOT_SUPPORTED') < 0:
                 raise
 
@@ -743,7 +743,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NOT_SUPPORTED') < 0:
                 raise
 
@@ -754,7 +754,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NOT_SUPPORTED') < 0:
                 raise
 
@@ -765,7 +765,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NOT_SUPPORTED') < 0:
                 raise
 
@@ -781,7 +781,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NOT_IMPLEMENTED') < 0:
                 raise
 
@@ -794,7 +794,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NO_SUCH_DOMAIN') < 0:
                 raise
 
@@ -809,7 +809,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NO_SUCH_DOMAIN') < 0:
                 raise
 
@@ -818,7 +818,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = nrpc.hNetrServerGetTrustInfo(dce, NULL, self.username, nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel,self.serverName,self.update_authenticator())
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NO_SUCH_DOMAIN') < 0:
                 raise
 
@@ -830,7 +830,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') < 0:
                 raise
 
@@ -844,7 +844,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') < 0:
                 raise
 
@@ -858,7 +858,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') < 0:
                 raise
 
@@ -873,7 +873,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_ACCESS_DENIED') < 0:
                 raise
 
@@ -886,7 +886,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') < 0:
                 raise
 
@@ -897,7 +897,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') < 0:
                 raise
 
@@ -913,7 +913,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') < 0:
                 raise
 
@@ -929,7 +929,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') < 0:
                 raise
 
@@ -944,7 +944,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_INVALID_LEVEL') < 0:
                 raise
 
@@ -957,7 +957,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') < 0:
                 raise
 
@@ -970,7 +970,7 @@ class NRPCTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') < 0:
                 raise
 

--- a/tests/SMB_RPC/test_rpcrt.py
+++ b/tests/SMB_RPC/test_rpcrt.py
@@ -135,7 +135,7 @@ class DCERPCTests(unittest.TestCase):
             request['ServerHandle'] = resp['ServerHandle']
             request['Name'] = 'A'*4500
             resp = dce.request(request)
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_SUCH_DOMAIN') < 0:
                 raise
         dce.disconnect()
@@ -290,7 +290,7 @@ class DCERPCTests(unittest.TestCase):
             request['max_ents'] = 499
             resp = dce.request(request)
             dce.disconnect()
-        except Exception, e:
+        except Exception as e:
             if not (str(e).find('STATUS_ACCESS_DENIED') >=0 and self.stringBinding.find('ncacn_np') >=0):
                 raise
 
@@ -391,7 +391,7 @@ class DCERPCTests(unittest.TestCase):
             request['max_ents'] = 499
             resp = dce.request(request)
             dce.disconnect()
-        except Exception, e:
+        except Exception as e:
             if not (str(e).find('STATUS_ACCESS_DENIED') >=0 and self.stringBinding.find('ncacn_np') >=0):
                 raise
 

--- a/tests/SMB_RPC/test_rrp.py
+++ b/tests/SMB_RPC/test_rrp.py
@@ -173,7 +173,7 @@ class RRPTests(unittest.TestCase):
         try: 
             resp = rrp.hBaseRegSetValue(dce, phKey, 'BETO2\x00',  rrp.REG_SZ, 'HOLA COMO TE VA\x00')
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
 
         type, data = rrp.hBaseRegQueryValue(dce, phKey, 'BETO2\x00')
@@ -217,7 +217,7 @@ class RRPTests(unittest.TestCase):
         try: 
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
 
         request = rrp.BaseRegQueryValue()
@@ -375,7 +375,7 @@ class RRPTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_FILE_NOT_FOUND') < 0:
                 raise
 
@@ -385,7 +385,7 @@ class RRPTests(unittest.TestCase):
         try:
             resp = rrp.hBaseRegReplaceKey(dce, phKey, 'SOFTWARE\x00', 'SOFTWARE\x00', 'SOFTWARE\x00')
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_FILE_NOT_FOUND') < 0:
                 raise
 
@@ -399,7 +399,7 @@ class RRPTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_FILE_NOT_FOUND') < 0:
                 raise
 
@@ -409,7 +409,7 @@ class RRPTests(unittest.TestCase):
         try:
             resp = rrp.hBaseRegRestoreKey(dce, phKey, 'SOFTWARE\x00')
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_FILE_NOT_FOUND') < 0:
                 raise
 

--- a/tests/SMB_RPC/test_samr.py
+++ b/tests/SMB_RPC/test_samr.py
@@ -253,7 +253,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_SUCH_DOMAIN') < 0:
                 raise
         
@@ -267,7 +267,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = samr.hSamrOpenDomain(dce, serverHandle = resp['ServerHandle'], domainId = sid) 
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_SUCH_DOMAIN') < 0:
                 raise
 
@@ -284,7 +284,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_SUCH_DOMAIN') < 0:
                 raise
         
@@ -293,7 +293,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = samr.hSamrOpenGroup(dce, domainHandle, groupId=samr.DOMAIN_GROUP_RID_USERS)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_SUCH_DOMAIN') < 0:
                 raise
 
@@ -306,7 +306,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_SUCH_ALIAS') < 0:
                 raise
 
@@ -315,7 +315,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = samr.hSamrOpenAlias(dce, domainHandle, aliasId = 25)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_SUCH_ALIAS') < 0:
                 raise
 
@@ -391,7 +391,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = samr.hSamrLookupNamesInDomain(dce, domainHandle, ('Administrator','Guest'))
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_MORE_ENTRIES') >=0:
                 pass
             e.get_packet().dump()
@@ -427,7 +427,7 @@ class SAMRTests(unittest.TestCase):
         while status == nt_errors.STATUS_MORE_ENTRIES:
             try:
                 resp4 = dce.request(request)
-            except Exception, e:
+            except Exception as e:
                 if str(e).find('STATUS_MORE_ENTRIES') < 0:
                     raise 
                 resp4 = e.get_packet()
@@ -450,7 +450,7 @@ class SAMRTests(unittest.TestCase):
         while status == nt_errors.STATUS_MORE_ENTRIES:
             try:
                 resp4 = dce.request(request)
-            except Exception, e:
+            except Exception as e:
                 if str(e).find('STATUS_MORE_ENTRIES') < 0:
                     raise 
                 resp4 = e.get_packet()
@@ -474,7 +474,7 @@ class SAMRTests(unittest.TestCase):
         while status == nt_errors.STATUS_MORE_ENTRIES:
             try:
                 resp4 = dce.request(request)
-            except Exception, e:
+            except Exception as e:
                 if str(e).find('STATUS_MORE_ENTRIES') < 0:
                     raise 
                 resp4 = e.get_packet()
@@ -487,7 +487,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = samr.hSamrEnumerateUsersInDomain(dce, domainHandle)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_MORE_ENTRIES') >=0:
                 pass
             e.get_packet().dump()
@@ -528,7 +528,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_MORE_ENTRIES') >=0:
                 e.get_packet().dump()
             else:
@@ -569,7 +569,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = samr.hSamrQueryDisplayInformation3(dce, domainHandle,  samr.DOMAIN_DISPLAY_INFORMATION.DomainDisplayUser)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_MORE_ENTRIES') >=0:
                 e.get_packet().dump()
             else:
@@ -589,7 +589,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = samr.hSamrQueryDisplayInformation2(dce, domainHandle,  samr.DOMAIN_DISPLAY_INFORMATION.DomainDisplayUser)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_MORE_ENTRIES') >=0:
                 e.get_packet().dump()
             else:
@@ -616,7 +616,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_MORE_ENTRIES') >=0:
                 e.get_packet().dump()
             else:
@@ -658,7 +658,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = samr.hSamrQueryDisplayInformation(dce, domainHandle,  samr.DOMAIN_DISPLAY_INFORMATION.DomainDisplayUser)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_MORE_ENTRIES') >=0:
                 e.get_packet().dump()
             else:
@@ -725,7 +725,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find("STATUS_ACCESS_DENIED") < 0:
                 raise
         request = samr.SamrDeleteGroup()
@@ -733,7 +733,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find("STATUS_OBJECT_TYPE_MISMATCH") < 0:
                 raise
 
@@ -742,13 +742,13 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = samr.hSamrCreateGroupInDomain(dce, domainHandle, 'testGroup', samr.GROUP_ALL_ACCESS | samr.DELETE)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find("STATUS_ACCESS_DENIED") < 0:
                 raise
         try:
             resp = samr.hSamrDeleteGroup(dce, domainHandle)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find("STATUS_OBJECT_TYPE_MISMATCH") < 0:
                 raise
 
@@ -1030,7 +1030,7 @@ class SAMRTests(unittest.TestCase):
         resp['Buffer']['General']['ReplicaSourceNodeName'] = 'BETUS'
         try:
             resp = samr.hSamrSetInformationDomain(dce, domainHandle, resp['Buffer'])
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_INVALID_INFO_CLASS') < 0:
                 raise
 
@@ -1127,7 +1127,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp0 = dce.request(request)
             resp0.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_SUCH_DOMAIN') < 0:
                 raise
 
@@ -1230,7 +1230,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp0 = samr.hSamrOpenGroup(dce, domainHandle,samr.GROUP_ALL_ACCESS, samr.DOMAIN_GROUP_RID_USERS )
             resp0.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_SUCH_DOMAIN') < 0:
                 raise
 
@@ -1297,7 +1297,7 @@ class SAMRTests(unittest.TestCase):
         while status == nt_errors.STATUS_MORE_ENTRIES:
             try:
                 resp4 = dce.request(request)
-            except Exception, e:
+            except Exception as e:
                 if str(e).find('STATUS_MORE_ENTRIES') < 0:
                     raise 
                 resp4 = e.get_packet()
@@ -1535,7 +1535,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_INVALID_INFO_CLASS') < 0:
                 raise
             pass
@@ -1557,7 +1557,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_INVALID_INFO_CLASS') < 0:
                 raise
             pass
@@ -1567,7 +1567,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_INVALID_INFO_CLASS') < 0:
                 raise
             pass
@@ -1577,7 +1577,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_INVALID_INFO_CLASS') < 0:
                 raise
             pass
@@ -1587,7 +1587,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_INVALID_INFO_CLASS') < 0:
                 raise
             pass
@@ -1822,7 +1822,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_INVALID_INFO_CLASS') < 0:
                 raise
             pass
@@ -1842,7 +1842,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_INVALID_INFO_CLASS') < 0:
                 raise
             pass
@@ -1852,7 +1852,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_INVALID_INFO_CLASS') < 0:
                 raise
             pass
@@ -1862,7 +1862,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_INVALID_INFO_CLASS') < 0:
                 raise
             pass
@@ -1872,7 +1872,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_INVALID_INFO_CLASS') < 0:
                 raise
             pass
@@ -1890,7 +1890,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_SUCH_DOMAIN') < 0:
                 raise
         request = samr.SamrRemoveMemberFromGroup()
@@ -1899,7 +1899,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp2 = dce.request(request)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_MEMBERS_PRIMARY_GROUP') < 0:
                 raise
         request = samr.SamrAddMemberToGroup()
@@ -1909,7 +1909,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp2 = dce.request(request)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_MEMBER_IN_GROUP') < 0:
                 raise
 
@@ -1926,19 +1926,19 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_SUCH_DOMAIN') < 0:
                 raise
         try:
             resp2 = samr.hSamrRemoveMemberFromGroup(dce, resp['GroupHandle'],samr.DOMAIN_USER_RID_ADMIN)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_MEMBERS_PRIMARY_GROUP') < 0:
                 raise
         try:
             resp2= samr.hSamrAddMemberToGroup(dce, resp['GroupHandle'] ,samr.DOMAIN_USER_RID_ADMIN, samr.SE_GROUP_ENABLED_BY_DEFAULT)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_MEMBER_IN_GROUP') < 0:
                 raise
 
@@ -1951,7 +1951,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_SUCH_DOMAIN') < 0:
                 raise
 
@@ -1969,7 +1969,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_NO_SUCH_DOMAIN') < 0:
                 raise
 
@@ -1986,7 +1986,7 @@ class SAMRTests(unittest.TestCase):
         while status == nt_errors.STATUS_MORE_ENTRIES:
             try:
                 resp4 = dce.request(request)
-            except Exception, e:
+            except Exception as e:
                 if str(e).find('STATUS_MORE_ENTRIES') < 0:
                     raise 
                 resp4 = e.get_packet()
@@ -2016,7 +2016,7 @@ class SAMRTests(unittest.TestCase):
         while status == nt_errors.STATUS_MORE_ENTRIES:
             try:
                 resp4 = dce.request(request)
-            except Exception, e:
+            except Exception as e:
                 if str(e).find('STATUS_MORE_ENTRIES') < 0:
                     raise 
                 resp4 = e.get_packet()
@@ -2258,7 +2258,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_SPECIAL_ACCOUNT') < 0:
                 raise
 
@@ -2294,7 +2294,7 @@ class SAMRTests(unittest.TestCase):
             resp= samr.hSamrRemoveMemberFromForeignDomain(dce, domainHandle, sid)
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_SPECIAL_ACCOUNT') < 0:
                 raise
 
@@ -2406,7 +2406,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = samr.hSamrGetAliasMembership(dce, domainHandle, sidsArray)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             request = samr.SamrDeleteAlias()
             request['AliasHandle'] = aliasHandle
             resp = dce.request(request)
@@ -2508,7 +2508,7 @@ class SAMRTests(unittest.TestCase):
         # calls made to SamrSetDSRMPassword using NCACN_IP_TCP are rejected with RPC_S_ACCESS_DENIED.
         try:
             resp = dce.request(request)
-        except Exception, e:
+        except Exception as e:
             if self.stringBinding.find('ncacn_ip_tcp') >=0:
                 if str(e).find('rpc_s_access_denied') < 0:
                     raise
@@ -2529,7 +2529,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') < 0:
                 raise
 
@@ -2544,7 +2544,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = samr.hSamrValidatePassword(dce, inputArg)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') < 0:
                 raise
 
@@ -2584,7 +2584,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_BAD_DESCRIPTOR_FORMAT') <= 0:
                 raise
 
@@ -2607,7 +2607,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = samr.hSamrSetSecurityObject(dce, userHandle,dtypes.GROUP_SECURITY_INFORMATION ,resp['SecurityDescriptor']  )
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_BAD_DESCRIPTOR_FORMAT') <= 0:
                 raise
 
@@ -2709,7 +2709,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_WRONG_PASSWORD') < 0:
                 raise
 
@@ -2780,7 +2780,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_PASSWORD_RESTRICTION') < 0:
                 raise
 
@@ -2827,7 +2827,7 @@ class SAMRTests(unittest.TestCase):
         try:
             resp = samr.hSamrUnicodeChangePasswordUser2(dce, '', 'testAccount', 'ADMIN', 'betus')
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_PASSWORD_RESTRICTION') < 0:
                 raise
 

--- a/tests/SMB_RPC/test_scmr.py
+++ b/tests/SMB_RPC/test_scmr.py
@@ -96,7 +96,7 @@ class SCMRTests(unittest.TestCase):
         request['cbBufSize'] = cbBuffSize
         try:
             resp = dce.request(request)
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_INSUFFICIENT_BUFFER') <= 0:
                 raise
             else: 
@@ -243,7 +243,7 @@ class SCMRTests(unittest.TestCase):
             #resp = dce.request(request)
             #self.changeServiceAndQuery2(dce, request, request['Info']['Union']['psma']['fIsManagedAccount'])
 
-        except Exception, e:
+        except Exception as e:
             import traceback
             traceback.print_exc()
             print e
@@ -273,7 +273,7 @@ class SCMRTests(unittest.TestCase):
         # Request again with the right bufSize
         try:
             resp = dce.request(request)
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_MORE_DATA') <= 0:
                 raise
             else: 
@@ -317,7 +317,7 @@ class SCMRTests(unittest.TestCase):
         try:
             resp = scmr.hREnumServiceGroupW(dce, scHandle, dwServiceType, dwServiceState, cbBufSize, lpResumeIndex, pszGroupName )
             resp.dump()
-        except Exception, e:
+        except Exception as e:
            if str(e).find('ERROR_SERVICE_DOES_NOT_EXISTS') <= 0:
                raise
 
@@ -426,7 +426,7 @@ class SCMRTests(unittest.TestCase):
   
         try:
             resp = scmr.hRStartServiceW(dce, serviceHandle, 3, ['arg1\x00', 'arg2\x00', 'arg3\x00'] )
-        except Exception, e:
+        except Exception as e:
            if str(e).find('ERROR_SERVICE_ALREADY_RUNNING') <= 0:
                raise
         resp = scmr.hRCloseServiceHandle(dce, scHandle)
@@ -478,7 +478,7 @@ class SCMRTests(unittest.TestCase):
         cbBufSize = 0
         try:
             resp = scmr.hRQueryServiceConfigW(dce, newHandle)
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_INSUFFICIENT_BUFFER') <= 0:
                 raise
             else: 
@@ -571,7 +571,7 @@ class SCMRTests(unittest.TestCase):
         try:
             resp = scmr.hREnumDependentServicesW(dce, serviceHandle, scmr.SERVICE_STATE_ALL,cbBufSize )
             resp.dump()
-        except scmr.DCERPCSessionError, e:
+        except scmr.DCERPCSessionError as e:
            if str(e).find('ERROR_MORE_DATA') <= 0:
                raise
            else:
@@ -599,7 +599,7 @@ class SCMRTests(unittest.TestCase):
         try:
             resp = scmr.hRQueryServiceObjectSecurity(dce, scHandle, scmr.DACL_SECURITY_INFORMATION, 0)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
            if str(e).find('rpc_s_access_denied') <= 0:
                raise
  
@@ -612,7 +612,7 @@ class SCMRTests(unittest.TestCase):
         try:
             resp = scmr.hRNotifyBootConfigStatus(dce, lpMachineName, 0x0)
             resp.dump()
-        except scmr.DCERPCSessionError, e:
+        except scmr.DCERPCSessionError as e:
            if str(e).find('ERROR_BOOT_ALREADY_ACCEPTED') <= 0:
                raise
  
@@ -633,7 +633,7 @@ class SCMRTests(unittest.TestCase):
             req['hService'] = serviceHandle
             req['dwControl'] = scmr.SERVICE_CONTROL_STOP
             resp = dce.request(req)
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_DEPENDENT_SERVICES_RUNNING') < 0 and str(e).find('ERROR_SERVICE_NOT_ACTIVE') < 0:
                 raise
             pass
@@ -649,7 +649,7 @@ class SCMRTests(unittest.TestCase):
         try:
             resp = scmr.hRStartServiceW(dce, serviceHandle, 0, NULL )
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_SERVICE_ALREADY_RUNNING') < 0:
                 raise
         return 

--- a/tests/SMB_RPC/test_secretsdump.py
+++ b/tests/SMB_RPC/test_secretsdump.py
@@ -80,7 +80,7 @@ class DumpSecrets:
                 try:
                     try:
                         self.connect()
-                    except Exception, e:
+                    except Exception as e:
                         if os.getenv('KRB5CCNAME') is not None and self.__doKerberos is True:
                             # SMBConnection failed. That might be because there was no way to log into the
                             # target system. We just have a last resort. Hope we have tickets cached and that they
@@ -97,7 +97,7 @@ class DumpSecrets:
                         bootKey             = self.__remoteOps.getBootKey()
                         # Let's check whether target system stores LM Hashes
                         self.__noLMHash = self.__remoteOps.checkNoLMHashPolicy()
-                except Exception, e:
+                except Exception as e:
                     self.__canProcessSAMLSA = False
                     if str(e).find('STATUS_USER_SESSION_DELETED') and os.getenv('KRB5CCNAME') is not None \
                         and self.__doKerberos is True:
@@ -119,7 +119,7 @@ class DumpSecrets:
                     self.__SAMHashes.dump()
                     if self.__outputFileName is not None:
                         self.__SAMHashes.export(self.__outputFileName)
-                except Exception, e:
+                except Exception as e:
                     logging.error('SAM hashes extraction failed: %s' % str(e))
 
                 try:
@@ -136,7 +136,7 @@ class DumpSecrets:
                     self.__LSASecrets.dumpSecrets()
                     if self.__outputFileName is not None:
                         self.__LSASecrets.exportSecrets(self.__outputFileName)
-                except Exception, e:
+                except Exception as e:
                     if logging.getLogger().level == logging.DEBUG:
                         import traceback
                         traceback.print_exc()
@@ -159,7 +159,7 @@ class DumpSecrets:
                                            printUserStatus= self.__printUserStatus, perSecretCallback=_print_helper)
             try:
                 self.__NTDSHashes.dump()
-            except Exception, e:
+            except Exception as e:
                 if logging.getLogger().level == logging.DEBUG:
                     import traceback
                     traceback.print_exc()
@@ -177,7 +177,7 @@ class DumpSecrets:
                 elif self.__useVSSMethod is False:
                     logging.info('Something wen\'t wrong with the DRSUAPI approach. Try again with -use-vss parameter')
             self.cleanup()
-        except (Exception, KeyboardInterrupt), e:
+        except (Exception, KeyboardInterrupt) as e:
             if logging.getLogger().level == logging.DEBUG:
                 import traceback
                 traceback.print_exc()

--- a/tests/SMB_RPC/test_smb.py
+++ b/tests/SMB_RPC/test_smb.py
@@ -265,7 +265,7 @@ class SMBTests(unittest.TestCase):
         is_socket_opened = True 
         try:
             select.select([s], [], [], 0)
-        except socket.error, e:
+        except socket.error as e:
             if e[0] == errno.EBADF:
                 is_socket_opened = False
         return is_socket_opened

--- a/tests/SMB_RPC/test_srvs.py
+++ b/tests/SMB_RPC/test_srvs.py
@@ -180,7 +180,7 @@ class SRVSTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             # I might be closing myself ;)
             if str(e).find('STATUS_PIPE_BROKEN') < 0 and str(e).find('STATUS_FILE_CLOSED') < 0 and str(e).find('STATUS_INVALID_HANDLE') < 0 and str(e).find('0x90a') < 0:
 
@@ -194,7 +194,7 @@ class SRVSTests(unittest.TestCase):
         try:
             resp = srvs.hNetrFileClose(dce, resp['InfoStruct']['FileInfo']['Level2']['Buffer'][0]['fi2_id'])
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             # I might be closing myself ;)
             if str(e).find('STATUS_PIPE_BROKEN') < 0 and str(e).find('STATUS_FILE_CLOSED') < 0 and str(e).find('STATUS_INVALID_HANDLE') < 0 and str(e).find('0x90a') < 0:
                 raise
@@ -275,7 +275,7 @@ class SRVSTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if e.get_error_code() != 0x908:
                 raise
 
@@ -287,7 +287,7 @@ class SRVSTests(unittest.TestCase):
         try:
             resp = srvs.hNetrSessionDel(dce, resp['InfoStruct']['SessionInfo']['Level502']['Buffer'][0]['sesi502_cname'], resp['InfoStruct']['SessionInfo']['Level502']['Buffer'][0]['sesi502_username'] )
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if e.get_error_code() != 0x908:
                 raise
 
@@ -874,7 +874,7 @@ class SRVSTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if e.get_error_code() != 0x2:
                 raise
 
@@ -883,7 +883,7 @@ class SRVSTests(unittest.TestCase):
         try:
             resp = srvs.hNetrDfsGetVersion(dce)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if e.get_error_code() != 0x2:
                 raise
 
@@ -895,7 +895,7 @@ class SRVSTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if e.get_error_code() != 0x32:
                 raise
 
@@ -914,7 +914,7 @@ class SRVSTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e) != 'rpc_x_bad_stub_data':
                 raise
 
@@ -926,7 +926,7 @@ class SRVSTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NOT_SUPPORTED') < 0:
                 raise
 
@@ -976,7 +976,7 @@ class SRVSTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e) != 'ERROR_NOT_SUPPORTED':
                 raise
 
@@ -985,7 +985,7 @@ class SRVSTests(unittest.TestCase):
         try:
             resp = srvs.hNetrServerAliasEnum(dce, 0)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
             if str(e) != 'ERROR_NOT_SUPPORTED':
                 raise
@@ -1078,7 +1078,7 @@ class SRVSTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NOT_SUPPORTED') < 0:
                 raise
 
@@ -1090,7 +1090,7 @@ class SRVSTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NOT_SUPPORTED') < 0:
                 raise
 
@@ -1103,7 +1103,7 @@ class SRVSTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NOT_SUPPORTED') < 0:
                 raise
 
@@ -1118,7 +1118,7 @@ class SRVSTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_x_bad_stub_data') < 0:
                 raise
 
@@ -1132,7 +1132,7 @@ class SRVSTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NOT_SUPPORTED') < 0:
                 raise
 

--- a/tests/SMB_RPC/test_tsch.py
+++ b/tests/SMB_RPC/test_tsch.py
@@ -250,7 +250,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if e.get_error_code() != 0x80070002:
                 raise
 
@@ -260,7 +260,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = sasec.hSASetAccountInformation(dce, NULL, 'MyJob.job', self.username, self.password, 0)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if e.get_error_code() != 0x80070002:
                 raise
 
@@ -309,7 +309,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if e.get_error_code() != 0x80070002:
                 raise
 
@@ -319,7 +319,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = sasec.hSAGetAccountInformation(dce, NULL, 'MyJob.job', 15)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if e.get_error_code() != 0x80070002:
                 raise
 
@@ -393,7 +393,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if e.get_error_code() != 0x80070002:
                 raise
 
@@ -406,7 +406,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = tsch.hSchRpcRetrieveTask(dce, '\\Microsoft\\Windows\\Defrag\\ScheduledDefrag\x00')
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
             pass
 
@@ -428,7 +428,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
             pass
 
@@ -522,7 +522,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if e.get_error_code() != 0x80070002:
                 raise
 
@@ -532,7 +532,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = tsch.hSchRpcEnumInstances(dce, '\\')
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if e.get_error_code() != 0x80070002:
                 raise
 
@@ -576,7 +576,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
             pass
 
@@ -609,7 +609,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = tsch.hSchRpcRun(dce, '\\At%d\x00' % jobId, ('arg0','arg1'))
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
             pass
 
@@ -642,7 +642,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = tsch.hSchRpcRun(dce, '\\At%d\x00' % jobId, ('arg0','arg1'))
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
             pass
 
@@ -651,7 +651,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('SCHED_E_TASK_NOT_RUNNING') <= 0:
                 raise
             pass
@@ -685,14 +685,14 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = tsch.hSchRpcRun(dce, '\\At%d\x00' % jobId, ('arg0','arg1'))
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
             pass
 
         try:
             resp = tsch.hSchRpcGetInstanceInfo(dce, resp['pGuid'])
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('SCHED_E_TASK_NOT_RUNNING') <= 0:
                 raise
             pass
@@ -726,7 +726,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = tsch.hSchRpcRun(dce, '\\At%d\x00' % jobId, ('arg0','arg1'))
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
             pass
 
@@ -736,7 +736,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('SCHED_E_TASK_NOT_RUNNING') <= 0:
                 raise
             pass
@@ -770,14 +770,14 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = tsch.hSchRpcRun(dce, '\\At%d\x00' % jobId, ('arg0','arg1'))
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
             pass
 
         try:
             resp = tsch.hSchRpcStopInstance(dce, resp['pGuid'])
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('SCHED_E_TASK_NOT_RUNNING') <= 0:
                 raise
             pass
@@ -820,7 +820,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             # It is actually S_FALSE
             if str(e).find('ERROR_INVALID_FUNCTION') <= 0:
                 raise
@@ -854,7 +854,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = tsch.hSchRpcStop(dce, '\\At%d\x00' % jobId)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             # It is actually S_FALSE
             if str(e).find('ERROR_INVALID_FUNCTION') <= 0:
                 raise
@@ -876,7 +876,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('E_NOTIMPL') <= 0:
                 raise
             pass
@@ -893,7 +893,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = tsch.hSchRpcRename(dce, '\\Beto', '\\Anita')
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('E_NOTIMPL') <= 0:
                 raise
             pass
@@ -913,7 +913,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             # It is actually S_FALSE
             if str(e).find('ERROR_INVALID_FUNCTIO') <= 0 and str(e).find('SCHED_S_TASK_NOT_SCHEDULED') < 0:
                 raise
@@ -933,7 +933,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = tsch.hSchRpcScheduledRuntimes(dce, '\\Microsoft\\Windows\\Defrag\\ScheduledDefrag', NULL, NULL, 0, 10)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             # It is actually S_FALSE
             if str(e).find('ERROR_INVALID_FUNCTIO') <= 0 and str(e).find('SCHED_S_TASK_NOT_SCHEDULED') < 0:
                 raise
@@ -948,7 +948,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('SCHED_S_TASK_HAS_NOT_RUN') <= 0:
                 raise
             pass
@@ -958,7 +958,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = tsch.hSchRpcGetLastRunInfo(dce, '\\Microsoft\\Windows\\Defrag\\ScheduledDefrag')
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('SCHED_S_TASK_HAS_NOT_RUN') <= 0:
                 raise
             pass
@@ -971,7 +971,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
             pass
 
@@ -980,7 +980,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = tsch.hSchRpcGetTaskInfo(dce, '\\Microsoft\\Windows\\Defrag\\ScheduledDefrag', tsch.SCH_FLAG_STATE)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
             pass
 
@@ -991,7 +991,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
             pass
 
@@ -1000,7 +1000,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = tsch.hSchRpcGetNumberOfMissedRuns(dce, '\\Microsoft\\Windows\\Defrag\\ScheduledDefrag')
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
             pass
 
@@ -1012,7 +1012,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = dce.request(request)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
             pass
 
@@ -1021,7 +1021,7 @@ class TSCHTests(unittest.TestCase):
         try:
             resp = tsch.hSchRpcEnableTask(dce, '\\Microsoft\\Windows\\Defrag\\ScheduledDefrag', True)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             print e
             pass
 

--- a/tests/SMB_RPC/test_wkst.py
+++ b/tests/SMB_RPC/test_wkst.py
@@ -179,7 +179,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = dce.request(req)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_INVALID_FUNCTION') < 0:
                 raise
 
@@ -194,7 +194,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp = wkst.hNetrUseAdd(dce, 1, info1)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') >=0:
                 # This could happen in newer OSes
                 pass
@@ -206,7 +206,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp = wkst.hNetrUseEnum(dce, 2)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_PIPE_DISCONNECTED') >=0:
                 # This could happen in newer OSes
                 pass
@@ -214,7 +214,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = wkst.hNetrUseGetInfo(dce, 'Z:', 3)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_PIPE_DISCONNECTED') >=0:
                 # This could happen in newer OSes
                 pass
@@ -222,7 +222,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp = wkst.hNetrUseDel(dce,'Z:')
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('STATUS_PIPE_DISCONNECTED') >=0:
                 # This could happen in newer OSes
                 pass
@@ -240,7 +240,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = dce.request(req)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') >=0:
                 # This could happen in newer OSes
                 pass
@@ -259,7 +259,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = dce.request(req)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') >=0:
                 # This could happen in newer OSes
                 pass
@@ -271,7 +271,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = dce.request(req)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') >=0:
                 # This could happen in newer OSes
                 pass
@@ -284,7 +284,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = dce.request(req)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('rpc_s_access_denied') >=0:
                 # This could happen in newer OSes
                 pass
@@ -301,7 +301,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = dce.request(req)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_INVALID_PARAMETER') < 0:
                 raise
 
@@ -311,7 +311,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = wkst.hNetrWorkstationStatisticsGet(dce, '\x00', 0, 0)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_INVALID_PARAMETER') < 0:
                 raise
 
@@ -325,7 +325,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = dce.request(req)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_INVALID_PARAMETER') < 0:
                 raise
 
@@ -335,7 +335,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp = wkst.hNetrGetJoinInformation(dce, '\x00')
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_INVALID_PARAMETER') < 0:
                 raise
 
@@ -353,7 +353,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = dce.request(req)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_INVALID_PASSWORD') < 0:
                 raise
 
@@ -363,7 +363,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp = wkst.hNetrJoinDomain2(dce,'172.16.123.1\\FREEFLY\x00','OU=BETUS,DC=FREEFLY\x00',NULL,'\x00'*512, wkst.NETSETUP_DOMAIN_JOIN_IF_JOINED)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_INVALID_PASSWORD') < 0:
                 raise
 
@@ -379,7 +379,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = dce.request(req)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_INVALID_PASSWORD') < 0:
                 raise
 
@@ -389,7 +389,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp = wkst.hNetrUnjoinDomain2(dce, NULL, '\x00'*512, wkst.NETSETUP_ACCT_DELETE)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_INVALID_PASSWORD') < 0:
                 raise
 
@@ -406,7 +406,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = dce.request(req)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_INVALID_PASSWORD') < 0:
                 raise
 
@@ -416,7 +416,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp = wkst.hNetrRenameMachineInDomain2(dce, 'BETUS\x00', NULL, '\x00'*512, wkst.NETSETUP_ACCT_CREATE)
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_INVALID_PASSWORD') < 0:
                 raise
 
@@ -432,7 +432,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = dce.request(req)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('0x8001011c') < 0:
                 raise
 
@@ -442,7 +442,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = wkst.hNetrValidateName2(dce, 'BETO\x00', NULL, NULL, wkst.NETSETUP_NAME_TYPE.NetSetupDomain)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('0x8001011c') < 0:
                 raise
 
@@ -459,7 +459,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = dce.request(req)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('0x8001011c') < 0:
                 raise
 
@@ -469,7 +469,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp = wkst.hNetrGetJoinableOUs2(dce,'FREEFLY\x00', NULL, NULL,0 )
             resp.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('0x8001011c') < 0:
                 raise
 
@@ -485,7 +485,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = dce.request(req)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NOT_SUPPORTED') < 0 and str(e).find('ERROR_INVALID_PASSWORD') < 0:
                 raise
 
@@ -495,7 +495,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2= wkst.hNetrAddAlternateComputerName(dce, 'FREEFLY\x00', NULL, NULL)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NOT_SUPPORTED') < 0 and str(e).find('ERROR_INVALID_PASSWORD') < 0:
                 raise
 
@@ -511,7 +511,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = dce.request(req)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NOT_SUPPORTED') < 0 and str(e).find('ERROR_INVALID_PASSWORD') < 0:
                 raise
 
@@ -521,7 +521,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = wkst.hNetrRemoveAlternateComputerName(dce,'FREEFLY\x00', NULL, NULL )
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NOT_SUPPORTED') < 0 and str(e).find('ERROR_INVALID_PASSWORD') < 0:
                 raise
 
@@ -537,7 +537,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = dce.request(req)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NOT_SUPPORTED') < 0:
                 if str(e).find('ERROR_INVALID_PARAMETER') < 0:
                     raise
@@ -548,7 +548,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = wkst.hNetrSetPrimaryComputerName(dce,'FREEFLY\x00', NULL, NULL )
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NOT_SUPPORTED') < 0:
                 if str(e).find('ERROR_INVALID_PARAMETER') < 0:
                     raise
@@ -563,7 +563,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = dce.request(req)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NOT_SUPPORTED') < 0:
                 raise
 
@@ -573,7 +573,7 @@ class WKSTTests(unittest.TestCase):
         try:
             resp2 = wkst.hNetrEnumerateComputerNames(dce,wkst.NET_COMPUTER_NAME_TYPE.NetAllComputerNames)
             resp2.dump()
-        except Exception, e:
+        except Exception as e:
             if str(e).find('ERROR_NOT_SUPPORTED') < 0:
                 raise
 

--- a/tests/SMB_RPC/test_wmi.py
+++ b/tests/SMB_RPC/test_wmi.py
@@ -73,7 +73,7 @@ class WMITests(unittest.TestCase):
         try:
             resp = iWbemLevel1Login.RequestChallenge()
             print resp
-        except Exception, e:
+        except Exception as e:
             if str(e).find('WBEM_E_NOT_SUPPORTED') < 0:
                 dcom.disconnect()
                 raise
@@ -86,7 +86,7 @@ class WMITests(unittest.TestCase):
         try:
             resp = iWbemLevel1Login.WBEMLogin()
             print resp
-        except Exception, e:
+        except Exception as e:
             if str(e).find('E_NOTIMPL') < 0:
                 dcom.disconnect()
                 raise
@@ -109,7 +109,7 @@ class WMITests(unittest.TestCase):
         try:
             resp = iWbemServices.OpenNamespace('__Namespace')
             print resp
-        except Exception, e:
+        except Exception as e:
             dcom.disconnect()
             raise
         dcom.disconnect()
@@ -140,13 +140,13 @@ class WMITests(unittest.TestCase):
                 while done is False:
                     try:
                         iEnumWbemClassObject.Next(0xffffffff,1)
-                    except Exception, e:
+                    except Exception as e:
                         if str(e).find('S_FALSE') < 0:
                             print e
                         else:
                             done = True
                             pass
-            except Exception, e:
+            except Exception as e:
                 if str(e).find('S_FALSE') < 0:
                     print e
         dcom.disconnect()


### PR DESCRIPTION
Python 3 treats old style exceptions as syntax errors.  New style exceptions work as expected in both Python 2 and Python 3.  This PR was created by __futurize -f lib2to3.fixes.fix_except -w .__.