### PR TITLE
Adding Python 3.8 compatibility

### DIFF
--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -226,7 +226,7 @@ if __name__ == '__main__':
         password = password + '@' + address.rpartition('@')[0]
         address = address.rpartition('@')[2]
 
-    if domain is '':
+    if domain == '':
         logging.critical('Domain should be specified!')
         sys.exit(1)
 

--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -410,7 +410,7 @@ if __name__ == '__main__':
         password = password + '@' + address.rpartition('@')[0]
         address = address.rpartition('@')[2]
 
-    if domain is '':
+    if domain == '':
         logging.critical('Domain should be specified!')
         sys.exit(1)
 

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -435,7 +435,7 @@ if __name__ == '__main__':
         password = password + '@' + address.rpartition('@')[0]
         address = address.rpartition('@')[2]
 
-    if userDomain is '':
+    if userDomain == '':
         logging.critical('userDomain should be specified!')
         sys.exit(1)
 

--- a/examples/addcomputer.py
+++ b/examples/addcomputer.py
@@ -620,7 +620,7 @@ if __name__ == '__main__':
         '')
 
     try:
-        if domain is None or domain is '':
+        if domain is None or domain == '':
             logging.critical('Domain should be specified!')
             sys.exit(1)
 

--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -936,7 +936,7 @@ class MS14_068:
                         # Windows XP). So, if that's the case we'll force using RC4 by converting
                         # the password to lm/nt hashes and hope for the best. If that's already
                         # done, byebye.
-                        if self.__lmhash is '' and self.__nthash is '':
+                        if self.__lmhash == '' and self.__nthash == '':
                             from impacket.ntlm import compute_lmhash, compute_nthash
                             self.__lmhash = compute_lmhash(self.__password)
                             self.__nthash = compute_nthash(self.__password)
@@ -991,7 +991,7 @@ class MS14_068:
                         # Windows XP). So, if that's the case we'll force using RC4 by converting
                         # the password to lm/nt hashes and hope for the best. If that's already
                         # done, byebye.
-                        if self.__lmhash is '' and self.__nthash is '':
+                        if self.__lmhash == '' and self.__nthash == '':
                             from impacket.ntlm import compute_lmhash, compute_nthash
                             self.__lmhash = compute_lmhash(self.__password)
                             self.__nthash = compute_nthash(self.__password)
@@ -1116,7 +1116,7 @@ if __name__ == '__main__':
         password = password + '@' + address.rpartition('@')[0]
         address = address.rpartition('@')[2]
 
-    if domain is '':
+    if domain == '':
         logging.critical('Domain should be specified!')
         sys.exit(1)
 

--- a/examples/ntfs-read.py
+++ b/examples/ntfs-read.py
@@ -497,7 +497,7 @@ class AttributeNonResident(Attribute):
         if offset % self.ClusterSize:
             # Read the whole VCN
             bufTemp = self.readVCN(vcnToStart, 1)
-            if bufTemp is b'':
+            if bufTemp == b'':
                 # Something went wrong
                 return None
             buf = bufTemp[offset % self.ClusterSize:]
@@ -513,7 +513,7 @@ class AttributeNonResident(Attribute):
         if curLength // self.ClusterSize:
             # Yep.. so let's read full clusters
             bufTemp = self.readVCN(vcnToStart, curLength // self.ClusterSize)
-            if bufTemp is b'':
+            if bufTemp == b'':
                 # Something went wrong
                 return None
             if len(bufTemp) > curLength:

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -1103,7 +1103,7 @@ class RAISECHILD:
                     # Windows XP). So, if that's the case we'll force using RC4 by converting
                     # the password to lm/nt hashes and hope for the best. If that's already
                     # done, byebye.
-                    if childCreds['lmhash'] is '' and childCreds['nthash'] is '':
+                    if childCreds['lmhash'] == '' and childCreds['nthash'] == '':
                         from impacket.ntlm import compute_lmhash, compute_nthash
                         childCreds['lmhash'] = compute_lmhash(childCreds['password'])
                         childCreds['nthash'] = compute_nthash(childCreds['password'])
@@ -1144,7 +1144,7 @@ class RAISECHILD:
                     # Windows XP). So, if that's the case we'll force using RC4 by converting
                     # the password to lm/nt hashes and hope for the best. If that's already
                     # done, byebye.
-                    if childCreds['lmhash'] is '' and childCreds['nthash'] is '':
+                    if childCreds['lmhash'] == '' and childCreds['nthash'] == '':
                         from impacket.ntlm import compute_lmhash, compute_nthash
                         childCreds['lmhash'] = compute_lmhash(childCreds['password'])
                         childCreds['nthash'] = compute_nthash(childCreds['password'])
@@ -1271,7 +1271,7 @@ if __name__ == '__main__':
     else:
         logging.getLogger().setLevel(logging.INFO)
 
-    if domain is '':
+    if domain == '':
         logging.critical('Domain should be specified!')
         sys.exit(1)
 

--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -2409,7 +2409,7 @@ class IWbemClassObject(IRemUnknown):
                 if itemValue is None:
                     ndTable |= 3 << (2*i)
             else:
-                if itemValue is '':
+                if itemValue == '':
                     ndTable |= 1 << (2*i)
                     valueTable += pack('<L', 0)
                 else:

--- a/impacket/dcerpc/v5/ndr.py
+++ b/impacket/dcerpc/v5/ndr.py
@@ -1333,7 +1333,7 @@ class NDRUNION(NDRCONSTRUCTEDTYPE):
             data += b'\xbd'*pad
             soFar += pad
 
-        if self.structure is ():
+        if self.structure == ():
             return data
 
         for fieldName, fieldTypeOrClass in self.structure:
@@ -1420,7 +1420,7 @@ class NDRUNION(NDRCONSTRUCTEDTYPE):
             data = data[pad:]
             soFar += pad
 
-        if self.structure is ():
+        if self.structure == ():
             return soFar-soFar0
 
         for fieldName, fieldTypeOrClass in self.structure:

--- a/impacket/dcerpc/v5/nrpc.py
+++ b/impacket/dcerpc/v5/nrpc.py
@@ -1659,7 +1659,7 @@ def ComputeSessionKeyStrongKey(sharedSecret, clientChallenge, serverChallenge, s
     md5.update(clientChallenge)
     md5.update(serverChallenge)
     finalMD5 = md5.digest()
-    hm = hmac.new(M4SS) 
+    hm = hmac.new(M4SS, digestmod=hashlib.md5)
     hm.update(finalMD5)
     return hm.digest()
 
@@ -1690,16 +1690,16 @@ def ComputeNetlogonSignatureMD5(authSignature, message, confounder, sessionKey):
     md5.update(confounder)
     md5.update(str(message))
     finalMD5 = md5.digest()
-    hm = hmac.new(sessionKey)
+    hm = hmac.new(sessionKey, digestmod=hashlib.md5)
     hm.update(finalMD5)
     return hm.digest()[:8]
 
 def encryptSequenceNumberRC4(sequenceNum, checkSum, sessionKey):
     # [MS-NRPC] Section 3.3.4.2.1, point 9
 
-    hm = hmac.new(sessionKey)
+    hm = hmac.new(sessionKey, digestmod=hashlib.md5)
     hm.update('\x00'*4)
-    hm2 = hmac.new(hm.digest())
+    hm2 = hmac.new(hm.digest(), digestmod=hashlib.md5)
     hm2.update(checkSum)
     encryptionKey = hm2.digest()
 
@@ -1754,9 +1754,9 @@ def SEAL(data, confounder, sequenceNum, key, aes = False):
 
     XorKey = ''.join(XorKey)
     if aes is False:
-        hm = hmac.new(XorKey)
+        hm = hmac.new(XorKey, digestmod=hashlib.md5)
         hm.update('\x00'*4)
-        hm2 = hmac.new(hm.digest())
+        hm2 = hmac.new(hm.digest(), digestmod=hashlib.md5)
         hm2.update(sequenceNum)
         encryptionKey = hm2.digest()
 
@@ -1787,9 +1787,9 @@ def UNSEAL(data, auth_data, key, aes = False):
     XorKey = ''.join(XorKey)
     if aes is False:
         sequenceNum = decryptSequenceNumberRC4(auth_data['SequenceNumber'], auth_data['Checksum'],  key)
-        hm = hmac.new(XorKey)
+        hm = hmac.new(XorKey, digestmod=hashlib.md5)
         hm.update('\x00'*4)
-        hm2 = hmac.new(hm.digest())
+        hm2 = hmac.new(hm.digest(), digestmod=hashlib.md5)
         hm2.update(sequenceNum)
         encryptionKey = hm2.digest()
 

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1318,7 +1318,7 @@ class LSASecrets(OfflineRegistry):
         return secret['Secret']
 
     def __decryptHash(self, key, value, iv):
-        hmac_md5 = HMAC.new(key,iv)
+        hmac_md5 = HMAC.new(key,iv,digestmod=hashlib.md5)
         rc4key = hmac_md5.digest()
 
         rc4 = ARC4.new(rc4key)

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -166,7 +166,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
         r = sendReceive(message, domain, kdcHost)
     except KerberosError as e:
         if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
-            if supportedCiphers[0] in (constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value) and aesKey is '':
+            if supportedCiphers[0] in (constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value) and aesKey == '':
                 supportedCiphers = (int(constants.EncryptionTypes.rc4_hmac.value),)
                 seq_set_iter(reqBody, 'etype', supportedCiphers)
                 message = encoder.encode(asReq)
@@ -299,7 +299,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
             tgt = sendReceive(encoder.encode(asReq), domain, kdcHost)
         except Exception as e:
             if str(e).find('KDC_ERR_ETYPE_NOSUPP') >= 0:
-                if lmhash is b'' and nthash is b'' and (aesKey is b'' or aesKey is None):
+                if lmhash == b'' and nthash == b'' and (aesKey == b'' or aesKey is None):
                     from impacket.ntlm import compute_lmhash, compute_nthash
                     lmhash = compute_lmhash(password)
                     nthash = compute_nthash(password)
@@ -576,7 +576,7 @@ def getKerberosType1(username, password, domain, lmhash, nthash, aesKey='', TGT 
                         # So, if that's the case we'll force using RC4 by converting
                         # the password to lm/nt hashes and hope for the best. If that's already
                         # done, byebye.
-                        if lmhash is b'' and nthash is b'' and (aesKey is b'' or aesKey is None) and TGT is None and TGS is None:
+                        if lmhash == b'' and nthash == b'' and (aesKey == b'' or aesKey is None) and TGT is None and TGS is None:
                             from impacket.ntlm import compute_lmhash, compute_nthash
                             LOG.debug('Got KDC_ERR_ETYPE_NOSUPP, fallback to RC4')
                             lmhash = compute_lmhash(password)
@@ -604,7 +604,7 @@ def getKerberosType1(username, password, domain, lmhash, nthash, aesKey='', TGT 
                     # So, if that's the case we'll force using RC4 by converting
                     # the password to lm/nt hashes and hope for the best. If that's already
                     # done, byebye.
-                    if lmhash is b'' and nthash is b'' and (aesKey is b'' or aesKey is None) and TGT is None and TGS is None:
+                    if lmhash == b'' and nthash == b'' and (aesKey == b'' or aesKey is None) and TGT is None and TGS is None:
                         from impacket.ntlm import compute_lmhash, compute_nthash
                         LOG.debug('Got KDC_ERR_ETYPE_NOSUPP, fallback to RC4')
                         lmhash = compute_lmhash(password)

--- a/impacket/ntlm.py
+++ b/impacket/ntlm.py
@@ -879,7 +879,7 @@ def KXKEY(flags, sessionBaseKey, lmChallengeResponse, serverChallenge, password,
       
 def hmac_md5(key, data):
     import hmac
-    h = hmac.new(key)
+    h = hmac.new(key, digestmod=hashlib.md5)
     h.update(data)
     return h.digest()
 

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -349,7 +349,7 @@ class SMBConnection:
                     # So, if that's the case we'll force using RC4 by converting
                     # the password to lm/nt hashes and hope for the best. If that's already
                     # done, byebye.
-                    if lmhash is '' and nthash is '' and (aesKey is '' or aesKey is None) and TGT is None and TGS is None:
+                    if lmhash == '' and nthash == '' and (aesKey == '' or aesKey is None) and TGT is None and TGS is None:
                         lmhash = compute_lmhash(password)
                         nthash = compute_nthash(password) 
                     else:

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -775,7 +775,7 @@ class MSSQL:
                             # So, if that's the case we'll force using RC4 by converting
                             # the password to lm/nt hashes and hope for the best. If that's already
                             # done, byebye.
-                            if lmhash is '' and nthash is '' and (aesKey is '' or aesKey is None) and TGT is None and TGS is None:
+                            if lmhash == '' and nthash == '' and (aesKey == '' or aesKey is None) and TGT is None and TGS is None:
                                 from impacket.ntlm import compute_lmhash, compute_nthash
                                 LOG.debug('Got KDC_ERR_ETYPE_NOSUPP, fallback to RC4')
                                 lmhash = compute_lmhash(password)
@@ -810,7 +810,7 @@ class MSSQL:
                         # So, if that's the case we'll force using RC4 by converting
                         # the password to lm/nt hashes and hope for the best. If that's already
                         # done, byebye.
-                        if lmhash is '' and nthash is '' and (aesKey is '' or aesKey is None) and TGT is None and TGS is None:
+                        if lmhash == '' and nthash == '' and (aesKey == '' or aesKey is None) and TGT is None and TGS is None:
                             from impacket.ntlm import compute_lmhash, compute_nthash
                             LOG.debug('Got KDC_ERR_ETYPE_NOSUPP, fallback to RC4')
                             lmhash = compute_lmhash(password)

--- a/tests/SMB_RPC/test_drsuapi.py
+++ b/tests/SMB_RPC/test_drsuapi.py
@@ -326,7 +326,7 @@ class DRSRTests(unittest.TestCase):
         #        thisObject.dump()
         #        print thisObject['Entinf']['pName']['StringName']
         #        thisObject = nextObject
-        #        if nextObject is '':
+        #        if nextObject == '':
         #            done = True
         #    request['pmsgIn']['V8']['uuidInvocIdSrc'] = resp['pmsgOut']['V6']['uuidInvocIdSrc']
         #    request['pmsgIn']['V8']['usnvecFrom'] = resp['pmsgOut']['V6']['usnvecTo']
@@ -345,7 +345,7 @@ class DRSRTests(unittest.TestCase):
                 #print '\n'
                 #print thisObject['Entinf']['pName']['StringName']
             #    thisObject = nextObject
-            #    if nextObject is '':
+            #    if nextObject == '':
             #        done = True
 
             request['pmsgIn']['V10']['uuidInvocIdSrc'] = resp['pmsgOut']['V6']
@@ -446,7 +446,7 @@ class DRSRTests(unittest.TestCase):
         #        #print '\n'
         #        #print thisObject['Entinf']['pName']['StringName']
         #        thisObject = nextObject
-        #        if nextObject is '':
+        #        if nextObject == '':
         #            done = True
 #
 #            print "B"*80


### PR DESCRIPTION
Hello.

I tried to use impacket with Python 3.8 and there were two things I think we should fix.

1) There were a lot of warnings: `SyntaxWarning: "is" with a literal. Did you mean "=="?` To eliminate them, I replaced `is` to `==` in every `is b''`, `is ''` and `is ()` occurrence.

2) Parameter `digestmod` is now required, so I added `digestmod=hashlib.md5` to all `hmac.new()` calls without such parameter. This error was mentioned in #702 issue.

I haven't properly tested Python 3.8 compatibility yet, but I didn't find any errors for now.

Thank you.