### PR TITLE
Relayservers ports

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -47,7 +47,7 @@ from impacket.examples.ntlmrelayx.utils.config import NTLMRelayxConfig
 from impacket.examples.ntlmrelayx.utils.targetsutils import TargetsProcessor, TargetsFileWatcher
 from impacket.examples.ntlmrelayx.servers.socksserver import SOCKS
 
-RELAY_SERVERS = ( SMBRelayServer, HTTPRelayServer )
+RELAY_SERVERS = []
 
 class MiniShell(cmd.Cmd):
     def __init__(self, relayConfig, threads):
@@ -205,6 +205,10 @@ if __name__ == '__main__':
     parser.add_argument('-ip','--interface-ip', action='store', metavar='INTERFACE_IP', help='IP address of interface to '
                   'bind SMB and HTTP servers',default='')
 
+    serversoptions = parser.add_mutually_exclusive_group()
+    serversoptions.add_argument('--no-smb-server', action='store_true', help='Disables the SMB server')
+    serversoptions.add_argument('--no-http-server', action='store_true', help='Disables the HTTP server')
+
     parser.add_argument('-ra','--random', action='store_true', help='Randomize target selection (HTTP server only)')
     parser.add_argument('-r', action='store', metavar = 'SMBSERVER', help='Redirect HTTP requests to a file:// path on SMBSERVER')
     parser.add_argument('-l','--lootdir', action='store', type=str, required=False, metavar = 'LOOTDIR',default='.', help='Loot '
@@ -295,8 +299,15 @@ if __name__ == '__main__':
             targetSystem = None
             mode = 'REFLECTION'
 
-    if options.r is not None:
-        logging.info("Running HTTP server in redirect mode")
+    if not options.no_smb_server:
+        RELAY_SERVERS.append(SMBRelayServer)
+    
+    if not options.no_http_server:
+        RELAY_SERVERS.append(HTTPRelayServer)
+
+        if options.r is not None:
+            logging.info("Running HTTP server in redirect mode")
+
 
     if targetSystem is not None and options.w:
         watchthread = TargetsFileWatcher(targetSystem)

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -151,6 +151,11 @@ def start_servers(options, threads):
         c.setInterfaceIp(options.interface_ip)
 
 
+        if server is HTTPRelayServer:
+            c.setListeningPort(options.http_port)
+        elif server is SMBRelayServer:
+            c.setListeningPort(options.smb_port)
+
         #If the redirect option is set, configure the HTTP server to redirect targets to SMB
         if server is HTTPRelayServer and options.r is not None:
             c.setMode('REDIRECT')
@@ -208,6 +213,9 @@ if __name__ == '__main__':
     serversoptions = parser.add_mutually_exclusive_group()
     serversoptions.add_argument('--no-smb-server', action='store_true', help='Disables the SMB server')
     serversoptions.add_argument('--no-http-server', action='store_true', help='Disables the HTTP server')
+
+    parser.add_argument('--smb-port', type=int, help='Port to listen on smb server', default=445)
+    parser.add_argument('--http-port', type=int, help='Port to listen on http server', default=80)
 
     parser.add_argument('-ra','--random', action='store_true', help='Randomize target selection (HTTP server only)')
     parser.add_argument('-r', action='store', metavar = 'SMBSERVER', help='Redirect HTTP requests to a file:// path on SMBSERVER')

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -315,8 +315,14 @@ class HTTPRelayServer(Thread):
 
     def run(self):
         LOG.info("Setting up HTTP Server")
+
+        if self.config.listeningPort:
+            httpport = self.config.listeningPort
+        else:
+            httpport = 80
+
         # changed to read from the interfaceIP set in the configuration
-        self.server = self.HTTPServer((self.config.interfaceIp, 80), self.HTTPHandler, self.config)
+        self.server = self.HTTPServer((self.config.interfaceIp, httpport), self.HTTPHandler, self.config)
 
         try:
              self.server.serve_forever()

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -80,7 +80,12 @@ class SMBRelayServer(Thread):
             SMBSERVER.address_family = socket.AF_INET6
 
         # changed to dereference configuration interfaceIp
-        self.server = SMBSERVER((config.interfaceIp,445), config_parser = smbConfig)
+        if self.config.listeningPort:
+            smbport = self.config.listeningPort
+        else:
+            smbport = 445
+
+        self.server = SMBSERVER((config.interfaceIp,smbport), config_parser = smbConfig)
         logging.getLogger('impacket.smbserver').setLevel(logging.CRITICAL)
 
         self.server.processConfigFile()

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -20,6 +20,8 @@ class NTLMRelayxConfig:
         # Set the value of the interface ip address
         self.interfaceIp = None
 
+        self.listeningPort = None
+
         self.domainIp = None
         self.machineAccount = None
         self.machineHashes = None
@@ -76,6 +78,9 @@ class NTLMRelayxConfig:
 
     def setInterfaceIp(self, ip):
         self.interfaceIp = ip
+    
+    def setListeningPort(self, port):
+        self.listeningPort = port
 
     def setRunSocks(self, socks, server):
         self.runSocks = socks


### PR DESCRIPTION
I added several options in ntlmrelayx.py to improve servers flexibility:
+ --no-smb-server => to avoid using the smb server
+ --no-http-server => to avoid using the http server
+ --smb-port => to set port of smb server (default=445)
+ --http-port => to set port of http server (default=80)

Additionally, I made some changes inside RelayServer classes and NTLMRelayxConfig to be able of introduce those modifications.