### PR TITLE
Added flags to SMBExec and PSExec to bypass badly made detection use cases

### DIFF
--- a/examples/psexec.py
+++ b/examples/psexec.py
@@ -56,7 +56,8 @@ lock = Lock()
 
 class PSEXEC:
     def __init__(self, command, path, exeFile, copyFile, port=445,
-                 username='', password='', domain='', hashes=None, aesKey=None, doKerberos=False, kdcHost=None, serviceName=None):
+                 username='', password='', domain='', hashes=None, aesKey=None, doKerberos=False, kdcHost=None, serviceName=None,
+                 remoteBinaryName=None):
         self.__username = username
         self.__password = password
         self.__port = port
@@ -71,6 +72,7 @@ class PSEXEC:
         self.__doKerberos = doKerberos
         self.__kdcHost = kdcHost
         self.__serviceName = serviceName
+        self.__remoteBinaryName = remoteBinaryName
         if hashes is not None:
             self.__lmhash, self.__nthash = hashes.split(':')
 
@@ -131,7 +133,7 @@ class PSEXEC:
             # We don't wanna deal with timeouts from now on.
             s.setTimeout(100000)
             if self.__exeFile is None:
-                installService = serviceinstall.ServiceInstall(rpctransport.get_smb_connection(), remcomsvc.RemComSvc(), self.__serviceName)
+                installService = serviceinstall.ServiceInstall(rpctransport.get_smb_connection(), remcomsvc.RemComSvc(), self.__serviceName, self.__remoteBinaryName)
             else:
                 try:
                     f = open(self.__exeFile)
@@ -139,7 +141,7 @@ class PSEXEC:
                     logging.critical(str(e))
                     sys.exit(1)
                 installService = serviceinstall.ServiceInstall(rpctransport.get_smb_connection(), f)
-    
+
             if installService.install() is False:
                 return
 
@@ -184,7 +186,7 @@ class PSEXEC:
                                            r'\%s%s%d' % (RemComSTDERR, packet['Machine'], packet['ProcessID']),
                                            smb.FILE_READ_DATA)
             stderr_pipe.start()
-            
+
             # And we stay here till the end
             ans = s.readNamedPipe(tid,fid_main,8)
 
@@ -240,7 +242,7 @@ class Pipes(Thread):
             else:
                 self.server.login(user, passwd, domain, lm, nt)
             lock.release()
-            self.tid = self.server.connectTree('IPC$') 
+            self.tid = self.server.connectTree('IPC$')
 
             self.server.waitNamedPipe(self.tid, self.pipe)
             self.fid = self.server.openFile(self.tid,self.pipe,self.permissions, creationOption = 0x40, fileAttributes = 0x80)
@@ -272,7 +274,7 @@ class RemoteStdOutPipe(Pipes):
                     else:
                         # Don't echo what I sent, and clear it up
                         LastDataSent = ''
-                    # Just in case this got out of sync, i'm cleaning it up if there are more than 10 chars, 
+                    # Just in case this got out of sync, i'm cleaning it up if there are more than 10 chars,
                     # it will give false positives tho.. we should find a better way to handle this.
                     if LastDataSent > 10:
                         LastDataSent = ''
@@ -327,7 +329,7 @@ class RemoteShell(cmd.Cmd):
  lcd {path}                 - changes the current local directory to {path}
  exit                       - terminates the server process (and this session)
  put {src_file, dst_path}   - uploads a local file to the dst_path RELATIVE to the connected share (%s)
- get {file}                 - downloads pathname RELATIVE to the connected share (%s) to the current local dir 
+ get {file}                 - downloads pathname RELATIVE to the connected share (%s) to the current local dir
  ! {cmd}                    - executes a local shell cmd
 """ % (self.share, self.share))
         self.send_data('\r\n', False)
@@ -352,7 +354,7 @@ class RemoteShell(cmd.Cmd):
             pass
 
         self.send_data('\r\n')
- 
+
     def do_put(self, s):
         try:
             if self.transferClient is None:
@@ -453,7 +455,8 @@ if __name__ == '__main__':
                             'This is useful when target is the NetBIOS name and you cannot resolve it')
     group.add_argument('-port', choices=['139', '445'], nargs='?', default='445', metavar="destination port",
                        help='Destination port to connect to SMB Server')
-    group.add_argument('-service-name', action='store', metavar="service name", default = '', help='This will be the name of the service')
+    group.add_argument('-service-name', action='store', metavar="service_name", default = '', help='The name of the service used to trigger the payload')
+    group.add_argument('-remote-binary-name', action='store', metavar="remote_binary_name", default = None, help='This will be the name of the executable uploaded on the target')
 
     if len(sys.argv)==1:
         parser.print_help()
@@ -470,7 +473,7 @@ if __name__ == '__main__':
 
     domain, username, password, remoteName = re.compile('(?:(?:([^/@:]*)/)?([^@:]*)(?::([^@]*))?@)?(.*)').match(
         options.target).groups('')
-    
+
     #In case the password contains '@'
     if '@' in remoteName:
         password = password + '@' + remoteName.rpartition('@')[0]
@@ -494,5 +497,5 @@ if __name__ == '__main__':
         command = 'cmd.exe'
 
     executer = PSEXEC(command, options.path, options.file, options.c, int(options.port), username, password, domain, options.hashes,
-                      options.aesKey, options.k, options.dc_ip, options.service_name)
+                      options.aesKey, options.k, options.dc_ip, options.service_name, options.remote_binary_name)
     executer.run(remoteName, options.target_ip)

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -326,7 +326,7 @@ if __name__ == '__main__':
                        'ones specified in the command line')
     group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication '
                                                                             '(128 or 256 bits)')
-    group.add_argument('-service-name', action='store', metavar="service name", default = SERVICE_NAME, help='The name of the service used to trigger the payload')
+    group.add_argument('-service-name', action='store', metavar="service_name", default = SERVICE_NAME, help='The name of the service used to trigger the payload')
 
 
     if len(sys.argv)==1:

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -7,21 +7,21 @@
 #
 # A similar approach to psexec w/o using RemComSvc. The technique is described here
 # https://www.optiv.com/blog/owning-computers-without-shell-access
-# Our implementation goes one step further, instantiating a local smbserver to receive the 
+# Our implementation goes one step further, instantiating a local smbserver to receive the
 # output of the commands. This is useful in the situation where the target machine does NOT
 # have a writeable share available.
-# Keep in mind that, although this technique might help avoiding AVs, there are a lot of 
-# event logs generated and you can't expect executing tasks that will last long since Windows 
-# will kill the process since it's not responding as a Windows service. 
+# Keep in mind that, although this technique might help avoiding AVs, there are a lot of
+# event logs generated and you can't expect executing tasks that will last long since Windows
+# will kill the process since it's not responding as a Windows service.
 # Certainly not a stealthy way.
 #
 # This script works in two ways:
 # 1) share mode: you specify a share, and everything is done through that share.
 # 2) server mode: if for any reason there's no share available, this script will launch a local
 #    SMB server, so the output of the commands executed are sent back by the target machine
-#    into a locally shared folder. Keep in mind you would need root access to bind to port 445 
+#    into a locally shared folder. Keep in mind you would need root access to bind to port 445
 #    in the local machine.
-# 
+#
 # Author:
 #  beto (@agsolino)
 #
@@ -49,6 +49,7 @@ OUTPUT_FILENAME = '__output'
 BATCH_FILENAME  = 'execute.bat'
 SMBSERVER_DIR   = '__tmp'
 DUMMY_SHARE     = 'TMP'
+SERVICE_NAME    = 'BTOBTO'
 CODEC = sys.stdout.encoding
 
 class SMBServer(Thread):
@@ -111,12 +112,12 @@ class SMBServer(Thread):
 
 class CMDEXEC:
     def __init__(self, username='', password='', domain='', hashes=None, aesKey=None,
-                 doKerberos=None, kdcHost=None, mode=None, share=None, port=445):
+                 doKerberos=None, kdcHost=None, mode=None, share=None, port=445, serviceName=SERVICE_NAME):
 
         self.__username = username
         self.__password = password
         self.__port = port
-        self.__serviceName = 'BTOBTO'
+        self.__serviceName = serviceName
         self.__domain = domain
         self.__lmhash = ''
         self.__nthash = ''
@@ -169,7 +170,7 @@ class RemoteShell(cmd.Cmd):
         self.__share = share
         self.__mode = mode
         self.__output = '\\\\127.0.0.1\\' + self.__share + '\\' + OUTPUT_FILENAME
-        self.__batchFile = '%TEMP%\\' + BATCH_FILENAME 
+        self.__batchFile = '%TEMP%\\' + BATCH_FILENAME
         self.__outputBuffer = b''
         self.__command = ''
         self.__shell = '%COMSPEC% /Q /c '
@@ -202,7 +203,7 @@ class RemoteShell(cmd.Cmd):
         # Just in case the service is still created
         try:
            self.__scmr = self.__rpc.get_dce_rpc()
-           self.__scmr.connect() 
+           self.__scmr.connect()
            self.__scmr.bind(scmr.MSRPC_UUID_SCMR)
            resp = scmr.hROpenSCManagerW(self.__scmr)
            self.__scHandle = resp['lpScHandle']
@@ -259,7 +260,7 @@ class RemoteShell(cmd.Cmd):
                   self.__shell + self.__batchFile
         if self.__mode == 'SERVER':
             command += ' & ' + self.__copyBack
-        command += ' & ' + 'del ' + self.__batchFile 
+        command += ' & ' + 'del ' + self.__batchFile
 
         logging.debug('Executing %s' % command)
         resp = scmr.hRCreateServiceW(self.__scmr, self.__scHandle, self.__serviceName, self.__serviceName,
@@ -325,8 +326,9 @@ if __name__ == '__main__':
                        'ones specified in the command line')
     group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication '
                                                                             '(128 or 256 bits)')
+    group.add_argument('-service-name', action='store', metavar="service name", default = SERVICE_NAME, help='The name of the service used to trigger the payload')
 
- 
+
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
@@ -367,7 +369,7 @@ if __name__ == '__main__':
 
     try:
         executer = CMDEXEC(username, password, domain, options.hashes, options.aesKey, options.k,
-                           options.dc_ip, options.mode, options.share, int(options.port))
+                           options.dc_ip, options.mode, options.share, int(options.port), options.service_name)
         executer.run(remoteName, options.target_ip)
     except Exception as e:
         if logging.getLogger().level == logging.DEBUG:


### PR DESCRIPTION
I have seen a lot of detection use cases and mitigation measures that relies on binary or service names to block PSExec and/or SMBExec lateral movement. Sysinternal's PSExec already allows to change the binary name to bypass those use cases, but Impacket did not have this capability.

This pull requests add the following features :
**SMBExec**
Possibility to rename the PSExec uploaded binary name with the -remote-binary-name flag

**PSExec**
Possibility to use another service name with the -service-name flag