### PR TITLE
Added codec parameter to smbexec.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
+.env/
+.venv/
 build/
 develop-eggs/
 dist/

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -232,7 +232,7 @@ if __name__ == '__main__':
     parser.add_argument('-codec', action='store', help='Sets encoding used (codec) from the target\'s output (default '
                                                        '"%s"). If errors are detected, run chcp.com at the target, '
                                                        'map the result with '
-                                                       'https://docs.python.org/2.4/lib/standard-encodings.html and then execute ntlmrelayx.py '
+                                                       'https://docs.python.org/3/library/codecs.html#standard-encodings and then execute ntlmrelayx.py '
                                                        'again with -codec and the corresponding codec ' % sys.getdefaultencoding())
     parser.add_argument('-smb2support', action="store_true", default=False, help='SMB2 Support (experimental!)')
     parser.add_argument('-socks', action='store_true', default=False,

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -49,6 +49,7 @@ OUTPUT_FILENAME = '__output'
 BATCH_FILENAME  = 'execute.bat'
 SMBSERVER_DIR   = '__tmp'
 DUMMY_SHARE     = 'TMP'
+CODEC = sys.stdout.encoding
 
 class SMBServer(Thread):
     def __init__(self):
@@ -275,7 +276,13 @@ class RemoteShell(cmd.Cmd):
 
     def send_data(self, data):
         self.execute_remote(data)
-        print(self.__outputBuffer.decode())
+        try:
+            print(self.__outputBuffer.decode(CODEC))
+        except UnicodeDecodeError:
+            logging.error('Decoding error detected, consider running chcp.com at the target,\nmap the result with '
+                          'https://docs.python.org/2.4/lib/standard-encodings.html\nand then execute smbexec.py '
+                          'again with -codec and the corresponding codec')
+            print(self.__outputBuffer.decode(CODEC, errors='replace'))
         self.__outputBuffer = b''
 
 
@@ -293,6 +300,11 @@ if __name__ == '__main__':
     parser.add_argument('-mode', action='store', choices = {'SERVER','SHARE'}, default='SHARE',
                         help='mode to use (default SHARE, SERVER needs root!)')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-codec', action='store', help='Sets encoding used (codec) from the target\'s output (default '
+                                                       '"%s"). If errors are detected, run chcp.com at the target, '
+                                                       'map the result with '
+                          'https://docs.python.org/2.4/lib/standard-encodings.html and then execute smbexec.py '
+                          'again with -codec and the corresponding codec ' % CODEC)
 
     group = parser.add_argument_group('connection')
 
@@ -320,6 +332,12 @@ if __name__ == '__main__':
         sys.exit(1)
 
     options = parser.parse_args()
+
+    if options.codec is not None:
+        CODEC = options.codec
+    else:
+        if CODEC is None:
+            CODEC = 'UTF-8'
 
     if options.debug is True:
         logging.getLogger().setLevel(logging.DEBUG)

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -280,7 +280,7 @@ class RemoteShell(cmd.Cmd):
             print(self.__outputBuffer.decode(CODEC))
         except UnicodeDecodeError:
             logging.error('Decoding error detected, consider running chcp.com at the target,\nmap the result with '
-                          'https://docs.python.org/2.4/lib/standard-encodings.html\nand then execute smbexec.py '
+                          'https://docs.python.org/3/library/codecs.html#standard-encodings\nand then execute smbexec.py '
                           'again with -codec and the corresponding codec')
             print(self.__outputBuffer.decode(CODEC, errors='replace'))
         self.__outputBuffer = b''
@@ -303,7 +303,7 @@ if __name__ == '__main__':
     parser.add_argument('-codec', action='store', help='Sets encoding used (codec) from the target\'s output (default '
                                                        '"%s"). If errors are detected, run chcp.com at the target, '
                                                        'map the result with '
-                          'https://docs.python.org/2.4/lib/standard-encodings.html and then execute smbexec.py '
+                          'https://docs.python.org/3/library/codecs.html#standard-encodings and then execute smbexec.py '
                           'again with -codec and the corresponding codec ' % CODEC)
 
     group = parser.add_argument_group('connection')

--- a/examples/smbrelayx.py
+++ b/examples/smbrelayx.py
@@ -148,7 +148,7 @@ class doAttack(Thread):
                         print(self.__answerTMP.decode(CODEC))
                     except UnicodeDecodeError:
                         logging.error('Decoding error detected, consider running chcp.com at the target,\nmap the result with '
-                                      'https://docs.python.org/2.4/lib/standard-encodings.html\nand then execute smbrelayx.py '
+                                      'https://docs.python.org/3/library/codecs.html#standard-encodings\nand then execute smbrelayx.py '
                                   'again with -codec and the corresponding codec')
                         print(self.__answerTMP)
 
@@ -1132,7 +1132,7 @@ if __name__ == '__main__':
     parser.add_argument('-codec', action='store', help='Sets encoding used (codec) from the target\'s output (default '
                                                        '"%s"). If errors are detected, run chcp.com at the target, '
                                                        'map the result with '
-                                                       'https://docs.python.org/2.4/lib/standard-encodings.html and then execute smbrelayx.py '
+                                                       'https://docs.python.org/3/library/codecs.html#standard-encodings and then execute smbrelayx.py '
                                                        'again with -codec and the corresponding codec ' % CODEC)
     parser.add_argument('-outputfile', action='store',
                         help='base output filename for encrypted hashes. Suffixes will be added for ntlm and ntlmv2')

--- a/examples/smbrelayx.py
+++ b/examples/smbrelayx.py
@@ -148,7 +148,7 @@ class doAttack(Thread):
                         print(self.__answerTMP.decode(CODEC))
                     except UnicodeDecodeError:
                         logging.error('Decoding error detected, consider running chcp.com at the target,\nmap the result with '
-                                      'https://docs.python.org/2.4/lib/standard-encodings.html\nand then execute wmiexec.py '
+                                      'https://docs.python.org/2.4/lib/standard-encodings.html\nand then execute smbrelayx.py '
                                   'again with -codec and the corresponding codec')
                         print(self.__answerTMP)
 
@@ -1132,7 +1132,7 @@ if __name__ == '__main__':
     parser.add_argument('-codec', action='store', help='Sets encoding used (codec) from the target\'s output (default '
                                                        '"%s"). If errors are detected, run chcp.com at the target, '
                                                        'map the result with '
-                                                       'https://docs.python.org/2.4/lib/standard-encodings.html and then execute wmiexec.py '
+                                                       'https://docs.python.org/2.4/lib/standard-encodings.html and then execute smbrelayx.py '
                                                        'again with -codec and the corresponding codec ' % CODEC)
     parser.add_argument('-outputfile', action='store',
                         help='base output filename for encrypted hashes. Suffixes will be added for ntlm and ntlmv2')

--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -239,7 +239,7 @@ class RemoteShell(cmd.Cmd):
                 self.__outputBuffer += data.decode(CODEC)
             except UnicodeDecodeError:
                 logging.error('Decoding error detected, consider running chcp.com at the target,\nmap the result with '
-                              'https://docs.python.org/2.4/lib/standard-encodings.html\nand then execute wmiexec.py '
+                              'https://docs.python.org/3/library/codecs.html#standard-encodings\nand then execute wmiexec.py '
                               'again with -codec and the corresponding codec')
                 self.__outputBuffer += data.decode(CODEC, errors='replace')
 
@@ -344,7 +344,7 @@ if __name__ == '__main__':
     parser.add_argument('-codec', action='store', help='Sets encoding used (codec) from the target\'s output (default '
                                                        '"%s"). If errors are detected, run chcp.com at the target, '
                                                        'map the result with '
-                          'https://docs.python.org/2.4/lib/standard-encodings.html and then execute wmiexec.py '
+                          'https://docs.python.org/3/library/codecs.html#standard-encodings and then execute wmiexec.py '
                           'again with -codec and the corresponding codec ' % CODEC)
 
     parser.add_argument('command', nargs='*', default = ' ', help='command to execute at the target. If empty it will '


### PR DESCRIPTION
Fixes #708.

I used the same solution found in `wmiexec.py` to deal with the `UnicodeDecodeError`. I tested it and it works well. `smbexec.py` now has a `-codec` parameter.

I added a few additional commits:

- added common virtualenv folders to `.gitignore`
- fixed a copy and paste error in `smbrelayx.py` where it was printing something about running `wmiexec.py`
- updated the Python docs URL to the modern Python 3 version

If you don't like the last commit for some reason, feel free to cherry-pick the other commits. I could also force push the branch to remove this one if necessary.

