### PR TITLE
ntlmrelayx: added option to avoid privileges enumeration on LDAP attack

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -141,7 +141,7 @@ def start_servers(options, threads):
         c.setAttacks(PROTOCOL_ATTACKS)
         c.setLootdir(options.lootdir)
         c.setOutputFile(options.output_file)
-        c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.escalate_user)
+        c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user)
         c.setMSSQLOptions(options.query)
         c.setInteractive(options.interactive)
         c.setIMAPOptions(options.keyword, options.mailbox, options.all, options.imap_max)
@@ -257,6 +257,7 @@ if __name__ == '__main__':
     ldapoptions.add_argument('--no-dump', action='store_false', required=False, help='Do not attempt to dump LDAP information')
     ldapoptions.add_argument('--no-da', action='store_false', required=False, help='Do not attempt to add a Domain Admin')
     ldapoptions.add_argument('--no-acl', action='store_false', required=False, help='Disable ACL attacks')
+    ldapoptions.add_argument('--no-validate-privs', action='store_false', required=False, help='Do not attempt to enumerate privileges, assume permissions are granted to escalate a user via ACL attacks')
     ldapoptions.add_argument('--escalate-user', action='store', required=False, help='Escalate privileges of this user instead of creating a new one')
 
     #IMAP options

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -57,6 +57,7 @@ class NTLMRelayxConfig:
         self.dumpdomain = True
         self.addda = True
         self.aclattack = True
+        self.validateprivs = True
         self.escalateuser = None
 
         # MSSQL options
@@ -124,10 +125,11 @@ class NTLMRelayxConfig:
     def setRandomTargets(self, randomtargets):
         self.randomtargets = randomtargets
 
-    def setLDAPOptions(self, dumpdomain, addda, aclattack, escalateuser):
+    def setLDAPOptions(self, dumpdomain, addda, aclattack, validateprivs, escalateuser):
         self.dumpdomain = dumpdomain
         self.addda = addda
         self.aclattack = aclattack
+        self.validateprivs = validateprivs
         self.escalateuser = escalateuser
 
     def setMSSQLOptions(self, queries):


### PR DESCRIPTION
As this might be noise and slow on certain Domains, it might be handy to have an option to explicitely avoid validating user's privileges and assume the user have it. Note that this only leaves escalating to a user via ACL attacks, as the other methods requires determining the proper containers.