### PR TITLE
Adjust 5257b9d changes to dtypes.STR to work in Python 2 & 3

### DIFF
--- a/impacket/dcerpc/v5/dtypes.py
+++ b/impacket/dcerpc/v5/dtypes.py
@@ -12,6 +12,7 @@
 from __future__ import division
 from __future__ import print_function
 from struct import pack
+from six import binary_type
 
 from impacket.dcerpc.v5.ndr import NDRULONG, NDRUHYPER, NDRSHORT, NDRLONG, NDRPOINTER, NDRUniConformantArray, \
     NDRUniFixedArray, NDR, NDRHYPER, NDRSMALL, NDRPOINTERNULL, NDRSTRUCT, \
@@ -105,9 +106,10 @@ class STR(NDRSTRUCT):
     def __setitem__(self, key, value):
         if key == 'Data':
             try:
-                if not isinstance(value, bytes):
+                if not isinstance(value, binary_type):
                     self.fields[key] = value.encode('utf-8')
                 else:
+                    # if it is a binary type (str in Python 2, bytes in Python 3), then we assume it is a raw buffer
                     self.fields[key] = value
             except UnicodeDecodeError:
                 import sys
@@ -120,7 +122,11 @@ class STR(NDRSTRUCT):
 
     def __getitem__(self, key):
         if key == 'Data':
-            return self.fields[key].decode('utf-8')
+            try:
+                return self.fields[key].decode('utf-8')
+            except UnicodeDecodeError:
+                # if we could't decode it, we assume it is a raw buffer
+                return self.fields[key]
         else:
             return NDR.__getitem__(self,key)
 


### PR DESCRIPTION
Using `six.binary_type` to make 5257b9d changes to `dtypes.STR.__setitem__()` work in both _Python 2 & 3_. Also handling raw buffers in `dtypes.STR.__getitem__()`.