### PR TITLE
smb3: fix the check to not encrypt anonymous connection

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -650,7 +650,7 @@ class SMB3:
                 self._Session['SigningKey']  = crypto.KDF_CounterMode(self._Session['SessionKey'], b"SMB2AESCMAC\x00", b"SmbSign\x00", 128)
 
             # Do not encrypt anonymous connections
-            if user == '':
+            if user == '' or self.isGuestSession():
                 self._Connection['SupportsEncryption'] = False
 
             # Calculate the key derivations for dialect 3.0
@@ -798,7 +798,7 @@ class SMB3:
                     self._Session['SessionID']    = packet['SessionID']
 
                     # Do not encrypt anonymous connections
-                    if user == '':
+                    if user == '' or self.isGuestSession():
                         self._Connection['SupportsEncryption'] = False
 
                     # Calculate the key derivations for dialect 3.0


### PR DESCRIPTION
I had a bug where impacket (latest version 0.9.19) tries to encrypt a SMB3 communication with a server that supports it, but within a guest session. The server then closes the connection.
My debug showed that since I passed credentials, the `user` variable is not empty so the check fails. By adding `self.isGuestSession()`, it properly detects that it is a guest session and disables encryption (then the whole process continues fine).

See this traffic capture before the patch (.210 is the client, .200 is the server):
![image](https://user-images.githubusercontent.com/550823/55487457-68e78b00-562e-11e9-8df8-a3af9a0891c4.png)

Maybe checking `user == ''` is redundant now, but I let you judge as you know the code better than me :)