### PR TITLE
Add FSCTL_SRV_ENUMERATE_SNAPSHOTS functionality

### DIFF
--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -113,6 +113,7 @@ class MiniImpacketShell(cmd.Cmd):
  get {filename} - downloads the filename from the current path
  mount {target,path} - creates a mount point from {path} to {target} (admin required)
  umount {path} - removes the mount point at {path} without deleting the directory (admin required)
+ list_snapshots {path} - lists the vss snapshots for the specified path
  info - returns NetrServerInfo main results
  who - returns the sessions currently connected at the target host (admin required)
  close - closes the current SMB Session
@@ -461,6 +462,17 @@ class MiniImpacketShell(cmd.Cmd):
 
     def do_close(self, line):
         self.do_logoff(line)
+
+    def do_list_snapshots(self, line):
+        l = line.split(' ')
+        if len(l) > 0:
+            pathName= l[0].replace('/','\\')
+
+        # Relative or absolute path?
+        if pathName.startswith('\\') is not True:
+            pathName = ntpath.join(self.pwd, pathName)
+
+        self.smb.listSnapshots(self.tid, pathName)
 
     def do_mount(self, line):
         l = line.split(' ')

--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -472,7 +472,14 @@ class MiniImpacketShell(cmd.Cmd):
         if pathName.startswith('\\') is not True:
             pathName = ntpath.join(self.pwd, pathName)
 
-        self.smb.listSnapshots(self.tid, pathName)
+        snapshotList = self.smb.listSnapshots(self.tid, pathName)
+
+        if not snapshotList:
+            print("No snapshots found")
+            return
+
+        for timestamp in snapshotList:
+            print(timestamp)
 
     def do_mount(self, line):
         l = line.split(' ')

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -1569,6 +1569,13 @@ class SMB3:
         return True
 
     def retrieveFile(self, shareName, path, callback, mode = FILE_OPEN, offset = 0, password = None, shareAccessMode = FILE_SHARE_READ):
+        createContexts = None
+
+        if self.isSnapshotRequest(path):
+            createContexts = []
+            path, ctx = self.timestampForSnapshot(path)
+            createContexts.append(ctx)
+
         # ToDo: Handle situations where share is password protected
         path = path.replace('/', '\\')
         path = ntpath.normpath(path)
@@ -1579,7 +1586,7 @@ class SMB3:
         fileId = None
         from impacket import smb
         try:
-            fileId = self.create(treeId, path, FILE_READ_DATA, shareAccessMode, FILE_NON_DIRECTORY_FILE, mode, 0)
+            fileId = self.create(treeId, path, FILE_READ_DATA, shareAccessMode, FILE_NON_DIRECTORY_FILE, mode, 0, createContexts=createContexts)
             res = self.queryInfo(treeId, fileId)
             fileInfo = smb.SMBQueryFileStandardInfo(res)
             fileSize = fileInfo['EndOfFile']

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -963,17 +963,17 @@ class SMB3:
        
         smb2Create['NameLength']           = len(fileName)*2
         if fileName != '':
-            smb2Create['Buffer']               = fileName.encode('utf-16le')
+            smb2Create['Buffer']           = fileName.encode('utf-16le')
         else:
-            smb2Create['Buffer']               = '\x00'
+            smb2Create['Buffer']           = b'\x00'
 
         if createContexts is not None:
-            contextsBuf = ''.join(x.getData() for x in createContexts)
+            contextsBuf = b''.join(x.getData() for x in createContexts)
             smb2Create['CreateContextsOffset'] = len(SMB2Packet()) + SMB2Create.SIZE + len(smb2Create['Buffer'])
 
             # pad offset to 8-byte align
             if (smb2Create['CreateContextsOffset'] % 8):
-                smb2Create['Buffer'] += '\x00'*(8-(smb2Create['CreateContextsOffset'] % 8))
+                smb2Create['Buffer'] += b'\x00'*(8-(smb2Create['CreateContextsOffset'] % 8))
                 smb2Create['CreateContextsOffset'] = len(SMB2Packet()) + SMB2Create.SIZE + len(smb2Create['Buffer'])
 
             smb2Create['CreateContextsLength'] = len(contextsBuf)
@@ -1438,8 +1438,8 @@ class SMB3:
         ctx['NameLength'] = len('TWrp')
         ctx['DataOffset'] = 24
         ctx['DataLength'] = 8
-        ctx['Buffer'] = 'TWrp'
-        ctx['Buffer'] += '\x00'*4 # 4 bytes to 8-byte align
+        ctx['Buffer'] = b'TWrp'
+        ctx['Buffer'] += b'\x00'*4 # 4 bytes to 8-byte align
         ctx['Buffer'] += token.getData()
 
         # fix-up the path

--- a/impacket/smb3structs.py
+++ b/impacket/smb3structs.py
@@ -787,7 +787,7 @@ class SMB2_CREATE_ALLOCATION_SIZE(Structure):
 
 class SMB2_CREATE_TIMEWARP_TOKEN(Structure):
     structure = (
-        ('AllocationSize','<Q=0'),
+        ('Timestamp','<Q=0'),
     )
 
 class SMB2_CREATE_REQUEST_LEASE(Structure):

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -850,7 +850,7 @@ class SMBConnection:
                raise SessionError(e.get_error_code(), e.get_error_packet())
 
         self.closeFile(tid, fid)
-        return filter(None, snapshotData['SnapShots'].decode('utf16').split('\x00'))
+        return list(filter(None, snapshotData['SnapShots'].decode('utf16').split('\x00')))
 
     def createMountPoint(self, tid, path, target):
         """

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -843,17 +843,14 @@ class SMBConnection:
         if snapshotData['SnapShotArraySize'] >= 52:
             # now send an appropriate sized buffer
             try:
-               snapshotData2 = SRV_SNAPSHOT_ARRAY(self._SMBConnection.ioctl(tid, fid, FSCTL_SRV_ENUMERATE_SNAPSHOTS,
+               snapshotData = SRV_SNAPSHOT_ARRAY(self._SMBConnection.ioctl(tid, fid, FSCTL_SRV_ENUMERATE_SNAPSHOTS,
                                   flags=SMB2_0_IOCTL_IS_FSCTL, maxOutputResponse=snapshotData['SnapShotArraySize']+12))
             except (smb.SessionError, smb3.SessionError) as e:
                self.closeFile(tid, fid)
                raise SessionError(e.get_error_code(), e.get_error_packet())
 
-            for label in snapshotData2['SnapShots'].decode('utf16').split('\x00'):
-                print(label)
-        else:
-            print("No snapshots found")
         self.closeFile(tid, fid)
+        return filter(None, snapshotData['SnapShots'].decode('utf16').split('\x00'))
 
     def createMountPoint(self, tid, path, target):
         """

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -21,7 +21,8 @@ from impacket.smb3structs import SMB2Packet, SMB2_DIALECT_002, SMB2_DIALECT_21, 
     FILE_SHARE_WRITE, FILE_SHARE_DELETE, FILE_NON_DIRECTORY_FILE, FILE_OVERWRITE_IF, FILE_ATTRIBUTE_NORMAL, \
     SMB2_IL_IMPERSONATION, SMB2_OPLOCK_LEVEL_NONE, FILE_READ_DATA , FILE_WRITE_DATA, FILE_OPEN, GENERIC_READ, GENERIC_WRITE, \
     FILE_OPEN_REPARSE_POINT, MOUNT_POINT_REPARSE_DATA_STRUCTURE, FSCTL_SET_REPARSE_POINT, SMB2_0_IOCTL_IS_FSCTL, \
-    MOUNT_POINT_REPARSE_GUID_DATA_STRUCTURE, FSCTL_DELETE_REPARSE_POINT
+    MOUNT_POINT_REPARSE_GUID_DATA_STRUCTURE, FSCTL_DELETE_REPARSE_POINT, FSCTL_SRV_ENUMERATE_SNAPSHOTS, SRV_SNAPSHOT_ARRAY, \
+    FILE_SYNCHRONOUS_IO_NONALERT, FILE_READ_EA, FILE_READ_ATTRIBUTES, READ_CONTROL, SYNCHRONIZE
 
 
 # So the user doesn't need to import smb, the smb3 are already in here
@@ -814,6 +815,45 @@ class SMBConnection:
                 return self._SMBConnection.stor_file(shareName, pathName, callback, shareAccessMode)
         except (smb.SessionError, smb3.SessionError) as e:
             raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def listSnapshots(self, tid, path):
+        """
+        lists the snapshots for the given directory
+
+        :param int tid: tree id of current connection
+        :param string path: directory to list the snapshots of
+        """
+
+        # Verify we're under SMB2+ session
+        if self.getDialect() not in [SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30]:
+            raise SessionError(error = nt_errors.STATUS_NOT_SUPPORTED)
+
+        fid = self.openFile(tid, path, FILE_READ_DATA | FILE_READ_EA | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE,
+                            fileAttributes=None, creationOption=FILE_SYNCHRONOUS_IO_NONALERT,
+                            shareMode=FILE_SHARE_READ | FILE_SHARE_WRITE)
+
+        # first send with maxOutputResponse=16 to get the required size
+        try:
+            snapshotData = SRV_SNAPSHOT_ARRAY(self._SMBConnection.ioctl(tid, fid, FSCTL_SRV_ENUMERATE_SNAPSHOTS,
+                                  flags=SMB2_0_IOCTL_IS_FSCTL, maxOutputResponse=16))
+        except (smb.SessionError, smb3.SessionError) as e:
+            self.closeFile(tid, fid)
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+        if snapshotData['SnapShotArraySize'] >= 52:
+            # now send an appropriate sized buffer
+            try:
+               snapshotData2 = SRV_SNAPSHOT_ARRAY(self._SMBConnection.ioctl(tid, fid, FSCTL_SRV_ENUMERATE_SNAPSHOTS,
+                                  flags=SMB2_0_IOCTL_IS_FSCTL, maxOutputResponse=snapshotData['SnapShotArraySize']+12))
+            except (smb.SessionError, smb3.SessionError) as e:
+               self.closeFile(tid, fid)
+               raise SessionError(e.get_error_code(), e.get_error_packet())
+
+            for label in snapshotData2['SnapShots'].decode('utf16').split('\x00'):
+                print(label)
+        else:
+            print("No snapshots found")
+        self.closeFile(tid, fid)
 
     def createMountPoint(self, tid, path, target):
         """


### PR DESCRIPTION
Adds functionality for `FSCTL_SRV_ENUMERATE_SNAPSHOTS `to `smbconnection.py` and `examples/smbclient.py`. This allows the user to list the VSS snapshots for a given path/file and then download the file using a UNC path of: `\\server\path\@GMT-2019.09.27-14.39.44\file.txt`, for example. This can be used to extend secretsdump, by dumping the NTDS/SAM over pure SMB. If a snapshot doesn't exist, you can still create one using WMI without calling any Process Create/Exec type calls.