### PR TITLE
Add STYPE_MASK constant

### DIFF
--- a/impacket/dcerpc/v5/srvs.py
+++ b/impacket/dcerpc/v5/srvs.py
@@ -86,6 +86,9 @@ STYPE_CLUSTER_DFS  = 0x08000000
 STYPE_SPECIAL      = 0x80000000
 STYPE_TEMPORARY    = 0x40000000
 
+# AND with shi_type to extract the Share Type part
+STYPE_MASK         = 0x000000FF
+
 # 2.2.2.5 Client-Side Caching (CSC) States
 CSC_CACHE_MANUAL_REINT = 0x00
 CSC_CACHE_AUTO_REINT   = 0x10


### PR DESCRIPTION
The only interest of this mask constant is to extract the type information of a share, while discarding the `STYPE_SPECIAL` and `STYPE_TEMPORARY` options that can be added through OR

I know that this constant is not declared in [\[MS-SRVS\]](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-srvs/6069f8c0-c93f-43a0-a5b4-7ed447eb4b84)

But it is referenced in [LMShare.h](https://docs.microsoft.com/fr-fr/windows/desktop/api/lmshare/ns-lmshare-_share_info_1)
> One of the following values may be specified. You can isolate these values by using the STYPE_MASK value.

It can also be found re-used in other projects such as [mimikatz](https://github.com/gentilkiwi/mimikatz/blob/110a831ebe7b529c5dd3010f9e7fced0d3e3a46c/modules/kull_m_net.h#L124)

However, I'm wondering if the value "0x0FFFFFFF" wouldn't be more appropriate since now we have more types than `STYPE_DISKTREE, STYPE_PRINTQ, STYPE_DEVICE, STYPE_IPC` (that were coded on 1 octet), like `STYPE_CLUSTER_FS, STYPE_CLUSTER_SOFS and STYPE_CLUSTER_DFS`.
What do you think? :)