### PR TITLE
removed old documentation about smbserver not authenticating clients

### DIFF
--- a/examples/smbserver.py
+++ b/examples/smbserver.py
@@ -26,8 +26,8 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(add_help = True, description = "This script will launch a SMB Server and add a "
                                      "share specified as an argument. You need to be root in order to bind to port 445. "
-                                     "No authentication will be enforced. Example: smbserver.py -comment 'My share' TMP "
-                                     "/tmp")
+                                     "For optional authentication, it is possible to specify username and password or the NTLM hash. "
+                                     "Example: smbserver.py -comment 'My share' TMP /tmp")
 
     parser.add_argument('shareName', action='store', help='name of the share to add')
     parser.add_argument('sharePath', action='store', help='path of the share to add')

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -14,7 +14,6 @@
 # [*] Add capability to send a bad user ID if the user is not authenticated,
 #     right now you can ask for any command without actually being authenticated
 # [ ] PATH TRAVERSALS EVERYWHERE.. BE WARNED!
-# [ ] Check the credentials.. now we're just letting everybody to log in.
 # [ ] Check error situation (now many places assume the right data is coming)
 # [ ] Implement IPC to the main process so the connectionData is on a single place
 # [ ] Hence.. implement locking


### PR DESCRIPTION
I was confused about `smbserver.py`'s help output, explaining there is no authentication, while `-username` and `-password` options exist. Turns out, this was an old comment, no longer true. I rephrased the description.