### PR TITLE
hLsarOpenPolicy2 was being reference (incorrectly) from lsat

### DIFF
--- a/examples/lookupsid.py
+++ b/examples/lookupsid.py
@@ -87,7 +87,7 @@ class LSALookupSid:
 
         dce.bind(lsat.MSRPC_UUID_LSAT)
         
-        resp = lsat.hLsarOpenPolicy2(dce, MAXIMUM_ALLOWED | lsat.POLICY_LOOKUP_NAMES)
+        resp = lsad.hLsarOpenPolicy2(dce, MAXIMUM_ALLOWED | lsat.POLICY_LOOKUP_NAMES)
         policyHandle = resp['PolicyHandle']
 
         if self.__domain_sids: # get the Domain SID


### PR DESCRIPTION
Not sure when that function was moved from lsat to lsad, but it broke the lookupsids script. I've fixed it up here. Tested and works from what I can see.