### PR TITLE
nmb: add timeout for whole read operation in non_polling_read

### DIFF
--- a/impacket/nmb.py
+++ b/impacket/nmb.py
@@ -967,13 +967,17 @@ class NetBIOSTCPSession(NetBIOSSession):
 
     def non_polling_read(self, read_length, timeout):
         data = b''
+        if timeout is None:
+            timeout = 3600
+
+        start_time = time.time()
         bytes_left = read_length
 
         while bytes_left > 0:
             try:
                 ready, _, _ = select.select([self._sock.fileno()], [], [], timeout)
 
-                if not ready:
+                if not ready or (time.time() - start_time) > timeout:
                     raise NetBIOSTimeout
 
                 received = self._sock.recv(bytes_left)


### PR DESCRIPTION
I have seen a case where impacket was stuck when opening an `SMBConnection` to a server. Using Wireshark I saw that it responded in chunks but very slowly and with a few bytes at a time.
I thought that the `timeout` setting would deal with that but it didn't.

Actually the timeout only applies to `select.select`, so in this case the server responded in the allotted time for each chunk, but the whole read operation would take forever...

With this change, the read operation will timeout with a `NetBIOSTimeout` exception if, either one read is longer than the timeout, or the whole read of all chunks is longer. 

This change is similar to the custom timeout implementation in `polling_read` above.