### PR TITLE
Fixes for failing test_WEPEncoder on python36 branch

### DIFF
--- a/impacket/Dot11Crypto.py
+++ b/impacket/Dot11Crypto.py
@@ -12,22 +12,23 @@
 
 class RC4():
     def __init__(self, key):
+        bkey = bytearray(key)
         j = 0
-        self.state = range(256)
+        self.state = bytearray(range(256))
         for i in range(256):
-            j = (j + self.state[i] + ord(key[i % len(key)])) & 0xff
+            j = (j + self.state[i] + bkey[i % len(key)]) & 0xff
             self.state[i],self.state[j] = self.state[j],self.state[i] # SSWAP(i,j)
 
     def encrypt(self, data):
         i = j = 0
-        out=''
-        for char in data:
+        out=bytearray()
+        for char in bytearray(data):
             i = (i+1) & 0xff
             j = (j+self.state[i]) & 0xff
             self.state[i],self.state[j] = self.state[j],self.state[i] # SSWAP(i,j)
-            out+=chr(ord(char) ^ self.state[(self.state[i] + self.state[j]) & 0xff])
+            out.append(char ^ self.state[(self.state[i] + self.state[j]) & 0xff])
         
-        return out
+        return bytes(out)
     
     def decrypt(self, data):
         # It's symmetric

--- a/tests/dot11/test_WEPEncoder.py
+++ b/tests/dot11/test_WEPEncoder.py
@@ -115,7 +115,7 @@ class TestDot11WEPData(unittest.TestCase):
         self.wepdata.set_icv(0xA1F93985)
         wep_enc=self.wep.get_encrypted_data(unhexlify('999cbb701ca2ef030e302dcc35'))
         #print "\nWEP Data Encrypted [%s]"%hexlify(wep_enc)
-        self.assertEqual(wep_enc,b'8d2381e9251cb5aa83d2c716ba6ee18e7d3a2c71c00f6ab82fbc54c4b014ab03115edeccab2b18ebeb250f75eb6bf57fd65cb9e1b26e50ba4bb48b9f3471da9ecf12cb8f361b0253'.decode('hex_codec'))
+        self.assertEqual(wep_enc,unhexlify('8d2381e9251cb5aa83d2c716ba6ee18e7d3a2c71c00f6ab82fbc54c4b014ab03115edeccab2b18ebeb250f75eb6bf57fd65cb9e1b26e50ba4bb48b9f3471da9ecf12cb8f361b0253'))
         
         #print "\nDot11 decrypted [%s]"%hexlify(self.dot11.get_packet())
         self.wep.encrypt_frame(unhexlify('999cbb701ca2ef030e302dcc35'))


### PR DESCRIPTION
Python3 fixes in Dot11Crypto.py and test_WEPEncoder.py