### PR TITLE
Travis CI: Xenial is now Travis' default distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install: pip install flake8 tox -r requirements.txt
   
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+  - flake8 . --count --select=E9,F7,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --ignore=E1,E2,E3,E501,W291,W293 --exit-zero --max-complexity=65 --max-line-length=127 --statistics
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,12 @@ matrix:
       env: NO_REMOTE=true, TOXENV=py36
     - python: 3.7
       env: NO_REMOTE=true, TOXENV=py37
-      dist: xenial  # required for Python >= 3.7
 
 install: pip install flake8 tox -r requirements.txt
   
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E9,F72,F82 --show-source --statistics
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --ignore=E1,E2,E3,E501,W291,W293 --exit-zero --max-complexity=65 --max-line-length=127 --statistics
 


### PR DESCRIPTION
Also add more flake8 tests.

__flake8 --select=F63__, Use ==/!= to compare str, bytes, and int literals because identity is not the same thing as equality in Python. These instances will raise __SyntaxWarnings__ on Python >= 3.8. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8