### PR TITLE
Travis CI: Add Python 3.8 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,14 @@ matrix:
       env: NO_REMOTE=true, TOXENV=py36
     - python: 3.7
       env: NO_REMOTE=true, TOXENV=py37
-      dist: xenial  # required for Python >= 3.7
+    - python: 3.8
+      env: NO_REMOTE=true, TOXENV=py38
 
 install: pip install flake8 tox -r requirements.txt
   
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E9,F72,F82 --show-source --statistics
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --ignore=E1,E2,E3,E501,W291,W293 --exit-zero --max-complexity=65 --max-line-length=127 --statistics
 

--- a/examples/netview.py
+++ b/examples/netview.py
@@ -127,7 +127,7 @@ class USERENUM:
     def getDomainMachines(self):
         if self.__kdcHost is not None:
             domainController = self.__kdcHost
-        elif self.__domain is not '':
+        elif self.__domain != '':
             domainController = self.__domain
         else:
             raise Exception('A domain is needed!')

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -2461,7 +2461,7 @@ class SMBCommands:
                                                             authenticateMessage['domain_name'],
                                                             authenticateMessage['lanman'], authenticateMessage['ntlm'])
                         smbServer.log(ntlm_hash_data['hash_string'])
-                        if jtr_dump_path is not '':
+                        if jtr_dump_path != '':
                             writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'], jtr_dump_path)
                     except:
                         smbServer.log("Could not write NTLM Hashes to the specified JTR_Dump_Path %s" % jtr_dump_path)
@@ -2497,7 +2497,7 @@ class SMBCommands:
                 jtr_dump_path = smbServer.getJTRdumpPath()
                 ntlm_hash_data = outputToJohnFormat( b'', sessionSetupData['Account'], sessionSetupData['PrimaryDomain'], sessionSetupData['AnsiPwd'], sessionSetupData['UnicodePwd'] )
                 smbServer.log(ntlm_hash_data['hash_string'])
-                if jtr_dump_path is not '':
+                if jtr_dump_path != '':
                     writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'], jtr_dump_path)
             except:
                 smbServer.log("Could not write NTLM Hashes to the specified JTR_Dump_Path %s" % jtr_dump_path)
@@ -2839,7 +2839,7 @@ class SMB2Commands:
                                                         authenticateMessage['domain_name'],
                                                         authenticateMessage['lanman'], authenticateMessage['ntlm'])
                     smbServer.log(ntlm_hash_data['hash_string'])
-                    if jtr_dump_path is not '':
+                    if jtr_dump_path != '':
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
                                               jtr_dump_path)
                 except:
@@ -4413,7 +4413,7 @@ smb.SMB.TRANS_TRANSACT_NMPIPE          :self.__smbTransHandler.transactNamedPipe
 
         # Process the credentials
         credentials_fname = self.__serverConfig.get('global','credentials_file')
-        if credentials_fname is not "":
+        if credentials_fname != "":
             cred = open(credentials_fname)
             line = cred.readline()
             while line:

--- a/setup.py
+++ b/setup.py
@@ -42,8 +42,9 @@ setup(name = PACKAGE_NAME,
                       'python_version<"2.7"': [ 'argparse' ],
                     },
       classifiers = [
+          "Programming Language :: Python :: 3.8",
+          "Programming Language :: Python :: 3.7",
           "Programming Language :: Python :: 3.6",
           "Programming Language :: Python :: 2.7",
-          "Programming Language :: Python :: 2.6",
       ]
       )

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,14 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-#envlist = py26#, py27,py36,py37
-envlist = py27,py36,py37
+envlist = py27,py36,py37,py38
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 changedir = {toxinidir}/tests
 deps=-rrequirements.txt
-    coverage
-    py26: wheel==0.29.0
     coverage
 passenv = NO_REMOTE
 commands_pre = {envpython} -m pip check


### PR DESCRIPTION
Add Flake8 F63 tests which are usually about the confusion between identity and equality in Python. Use ==/!= to compare str, bytes, and int literals is the classic case. These are areas where a == b is True but a is b is False (or vice versa). Python >= 3.8 will raise SyntaxWarnings on these instances.

$ python3.8
```
Python 3.8.2 (default, Mar 11 2020, 00:29:50)
Type "help", "copyright", "credits" or "license" for more information.
>>> '' is ''
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```