### PR TITLE
Support w/wo FQDN when using ticketer.py and all impacket tools

### DIFF
--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -355,8 +355,11 @@ class CCache:
 
     def getCredential(self, server, anySPN=True):
         for c in self.credentials:
-            if c['server'].prettyPrint().upper() == b(server.upper()) or c['server'].prettyPrint().upper().split(b'@')[0] == b(server.upper())\
-                    or c['server'].prettyPrint().upper().split(b'@')[0] == b(server.upper().split('@')[0]):
+            if c['server'].prettyPrint().upper() == b(server.upper())\
+                    or c['server'].prettyPrint().upper().split(b'@')[0] == b(server.upper())\
+                    or c['server'].prettyPrint().upper().split(b'@')[0] == b(server.upper().split('@')[0])\
+                    or c['server'].prettyPrint().upper().split(b'@')[0] == b(server.upper().split('@')[0] + "." + server.upper().split('@')[1])\
+                    or c['server'].prettyPrint().upper().split(b'@')[0] + "." + c['server'].prettyPrint().upper().split(b'@')[1] == server.upper().split('@')[0]:
                 LOG.debug('Returning cached credential for %s' % c['server'].prettyPrint().upper())
                 return c
         LOG.debug('SPN %s not found in cache' % server.upper())


### PR DESCRIPTION
Hello there !

**Context**
Using ticketer with or without FQDN in SPN field creates a ccache file.

```bash
ticketer.py -nthash <hash> -domain-sid S-1-5-21-123-123-123 -domain adsec.local -spn CIFS/HOSTNAME.ADSEC.LOCAL pixis
export KRB5CCNAME='pixis.ccache'
```
**Expected Behavior**
Using any impacket tool with `-k` option should work with or without FQDN.

```bash
# ticketer.py using FQDN in SPN
smbclient.py -k HOSTNAME
Impacket v0.9.21-dev - Copyright 2019 SecureAuth Corporation

Type help for list of commands
# 
```

```bash
# ticketer.py without using FQDN in SPN
smbclient.py -k HOSTNAME.ADSEC.LOCAL
Impacket v0.9.21-dev - Copyright 2019 SecureAuth Corporation

Type help for list of commands
# 
```

**Actual Behavior**
When using FQDN in ticketer but not in impacket tools (or vice-versa), the ccache file is not considered OK for the requested SPN.
```
smbclient.py -k HOSTNAME -debug
Impacket v0.9.21-dev - Copyright 2019 SecureAuth Corporation

[+] Using Kerberos Cache: pixis.ccache
[+] Domain retrieved from CCache: ADSEC.LOCAL
[+] SPN CIFS/HOSTNAME@ADSEC.LOCAL not found in cache
[+] AnySPN is True, looking for another suitable SPN
[+] SPN KRBTGT/ADSEC.LOCAL@ADSEC.LOCAL not found in cache
[+] AnySPN is True, looking for another suitable SPN
[+] No valid credentials found in cache. 
[+] Username retrieved from CCache: pixis
[+] Trying to connect to KDC at ADSEC.LOCAL
[+] Trying to connect to KDC at ADSEC.LOCAL
Traceback (most recent call last):
  File "smbclient.py", line 101, in main
    smbClient.kerberosLogin(username, password, domain, lmhash, nthash, options.aesKey, options.dc_ip )
  File "build/bdist.linux-x86_64/egg/impacket/smbconnection.py", line 358, in kerberosLogin
    raise e
KerberosError: Kerberos SessionError: KDC_ERR_PREAUTH_FAILED(Pre-authentication information was invalid)
[-] Kerberos SessionError: KDC_ERR_PREAUTH_FAILED(Pre-authentication information was invalid)
```

**Proposed fix**
This fix is not ideal, but it works. It adds two tests to check if the provided ccache file has the appropriate SPN. It appends domain name to either the ccache SPN or the targeted SPN. If one of them wasn't provided in an FQDN manner.