### PR TITLE
Replace dict's has_key by in operator

### DIFF
--- a/impacket/Dot11KeyManager.py
+++ b/impacket/Dot11KeyManager.py
@@ -37,7 +37,7 @@ class KeyManager:
         
     def get_key(self, bssid):
         bssid=self.__get_bssid_hasheable_type(bssid)
-        if self.keys.has_key(bssid):
+        if bssid in self.keys:
             return self.keys[bssid]
         else:
             return False
@@ -47,7 +47,7 @@ class KeyManager:
         if not isinstance(bssid, list):
             raise Exception('BSSID datatype must be a list')
         
-        if self.keys.has_key(bssid):
+        if bssid in self.keys:
             del self.keys[bssid] 
             return True
         

--- a/impacket/examples/os_ident.py
+++ b/impacket/examples/os_ident.py
@@ -1973,8 +1973,8 @@ class NMAP2_Fingerprint:
         try:
             return int(value, 16)
         except ValueError, err:
-            if NMAP2_Fingerprint.literal_conv.has_key( field ):
-                if NMAP2_Fingerprint.literal_conv[field].has_key(value):
+            if field in NMAP2_Fingerprint.literal_conv:
+                if value in NMAP2_Fingerprint.literal_conv[field]:
                     return NMAP2_Fingerprint.literal_conv[field][value]
             return 0
 
@@ -2009,14 +2009,14 @@ class NMAP2_Fingerprint:
 
         for test in self.__tests:
             # ignore unknown response lines:
-            if not sample.has_key(test):
+            if test not in sample:
                 continue
         
             for field in self.__tests[test]:
                     # ignore unsupported fields:
-                if not sample[test].has_key(field) or \
-                   not mp.has_key(test) or \
-                   not mp[test].has_key(field):
+                if fields not in sample[test] or \
+                   test not in mp or \
+                   field not in mp[test]:
                     continue
             
                 ref = self.__tests[test][field]

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -937,7 +937,7 @@ class SMB3:
            # Is this file NOT on the root directory?
            if len(fileName.split('\\')) > 2:
                parentDir = ntpath.dirname(pathName)
-           if self.GlobalFileTable.has_key(parentDir):
+           if parentDir in self.GlobalFileTable:
                raise Exception("Don't know what to do now! :-o")
            else:
                parentEntry = copy.deepcopy(FILE)


### PR DESCRIPTION
Removed the deprecated has_key method of dict and replaced it by
the 'in' operator.

This PR fixes partially the ``test_05`` of the suite ``TestDot11WEPData``. The test still fails but now it fails with the same error than other tests in the same suite.

This PR also modify ``smb3`` and ``os_ident`` modules which, due a lack of infrastructure of my part, I could not run the tests.