### PR TITLE
secretsdump unicode support

### DIFF
--- a/impacket/dcerpc/v5/drsuapi.py
+++ b/impacket/dcerpc/v5/drsuapi.py
@@ -613,7 +613,7 @@ class WCHAR_ARRAY(NDRUniConformantArray):
                 # We might have Unicode chars in here, let's use unichr instead
                 LOG.debug('ValueError exception on %s' % self.fields[key])
                 LOG.debug('Switching to unichr()')
-                return ''.join([chr(i) for i in self.fields[key]])
+                return ''.join([unichr(i) for i in self.fields[key]])
 
         else:
             return NDR.__getitem__(self,key)


### PR DESCRIPTION
sorry for submitting against master....

unichr() support

When running secretsdump, if the DN contains unicode chars it supposed to drop down to unichr support

`Decrypting hash for user: CN=ジョン,CN=Users,DC=nihong,DC=superheavy,DC=com`

```
python secretsdump.py -user-status -just-dc -debug nihongo/james@192.168.223.4
Impacket v0.9.20-dev - Copyright 2019 SecureAuth Corporation

Password:
==== SNIP SNIP ====
[+] Calling DRSCrackNames for S-1-5-21-700026053-4189613366-3793654415-1109 
[+] Calling DRSGetNCChanges for {a9ae436d-17e2-4604-99a6-8d0b581401aa} 
[+] Entering NTDSHashes.__decryptHash
[+] ValueError exception on [67, 78, 61, 12459, 12452, 12523, 44, 67, 78, 61, 85, 115, 101, 114, 115, 44, 68, 67, 61, 110, 105, 104, 111, 110, 103, 44, 68, 67, 61, 115, 117, 112, 101, 114, 104, 101, 97, 118, 121, 44, 68, 67, 61, 99, 111, 109, 0]
[+] Switching to unichr()
[-] Error while processing user!
[+] Exception
Traceback (most recent call last):
  File "build/bdist.linux-x86_64/egg/impacket/examples/secretsdump.py", line 2489, in dump
    hashesOutputFile)
  File "build/bdist.linux-x86_64/egg/impacket/examples/secretsdump.py", line 2167, in __decryptHash
    LOG.debug('Decrypting hash for user: %s' % record['pmsgOut'][replyVersion]['pNC']['StringName'][:-1])
  File "build/bdist.linux-x86_64/egg/impacket/dcerpc/v5/ndr.py", line 136, in __getitem__
    return self.fields[key]['Data']
  File "build/bdist.linux-x86_64/egg/impacket/dcerpc/v5/drsuapi.py", line 616, in __getitem__
    return ''.join([chr(i) for i in self.fields[key]])
ValueError: chr() arg not in range(256)
```

but the line where unichr support is supposed to be handled is still returning chr(), when running secretsdump you run into this

```
ebfe@ubuntu:~/tools/post/forked/examples$ python secretsdump.py -user-status -just-dc nihongo/james@192.168.223.4
Impacket v0.9.20-dev - Copyright 2019 SecureAuth Corporation

Password:
[*] Dumping Domain Credentials (domain\uid:rid:lmhash:nthash)
[*] Using the DRSUAPI method to get NTDS.DIT secrets
Administrator:500:aad3b435b51404eeaad3b435b51404ee:64e763d42e37c60e5caf9e9932a97261::: (status=Enabled)
Guest:501:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Disabled)
krbtgt:502:aad3b435b51404eeaad3b435b51404ee:8fe976cd04976c3c73836e3c45a936ff::: (status=Disabled)
DefaultAccount:503:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Disabled)
James:1000:aad3b435b51404eeaad3b435b51404ee:64e763d42e37c60e5caf9e9932a97261::: (status=Enabled)
[-] Error while processing user!
[-] chr() arg not in range(256)
[-] Error while processing user!
[-] chr() arg not in range(256)
[-] Error while processing user!
[-] chr() arg not in range(256)
[-] Error while processing user!
[-] chr() arg not in range(256)
nihong.superheavy.com\user1:1110:aad3b435b51404eeaad3b435b51404ee:62d6a9aa1ea010222c5e9fc49563d6a8::: (status=Enabled)
nihong.superheavy.com\user2:1111:aad3b435b51404eeaad3b435b51404ee:92a751a31f1e409e7d75ddc7d08e070f::: (status=Enabled)
nihong.superheavy.com\user3:1112:aad3b435b51404eeaad3b435b51404ee:4e35090acfe8d4f816a2e651e3a508cc::: (status=Enabled)
nihong.superheavy.com\user4:1113:aad3b435b51404eeaad3b435b51404ee:af4f2653482b07bdeca0b8c03d3bbc43::: (status=Enabled)
nihong.superheavy.com\user5:1114:aad3b435b51404eeaad3b435b51404ee:2bc7840404bfe75d5ee9c09ac7404621::: (status=Enabled)
nihong.superheavy.com\superuser:1115:aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c::: (status=Enabled)
NIHONGO-DC01$:1001:aad3b435b51404eeaad3b435b51404ee:ff334984da423160660bf391e2bc5c62::: (status=Enabled)
SUPERHEAVY$:1104:aad3b435b51404eeaad3b435b51404ee:1ae79e4389b9a8037e6254e062267845::: (status=Enabled)
[*] Kerberos keys grabbed
krbtgt:aes256-cts-hmac-sha1-96:e1c4e071b0a4905f09284d37dc002f482d8cf13359c33d683f49d6859a9f4c1b
krbtgt:aes128-cts-hmac-sha1-96:bddde3b90d3cadb9f467a61693d90c61
krbtgt:des-cbc-md5:c48c25435761ab5b
nihong.superheavy.com\user1:aes256-cts-hmac-sha1-96:b5fbc002bed22abd80cc87d66ee72ccc50e1c71df2ddafce284aafc8732efbd8
nihong.superheavy.com\user1:aes128-cts-hmac-sha1-96:a5deea075adacb72603aac6d08509222
nihong.superheavy.com\user1:des-cbc-md5:ae80d30e0740ad2c
nihong.superheavy.com\user2:aes256-cts-hmac-sha1-96:1b3fc467174aa563d8bad7f8425fd4a4d02455a022456bf55c274c5d7e612ba8
nihong.superheavy.com\user2:aes128-cts-hmac-sha1-96:02731e6809da503a1c29c6b59e15fc3d
nihong.superheavy.com\user2:des-cbc-md5:1ace32fedc2a046b
nihong.superheavy.com\user3:aes256-cts-hmac-sha1-96:312a82a3f3307b303cc7eeb3626f0caa7f52ec8c1fd36b490ccaf215dbbf40db
nihong.superheavy.com\user3:aes128-cts-hmac-sha1-96:19bea714448d092d38ae87994e4a96d5
nihong.superheavy.com\user3:des-cbc-md5:e9f28929baf44040
nihong.superheavy.com\user4:aes256-cts-hmac-sha1-96:130732877a7ce5c366f3c6025e5468fb6e2e557399d976556cbd90d7413e2e57
nihong.superheavy.com\user4:aes128-cts-hmac-sha1-96:65c5ee52e54d49b4c6cf136d2de66bd5
nihong.superheavy.com\user4:des-cbc-md5:861a1ccd3d02c44f
nihong.superheavy.com\user5:aes256-cts-hmac-sha1-96:c3ae2cbaf7641b24a35e637d716c428215799d7b839aeccab4acb2316e481f08
nihong.superheavy.com\user5:aes128-cts-hmac-sha1-96:5645ddd78dc0731cc53321eccc42d834
nihong.superheavy.com\user5:des-cbc-md5:3b02734962850edf
nihong.superheavy.com\superuser:aes256-cts-hmac-sha1-96:76e0b55d5b43aa08c6aeeafc06755c675a36158d981a2da2e04dda783755188d
nihong.superheavy.com\superuser:aes128-cts-hmac-sha1-96:209aee184ce992d2661799a6b23d4d5a
nihong.superheavy.com\superuser:des-cbc-md5:047a0b02b515043d
NIHONGO-DC01$:aes256-cts-hmac-sha1-96:0a909cd2bb2be749df165c2e4e4c08b0869c0bc1be192c3890a64e9b497ed57f
NIHONGO-DC01$:aes128-cts-hmac-sha1-96:acb24c7093156d0e4f53e9c818beb3ae
NIHONGO-DC01$:des-cbc-md5:6b922520fea75423
SUPERHEAVY$:aes256-cts-hmac-sha1-96:4bc9ff2daf8a86fd14621e33ee67414748aa34eb1e2a66f2d4266a62e4b46dcb
SUPERHEAVY$:aes128-cts-hmac-sha1-96:301c3d1fe3cb8de79262541c45d6af77
SUPERHEAVY$:des-cbc-md5:0e048957342aab10
[*] Cleaning up... 
```

AFTER this patch, you get

```
ebfe@ubuntu:~/tools/post/forked/examples$ python secretsdump.py -user-status -just-dc nihongo/james@192.168.223.4
Impacket v0.9.20-dev - Copyright 2019 SecureAuth Corporation

Password:
[*] Dumping Domain Credentials (domain\uid:rid:lmhash:nthash)
[*] Using the DRSUAPI method to get NTDS.DIT secrets
Administrator:500:aad3b435b51404eeaad3b435b51404ee:64e763d42e37c60e5caf9e9932a97261::: (status=Enabled)
Guest:501:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Disabled)
krbtgt:502:aad3b435b51404eeaad3b435b51404ee:8fe976cd04976c3c73836e3c45a936ff::: (status=Disabled)
DefaultAccount:503:aad3b435b51404eeaad3b435b51404ee:31d6cfe0d16ae931b73c59d7e0c089c0::: (status=Disabled)
James:1000:aad3b435b51404eeaad3b435b51404ee:64e763d42e37c60e5caf9e9932a97261::: (status=Enabled)
nihong.superheavy.com\user:1106:aad3b435b51404eeaad3b435b51404ee:62d6a9aa1ea010222c5e9fc49563d6a8::: (status=Enabled)
nihong.superheavy.com\john:1107:aad3b435b51404eeaad3b435b51404ee:92a751a31f1e409e7d75ddc7d08e070f::: (status=Enabled)
nihong.superheavy.com\ben:1108:aad3b435b51404eeaad3b435b51404ee:af4f2653482b07bdeca0b8c03d3bbc43::: (status=Enabled)
nihong.superheavy.com\kyle:1109:aad3b435b51404eeaad3b435b51404ee:2bc7840404bfe75d5ee9c09ac7404621::: (status=Enabled)
nihong.superheavy.com\user1:1110:aad3b435b51404eeaad3b435b51404ee:62d6a9aa1ea010222c5e9fc49563d6a8::: (status=Enabled)
nihong.superheavy.com\user2:1111:aad3b435b51404eeaad3b435b51404ee:92a751a31f1e409e7d75ddc7d08e070f::: (status=Enabled)
nihong.superheavy.com\user3:1112:aad3b435b51404eeaad3b435b51404ee:4e35090acfe8d4f816a2e651e3a508cc::: (status=Enabled)
nihong.superheavy.com\user4:1113:aad3b435b51404eeaad3b435b51404ee:af4f2653482b07bdeca0b8c03d3bbc43::: (status=Enabled)
nihong.superheavy.com\user5:1114:aad3b435b51404eeaad3b435b51404ee:2bc7840404bfe75d5ee9c09ac7404621::: (status=Enabled)
nihong.superheavy.com\superuser:1115:aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c::: (status=Enabled)
NIHONGO-DC01$:1001:aad3b435b51404eeaad3b435b51404ee:ff334984da423160660bf391e2bc5c62::: (status=Enabled)
SUPERHEAVY$:1104:aad3b435b51404eeaad3b435b51404ee:1ae79e4389b9a8037e6254e062267845::: (status=Enabled)
[*] Kerberos keys grabbed
krbtgt:aes256-cts-hmac-sha1-96:e1c4e071b0a4905f09284d37dc002f482d8cf13359c33d683f49d6859a9f4c1b
krbtgt:aes128-cts-hmac-sha1-96:bddde3b90d3cadb9f467a61693d90c61
krbtgt:des-cbc-md5:c48c25435761ab5b
nihong.superheavy.com\user:aes256-cts-hmac-sha1-96:d6f350872706c132a5f6b3d46e24583a4c737fc7a1e6778aec2ba8087bbefd8d
nihong.superheavy.com\user:aes128-cts-hmac-sha1-96:cd7ddc2bc4b25155db7dff9c5deb4241
nihong.superheavy.com\user:des-cbc-md5:ce893d9e51c7926d
nihong.superheavy.com\john:aes256-cts-hmac-sha1-96:3fafba0f323086b9270413038e15f022e6e8cacb3584be5556c531dca6f361a3
nihong.superheavy.com\john:aes128-cts-hmac-sha1-96:93619bbb89727cfab9339acb4b495b4e
nihong.superheavy.com\john:des-cbc-md5:d50ec2643ed59462
nihong.superheavy.com\ben:aes256-cts-hmac-sha1-96:7753c3a6c97e47a4de244c2a28ffd2cf260f0a6ead476674ca3af3b73506ff38
nihong.superheavy.com\ben:aes128-cts-hmac-sha1-96:efecc1efb226151d0fc791802b042d83
nihong.superheavy.com\ben:des-cbc-md5:0ecd4386e6dfc43d
nihong.superheavy.com\kyle:aes256-cts-hmac-sha1-96:5e2efa4b114b5c6f5c240ac10363c578515840d34993be0dce18d5006ca67ace
nihong.superheavy.com\kyle:aes128-cts-hmac-sha1-96:705bdeba686c08e663b26eace3b9f608
nihong.superheavy.com\kyle:des-cbc-md5:ea10b5d9f2643283
nihong.superheavy.com\user1:aes256-cts-hmac-sha1-96:b5fbc002bed22abd80cc87d66ee72ccc50e1c71df2ddafce284aafc8732efbd8
nihong.superheavy.com\user1:aes128-cts-hmac-sha1-96:a5deea075adacb72603aac6d08509222
nihong.superheavy.com\user1:des-cbc-md5:ae80d30e0740ad2c
nihong.superheavy.com\user2:aes256-cts-hmac-sha1-96:1b3fc467174aa563d8bad7f8425fd4a4d02455a022456bf55c274c5d7e612ba8
nihong.superheavy.com\user2:aes128-cts-hmac-sha1-96:02731e6809da503a1c29c6b59e15fc3d
nihong.superheavy.com\user2:des-cbc-md5:1ace32fedc2a046b
nihong.superheavy.com\user3:aes256-cts-hmac-sha1-96:312a82a3f3307b303cc7eeb3626f0caa7f52ec8c1fd36b490ccaf215dbbf40db
nihong.superheavy.com\user3:aes128-cts-hmac-sha1-96:19bea714448d092d38ae87994e4a96d5
nihong.superheavy.com\user3:des-cbc-md5:e9f28929baf44040
nihong.superheavy.com\user4:aes256-cts-hmac-sha1-96:130732877a7ce5c366f3c6025e5468fb6e2e557399d976556cbd90d7413e2e57
nihong.superheavy.com\user4:aes128-cts-hmac-sha1-96:65c5ee52e54d49b4c6cf136d2de66bd5
nihong.superheavy.com\user4:des-cbc-md5:861a1ccd3d02c44f
nihong.superheavy.com\user5:aes256-cts-hmac-sha1-96:c3ae2cbaf7641b24a35e637d716c428215799d7b839aeccab4acb2316e481f08
nihong.superheavy.com\user5:aes128-cts-hmac-sha1-96:5645ddd78dc0731cc53321eccc42d834
nihong.superheavy.com\user5:des-cbc-md5:3b02734962850edf
nihong.superheavy.com\superuser:aes256-cts-hmac-sha1-96:76e0b55d5b43aa08c6aeeafc06755c675a36158d981a2da2e04dda783755188d
nihong.superheavy.com\superuser:aes128-cts-hmac-sha1-96:209aee184ce992d2661799a6b23d4d5a
nihong.superheavy.com\superuser:des-cbc-md5:047a0b02b515043d
NIHONGO-DC01$:aes256-cts-hmac-sha1-96:0a909cd2bb2be749df165c2e4e4c08b0869c0bc1be192c3890a64e9b497ed57f
NIHONGO-DC01$:aes128-cts-hmac-sha1-96:acb24c7093156d0e4f53e9c818beb3ae
NIHONGO-DC01$:des-cbc-md5:6b922520fea75423
SUPERHEAVY$:aes256-cts-hmac-sha1-96:4bc9ff2daf8a86fd14621e33ee67414748aa34eb1e2a66f2d4266a62e4b46dcb
SUPERHEAVY$:aes128-cts-hmac-sha1-96:301c3d1fe3cb8de79262541c45d6af77
SUPERHEAVY$:des-cbc-md5:0e048957342aab10
[*] Cleaning up... 
```

where the signon name is properly displayed now.

userName.dump() returns

```
pdwOutVersion:                   6 
pmsgOut:                        
    tag:                             6 
    V6:                             
        uuidDsaObjSrc:                   'g\x1d\xa3WJ\xd9\x12D\x8f~\xf1=\xccw\xb9\xed' 
        uuidInvocIdSrc:                  '\xd9\xdf\xaf(\x0et?I\xb8\xcb\xdf&\xf1\xf2\xb9<' 
        pNC:                            
            structLen:                       152 
            SidLen:                          28 
            Guid:                            '\xc6\xa80\x83y\xb2^E\x98\xe7\xb2\x8b\xe8\xad1\xab' 
            Sid:                             '\x01\x05\x00\x00\x00\x00\x00\x05\x15\x00\x00\x00\xc5\x8c\xb9)6m\xb8\xf9\x8f\x92\x1e\xe2R\x04\x00\x00' 
            NameLen:                         47 
            StringName:                     [-] chr() arg not in range(256)
```

which should now be returned properly after unichr() vs chr()

there is a similar issue found [https://github.com/SecureAuthCorp/impacket/issues/632](url) not sure if this will fix that issue or not as I did not test that.