### PR TITLE
Check if the type of the 'data' variable is already "bytes"

### DIFF
--- a/impacket/structure.py
+++ b/impacket/structure.py
@@ -242,6 +242,8 @@ class Structure:
 
         # asciiz specifier
         if format[:1] == 'z':
+            if isinstance(data,bytes):
+                return data + b('\0')
             return bytes(b(data)+b('\0'))
 
         # unicode specifier


### PR DESCRIPTION
If `data` is already a bytes, then we cannot convert it to bytes again. This PR check if the the variable is not already a bytes.

This PR should fix issue #691