### PR TITLE
Do not overwrite default values with 0

### DIFF
--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -812,9 +812,7 @@ class INSTANCE_TYPE(Structure):
             # if itemValue == 0, default value remains
             if itemValue != 0:
                 value = ENCODED_VALUE.getValue( properties[key]['type'], itemValue, heap)
-            else:
-                value = 0
-            properties[key]['value'] = value
+                properties[key]['value'] = value
             valueTable = valueTable[dataSize:] 
         return properties
 


### PR DESCRIPTION
I have noticed that wmi queries that return an embedded object impacket will overwrite the actual values with 0.  "SELECT PRIVATEPROPERTIES FROM MSCluster_Resource" is an example where this occurs. 

The getValues method has been updated to behave as the comment implies leaving the initial value set to the field as part of the getProperties call and only overwriting when itemValue is not equal to 0.

