### PR TITLE
fix logger init on smbserver.py

### DIFF
--- a/examples/smbserver.py
+++ b/examples/smbserver.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
        logging.critical(str(e))
        sys.exit(1)
 
-    logger.init(options.ts)
+    logger.init()
 
     if options.debug is True:
         logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION
smbserver.py not working properly because logger.init call provides an argument while the function does not take any.

![image](https://user-images.githubusercontent.com/35694604/70848608-91d64600-1e74-11ea-80f9-908255f1def1.png)
