### PR TITLE
Add support for all info types query\set info request

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1310,7 +1310,7 @@ class SMB3:
 
         queryInfo = SMB2QueryInfo()
         queryInfo['FileID']                = fileId
-        queryInfo['InfoType']              = SMB2_0_INFO_FILE 
+        queryInfo['InfoType']              = infoType 
         queryInfo['FileInfoClass']         = fileInfoClass 
         queryInfo['OutputBufferLength']    = 65535
         queryInfo['AdditionalInformation'] = additionalInformation
@@ -1341,7 +1341,7 @@ class SMB3:
         packet['TreeID']  = treeId
 
         setInfo = SMB2SetInfo()
-        setInfo['InfoType']              = SMB2_0_INFO_FILE 
+        setInfo['InfoType']              = infoType 
         setInfo['FileInfoClass']         = fileInfoClass 
         setInfo['BufferLength']          = len(inputBlob)
         setInfo['AdditionalInformation'] = additionalInformation


### PR DESCRIPTION
Hi,

in SMB2QueryInfo the infoType field was statically set to SMB2_0_INFO_FILE. In order to query security descriptor and more, I change it to use the actual infoType parameter passed to the function.