### PR TITLE
Correct the values of NETSETUP_JOIN_STATUS enum

### DIFF
--- a/impacket/dcerpc/v5/wkst.py
+++ b/impacket/dcerpc/v5/wkst.py
@@ -127,10 +127,10 @@ class LPWKSSVC_IMPERSONATE_HANDLE(NDRPOINTER):
 # 2.2.3.1 NETSETUP_JOIN_STATUS
 class NETSETUP_JOIN_STATUS(NDRENUM):
     class enumItems(Enum):
-        NetSetupUnknownStatus = 1
-        NetSetupUnjoined      = 2
-        NetSetupWorkgroupName = 3
-        NetSetupDomainName    = 4
+        NetSetupUnknownStatus = 0
+        NetSetupUnjoined      = 1
+        NetSetupWorkgroupName = 2
+        NetSetupDomainName    = 3
 
 # 2.2.3.2 NETSETUP_NAME_TYPE
 class NETSETUP_NAME_TYPE(NDRENUM):


### PR DESCRIPTION
Following the specification [2.2.3.1 NETSETUP_JOIN_STATUS](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wkst/64c07967-1eb9-4021-a9a9-fe9995c906e1) from Microsoft, I corrected the values of class `NETSETUP_JOIN_STATUS` in the file `impacket/dcerpc/v5/wkst.py`.