### PR TITLE
Fixed broken ldap3 requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ matrix:
 install: pip install flake8 tox -r requirements.txt
   
 before_script:
-  # Verify installed packages have compatible dependencies
-  - pip check
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E9,F72,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
 install: pip install flake8 tox -r requirements.txt
   
 before_script:
+  # Verify installed packages have compatible dependencies
+  - pip check
   # stop the build if there are Python syntax errors or undefined names
   - flake8 . --count --select=E9,F72,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ six
 pyasn1>=0.2.3
 pycryptodomex
 pyOpenSSL>=0.16.2
-ldap3>=2.5
+ldap3==2.5.1
 ldapdomaindump>=0.9.0
 flask>=1.0

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name = PACKAGE_NAME,
                 'impacket.examples.ntlmrelayx.attacks'],
       scripts = glob.glob(os.path.join('examples', '*.py')),
       data_files = data_files,
-      install_requires=['pyasn1>=0.2.3', 'pycryptodomex', 'pyOpenSSL>=0.13.1', 'six', 'ldap3>=2.5.0', 'ldapdomaindump>=0.9.0', 'flask>=1.0'],
+      install_requires=['pyasn1>=0.2.3', 'pycryptodomex', 'pyOpenSSL>=0.13.1', 'six', 'ldap3==2.5.1', 'ldapdomaindump>=0.9.0', 'flask>=1.0'],
       extras_require={
                       'pyreadline:sys_platform=="win32"': [],
                       'python_version<"2.7"': [ 'argparse' ],

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,5 @@ deps=-rrequirements.txt
     py26: wheel==0.29.0
     coverage
 passenv = NO_REMOTE
+commands_pre = {envpython} -m pip check
 commands=./runall.sh {envname} > /dev/null


### PR DESCRIPTION
This should have been fixed with #583 (related issue #582), however for some reason my changes got reverted.
Looking at the [history ](https://github.com/SecureAuthCorp/impacket/commits/master/setup.py)of the setup.py, it appears to be the commits on March, 11th (cafda7b) but for some reason the revert is never shows as a change there. Git blame doesn't show it either, so I take the revert happened by mistake.

Anyway, this should now be resolved again. To be on the safe side and to spot possible dependency issues more easily in the future, I added `pip check` to travis.