### PR TITLE
Create/remove mount points and add smbclient "mount/umount" commands

### DIFF
--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -105,6 +105,8 @@ class MiniImpacketShell(cmd.Cmd):
  rmdir {dirname} - removes the directory under the current path
  put {filename} - uploads the filename into the current path
  get {filename} - downloads the filename from the current path
+ mount {target,path} - creates a mount point from {path} to {target} (admin required)
+ umount {path} - removes the mount point at {path} without deleting the directory (admin required)
  info - returns NetrServerInfo main results
  who - returns the sessions currently connected at the target host (admin required)
  close - closes the current SMB Session
@@ -456,4 +458,15 @@ class MiniImpacketShell(cmd.Cmd):
     def do_close(self, line):
         self.do_logoff(line)
 
+    def do_mount(self, line):
+        l = line.split(' ')
+        if len(l) > 1:
+            target  = string.replace(l[0],'/','\\')
+            path    = string.replace(l[1],'/','\\')
 
+        self.smb.createMountPoint(self.tid, path, target)
+
+    def do_umount(self, mountpoint):
+        mountpoint = string.replace(mountpoint,'/','\\')
+
+        self.smb.removeMountPoint(self.tid, mountpoint)

--- a/impacket/smb3structs.py
+++ b/impacket/smb3structs.py
@@ -273,6 +273,7 @@ FSCTL_SRV_COPYCHUNK_WRITE            = 0x001480F2
 FSCTL_LMR_REQUEST_RESILIENCY         = 0x001401D4
 FSCTL_QUERY_NETWORK_INTERFACE_INFO   = 0x001401FC
 FSCTL_SET_REPARSE_POINT              = 0x000900A4
+FSCTL_DELETE_REPARSE_POINT           = 0x000900AC
 FSCTL_DFS_GET_REFERRALS_EX           = 0x000601B0
 FSCTL_FILE_LEVEL_TRIM                = 0x00098208
 FSCTL_VALIDATE_NEGOTIATE_INFO        = 0x00140204
@@ -1188,6 +1189,27 @@ class NETWORK_INTERFACE_INFO(Structure):
         ('Reserved','<L=0'),
         ('LinkSpeed','<Q=0'),
         ('SockAddr_Storage','128s=""'),
+    )
+
+class MOUNT_POINT_REPARSE_DATA_STRUCTURE(Structure):
+    structure = (
+        ("ReparseTag", "<L=0xA0000003"),
+        ("ReparseDataLen", "<H=len(self['PathBuffer']) + 8"),
+        ("Reserved", "<H=0"),
+        ("SubstituteNameOffset", "<H=0"),
+        ("SubstituteNameLength", "<H=0"),
+        ("PrintNameOffset", "<H=0"),
+        ("PrintNameLength", "<H=0"),
+        ("PathBuffer", ":")
+    )
+
+class MOUNT_POINT_REPARSE_GUID_DATA_STRUCTURE(Structure):
+    structure = (
+        ("ReparseTag", "<L=0xA0000003"),
+        ("ReparseDataLen", "<H=len(self['DataBuffer'])"),
+        ("Reserved", "<H=0"),
+        ("ReparseGuid", "16s=''"),
+        ("DataBuffer", ":")
     )
 
 class SMB2Ioctl_Response(Structure):

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -787,6 +787,59 @@ class SMBConnection:
         except (smb.SessionError, smb3.SessionError), e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
 
+    def createMountPoint(self, tid, path, target):
+        """
+        creates a mount point at an existing directory
+
+        :param int tid: tree id of current connection
+        :param string path: directory at which to create mount point (must already exist)
+        :param string target: target address of mount point
+        """
+        fid = self.openFile(tid, path, GENERIC_READ | GENERIC_WRITE,
+                            creationOption=FILE_OPEN_REPARSE_POINT)
+
+        if target.startswith("\\"):
+            fixed_name  = target.encode('utf-16le')
+        else:
+            fixed_name  = ("\\??\\" + target).encode('utf-16le')
+
+        name        = target.encode('utf-16le')
+
+        reparseData = MOUNT_POINT_REPARSE_DATA_STRUCTURE()
+
+        reparseData['PathBuffer']           = fixed_name + "\x00\x00" + name + "\x00\x00"
+        reparseData['SubstituteNameLength'] = len(fixed_name)
+        reparseData['PrintNameOffset']      = len(fixed_name) + 2
+        reparseData['PrintNameLength']      = len(name)
+
+        self._SMBConnection.ioctl(tid, fid, FSCTL_SET_REPARSE_POINT, flags=SMB2_0_IOCTL_IS_FSCTL,
+                                  inputBlob=reparseData)
+
+        self.closeFile(tid, fid)
+
+    def removeMountPoint(self, tid, path):
+        """
+        removes a mount point without deleting the underlying directory
+
+        :param int tid: tree id of current connection
+        :param string path: path to mount point to remove
+        """
+        fid = self.openFile(tid, path, GENERIC_READ | GENERIC_WRITE,
+                            creationOption=FILE_OPEN_REPARSE_POINT)
+
+        reparseData = MOUNT_POINT_REPARSE_GUID_DATA_STRUCTURE()
+
+        reparseData['DataBuffer'] = ""
+
+        try:
+            self._SMBConnection.ioctl(tid, fid, FSCTL_DELETE_REPARSE_POINT, flags=SMB2_0_IOCTL_IS_FSCTL,
+                                      inputBlob=reparseData)
+        except (smb.SessionError, smb3.SessionError), e:
+            self.closeFile(tid, fid)
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+        self.closeFile(tid, fid)
+
     def rename(self, shareName, oldPath, newPath):
         """
         renames a file/directory


### PR DESCRIPTION
Hello,

James Forshaw published some research last month on creating mount points remotely via SMB. You can find that article here:

https://tyranidslair.blogspot.com/2018/12/abusing-mount-points-over-smb-protocol.html

This pull request implements creating and removing mount points remotely by adding the **createMountPoint** and **removeMountPoint** functions and associated structures.

This also adds the commands **mount** and **umount** to smbclient.py. They can be used like:

`# mount C:\Windows abc`

Adds a mount point to **C:\Windows** at the directory **./abc** (Note that the directory must already exist)

`# umount abc`

Remove the mount point from **./abc** (Does not delete the directory itself, just removes the mount point from it).