### PR TITLE
added support for using Referral TGT in smbclient.py, atexec.py

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -502,7 +502,7 @@ class SMB3:
             self.__TGT, 
             self.__TGS)
 
-    def kerberosLogin(self, user, password, domain = '', lmhash = '', nthash = '', aesKey='', kdcHost = '', TGT=None, TGS=None):
+    def kerberosLogin(self, user, password, userDomain = '', targetDomain = '', lmhash = '', nthash = '', aesKey='', kdcHost = '', TGT=None, TGS=None):
         # If TGT or TGS are specified, they are in the form of:
         # TGS['KDC_REP'] = the response from the server
         # TGS['cipher'] = the cipher used
@@ -519,7 +519,7 @@ class SMB3:
 
         self.__userName = user
         self.__password = password
-        self.__domain   = domain
+        self.__domain   = targetDomain
         self.__lmhash   = lmhash
         self.__nthash   = nthash
         self.__kdc      = kdcHost
@@ -573,7 +573,7 @@ class SMB3:
 
         if TGS is None:
             serverName = Principal('cifs/%s' % (self._Connection['ServerName']), type=constants.PrincipalNameType.NT_SRV_INST.value)
-            tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey)
+            tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, targetDomain, kdcHost, tgt, cipher, sessionKey)
         else:
             tgs = TGS['KDC_REP']
             cipher = TGS['cipher']
@@ -602,7 +602,7 @@ class SMB3:
 
         authenticator = Authenticator()
         authenticator['authenticator-vno'] = 5
-        authenticator['crealm'] = domain
+        authenticator['crealm'] = userDomain
         seq_set(authenticator, 'cname', userName.components_to_asn1)
         now = datetime.datetime.utcnow()
 
@@ -636,7 +636,7 @@ class SMB3:
         if ans.isValidAnswer(STATUS_SUCCESS):
             self._Session['SessionID']       = ans['SessionID']
             self._Session['SigningRequired'] = self._Connection['RequireSigning']
-            self._Session['UserCredentials'] = (user, password, domain, lmhash, nthash)
+            self._Session['UserCredentials'] = (user, password, targetDomain, lmhash, nthash)
             self._Session['Connection']      = self._NetBIOSSession.get_socket()
 
             self._Session['SessionKey']  = sessionKey.contents[:16]


### PR DESCRIPTION
There is possibility to craft and use refferal TGT (hereinafter RTGT) to authenticate across AD trusts. More info about RTGT is here  - https://adsecurity.org/?p=1588

It is possible to use those RTGT in linux environment, with impacket, but there are changes have to be done.

Impacket can use normal TGT (Golden Ticket) but fails to use RTGT because there a litte difference between them:

Normal TGT has SPN: **krbtgt/domain.com@domain.com**. As you can see origin and target domains are the same, because TGT was intended to be used in the same domain where it was crafted.

RTGT has SPN: **krbtgt/domain2.com@domain1.com**. 
-  domain1.com (hereinafter userDomain ) is the realm where RTGT was initially crafted, and encrypted with INTER_DOMAIN_ACCOUNT hash. 
-  domain2.com (hereinafter targetDomain)  is the realm where RTGT is intended to be used for authentication and gaining service tickets.

So while using RTGT you should strictly distinguish userDomain and targetDomain. 

Unfortunately impacket fails with that. The only one domain name is used which results in authentication  errors:
- WRONG_REALM, appears when impacket connects to wrong KDC. It takes KDC name from domain name which in turn is taken from .ccache file, and this domain name is userDomain. But it should connect to targetDomain KDC instead. 
- STATUS_MORE_PROCESSING_REQUIRED, appears when realm which was used in authenticator  differs from realm in service ticket. It happens when you try to avoid the problem above  and explicitly use domain/username, where domain is the targetDomain eg: 
`smbclient.py -k domain2.com/user@host.domain2.com -no-pass`

So i've added this userDomain and targetDomain distinctions to code.
I've only tested it with smbclient.py (SMB3) and atexec.py.
I've also tested smbclient.py and atexec.py  with usual (Golden) TGT, and there were no errors.




