### PR TITLE
dpapi.py Add RPC masterkey decryption

### DIFF
--- a/examples/dpapi.py
+++ b/examples/dpapi.py
@@ -46,6 +46,8 @@ from impacket import crypto
 from impacket.smbconnection import SMBConnection
 from impacket.dcerpc.v5 import transport
 from impacket.dcerpc.v5 import lsad
+from impacket.dcerpc.v5 import bkrp
+from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY
 from impacket import version
 from impacket.examples import logger
 from impacket.examples.secretsdump import LocalOperations, LSASecrets
@@ -257,6 +259,57 @@ class DPAPI:
                     print('Decrypted key: 0x%s' % hexlify(decryptedKey).decode('latin-1'))
                     return
 
+            elif self.options.target is not None:
+                domain, username, password, remoteName = re.compile('(?:(?:([^/@:]*)/)?([^@:]*)(?::([^@]*))?@)?(.*)').match(self.options.target).groups('')
+                #In case the password contains '@'
+                if '@' in remoteName:
+                    password = password + '@' + remoteName.rpartition('@')[0]
+                    remoteName = remoteName.rpartition('@')[2]
+
+                if domain is None:
+                    domain = ''
+
+                if password == '' and username != '' and self.options.hashes is None and self.options.no_pass is False and self.options.aesKey is None:
+                    from getpass import getpass
+                    password = getpass("Password:")
+
+                if self.options.hashes is not None:
+                    lmhash, nthash = self.options.hashes.split(':')
+                else:
+                    lmhash, nthash = '',''
+                rpctransport = transport.DCERPCTransportFactory(r'ncacn_np:%s[\PIPE\protected_storage]' % remoteName)
+
+                if hasattr(rpctransport, 'set_credentials'):
+                    # This method exists only for selected protocol sequences.
+                    rpctransport.set_credentials(username, password, domain, lmhash, nthash, self.options.aesKey)
+                
+                rpctransport.set_kerberos(self.options.k, self.options.dc_ip)
+                
+                dce = rpctransport.get_dce_rpc()
+                dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
+                dce.connect()
+                dce.bind(bkrp.MSRPC_UUID_BKRP, transfer_syntax = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0'))
+                
+                request = bkrp.BackuprKey()
+                request['pguidActionAgent'] = bkrp.BACKUPKEY_RESTORE_GUID
+                request['pDataIn'] = dk.getData()
+                request['cbDataIn'] = len(dk.getData())
+                request['dwParam'] = 0
+
+                resp = dce.request(request)
+                
+                ## Stripping heading zeros resulting from asymetric decryption
+                beginning=0
+                for i in range(len(resp['ppDataOut'])):
+                    if resp['ppDataOut'][i]==b'\x00':
+                        beginning+=1
+                    else:
+                        break
+                masterkey=b''.join(resp['ppDataOut'][beginning:])
+                print('Decrypted key using rpc call')
+                print('Decrypted key: 0x%s' % hexlify(masterkey[beginning:]).decode())
+                return
+
             else:
                 # Just print key's data
                 if mkf['MasterKeyLen'] > 0:
@@ -436,6 +489,17 @@ if __name__ == '__main__':
     masterkey.add_argument('-password', action='store', help='User\'s password. If you specified the SID and not the password it will be prompted')
     masterkey.add_argument('-system', action='store', help='SYSTEM hive to parse')
     masterkey.add_argument('-security', action='store', help='SECURITY hive to parse')
+    masterkey.add_argument('-t', '--target', action='store', help='The masterkey owner\'s credentails to ask the DC for decryption'
+                                                                  'Format: [[domain/]username[:password]@]<targetName or address>')
+    masterkey.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
+    masterkey.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful for -k)')
+    masterkey.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file '
+                       '(KRB5CCNAME) based on target parameters. If valid credentials cannot be found, it will use the '
+                       'ones specified in the command line')
+    masterkey.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication '
+                                                                            '(128 or 256 bits)')
+    masterkey.add_argument('-dc-ip', action='store',metavar = "ip address", help='IP Address of the domain controller. '
+                       'If omitted it will use the domain part (FQDN) specified in the target parameter')
 
     # A credential command
     credential = subparsers.add_parser('credential', help='credential related functions')


### PR DESCRIPTION
Added feature to decrypt a user's masterkey using the MS-BKRP (BackupKey Remote Protocol). This is already implemented in mimikatz to decrypt masterkeys using the /rpc flag (https://github.com/gentilkiwi/mimikatz/blob/172200295688ccbb76c44c6db0b3b47d39dd0d4d/modules/rpc/kull_m_rpc_bkrp.c#L51-L54)
This makes an RPC call with the user's identity to the function BackuprKey on the DC. The GUID of this operation is BACKUPKEY_RESTORE_GUID and the details can be found on microsoft documentation here: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-bkrp/7accb903-3863-4385-9c99-11af8c18d656