### PR TITLE
Added NTLM relays leveraging Webdav authentications

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -154,7 +154,7 @@ def start_servers(options, threads):
         c.setSMB2Support(options.smb2support)
         c.setInterfaceIp(options.interface_ip)
         c.setExploitOptions(options.remove_mic, options.remove_target)
-
+        c.setWebDAVOptions(options.serve_image)
 
         if server is HTTPRelayServer:
             c.setListeningPort(options.http_port)
@@ -243,6 +243,7 @@ if __name__ == '__main__':
                                                                    'before serving a WPAD file.')
     parser.add_argument('-6','--ipv6', action='store_true',help='Listen on both IPv6 and IPv4')
     parser.add_argument('--remove-mic', action='store_true',help='Remove MIC (exploit CVE-2019-1040)')
+    parser.add_argument('--serve-image', action='store',help='local path of the image that will we returned to clients')
 
     #SMB arguments
     smboptions = parser.add_argument_group("SMB client options")

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -74,6 +74,9 @@ class NTLMRelayxConfig:
         # HTTP options
         self.remove_target = False
 
+        # WebDAV options
+        self.serve_image = False
+
     def setSMB2Support(self, value):
         self.smb2support = value
 
@@ -166,3 +169,6 @@ class NTLMRelayxConfig:
     def setExploitOptions(self, remove_mic, remove_target):
         self.remove_mic = remove_mic
         self.remove_target = remove_target
+
+    def setWebDAVOptions(self, serve_image):
+        self.serve_image = serve_image


### PR DESCRIPTION
Added a new flag (--serve-image) to ntlmrealyx.py to allow NTLM relays leveraging WebDAV authentications. Useful for attacks like "Case Study 2: Windows 10/2016/2019 LPE" explained in the post "Wagging the Dog" from Elad Shamir: 
•  https://shenaniganslabs.io/2019/01/28/Wagging-the-Dog.html

PS: this new flag in conjunction with the tool "change-lockscreen" that we will release soon allows to perform this attack without having GUI access on the victim

Thanks to 3xocyte, elad shamir and dirkjanm for their previous work.

Authors: Simone Salucci & Daniel López Jiménez (NCC Group)
