### PR TITLE
Change the way getting errno from Exception object [Python3 compatible]

### DIFF
--- a/impacket/nmb.py
+++ b/impacket/nmb.py
@@ -556,8 +556,8 @@ class NetBIOS:
                             raise NetBIOSError('Negative response', ERRCLASS_QUERY, res['FLAGS'] & 0xf)
                         return res
             except select.error as ex:
-                if ex[0] != errno.EINTR and ex[0] != errno.EAGAIN:
-                    raise NetBIOSError('Error occurs while waiting for response', ERRCLASS_OS, ex[0])
+                if ex.errno != errno.EINTR and ex.errno != errno.EAGAIN:
+                    raise NetBIOSError('Error occurs while waiting for response', ERRCLASS_OS, ex.errno)
             except socket.error as ex:
                 raise NetBIOSError('Connection error: %s' % str(ex))
 
@@ -960,8 +960,8 @@ class NetBIOSTCPSession(NetBIOSSession):
                 data = data + received
                 bytes_left = read_length - len(data)
             except select.error as ex:
-                if ex[0] != errno.EINTR and ex[0] != errno.EAGAIN:
-                    raise NetBIOSError('Error occurs while reading from remote', ERRCLASS_OS, ex[0])
+                if ex.errno != errno.EINTR and ex.errno != errno.EAGAIN:
+                    raise NetBIOSError('Error occurs while reading from remote', ERRCLASS_OS, ex.errno)
 
         return bytes(data)
 
@@ -987,8 +987,8 @@ class NetBIOSTCPSession(NetBIOSSession):
                 data = data + received
                 bytes_left = read_length - len(data)
             except select.error as ex:
-                if ex[0] != errno.EINTR and ex[0] != errno.EAGAIN:
-                    raise NetBIOSError('Error occurs while reading from remote', ERRCLASS_OS, ex[0])
+                if ex.errno != errno.EINTR and ex.errno != errno.EAGAIN:
+                    raise NetBIOSError('Error occurs while reading from remote', ERRCLASS_OS, ex.errno)
 
         return bytes(data)
 

--- a/tests/SMB_RPC/test_smb.py
+++ b/tests/SMB_RPC/test_smb.py
@@ -269,7 +269,7 @@ class SMBTests(unittest.TestCase):
         try:
             select.select([s], [], [], 0)
         except socket.error as e:
-            if e[0] == errno.EBADF:
+            if e.errno == errno.EBADF:
                 is_socket_opened = False
         except ValueError:
             is_socket_opened = False


### PR DESCRIPTION
I change the way getting `errno` from `Exception` object to make Python 3 compatible.

For detail, in file `impacket\nmb.py`, line **558**, **962** and **989**:
```py
except select.error as ex:
    if ex[0] != errno.EINTR and ex[0] != errno.EAGAIN:
        raise NetBIOSError('Error occurs while reading from remote', ERRCLASS_OS, ex[0])
```

In Python 3, using `exe[0]` wil throw `TypeError: ConnectionAbortedError object is not subscriptable`.

I changed `ex[0]` to `ex.errno` to make both Python 3 and Python 2.7 compatible.


Use following script to reproduce the error:
```py
import logging
import traceback
from impacket.dcerpc.v5 import srvs
from impacket.dcerpc.v5.transport import SMBTransport
from impacket.nmb import NetBIOSError
from impacket.smbconnection import SMBConnection, SessionError


def example():
    try:
        ip_addr = "192.168.71.100"
        smb_conn = SMBConnection(ip_addr, ip_addr)
    except (NetBIOSError, SessionError) as e:
        logging.error(e)
        return
    for i in range(2):
        try:
            rpc_transport = SMBTransport(
                smb_conn.getRemoteName(), smb_conn.getRemoteHost(), filename='\\srvsvc', smb_connection=smb_conn)
            dce = rpc_transport.get_dce_rpc()
            dce.connect()
            dce.bind(srvs.MSRPC_UUID_SRVS)
        except (NetBIOSError, SessionError) as e:
            logging.error(e)
        except:
            traceback.print_exc()

if __name__ == '__main__':
    example()
```
