### PR TITLE
Fixed UnsupportedOperation('not writable') when using interactive shell with Python 3.

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/smbattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/smbattack.py
@@ -57,7 +57,7 @@ class SMBAttack(ProtocolAttack):
             LOG.info('Started interactive SMB client shell via TCP on 127.0.0.1:%d' % self.tcpshell.port)
             #Start listening and launch interactive shell
             self.tcpshell.listen()
-            self.shell = MiniImpacketShell(self.__SMBConnection,self.tcpshell.socketfile)
+            self.shell = MiniImpacketShell(self.__SMBConnection, self.tcpshell)
             self.shell.cmdloop()
             return
         if self.config.exeFile is not None:

--- a/impacket/examples/ntlmrelayx/utils/tcpshell.py
+++ b/impacket/examples/ntlmrelayx/utils/tcpshell.py
@@ -30,5 +30,11 @@ class TcpShell:
         #Don't allow a backlog
         serversocket.listen(0)
         self.connection, host = serversocket.accept()
-        #Create a file object from the socket
-        self.socketfile = self.connection.makefile()
+        #Create file objects from the socket
+        self.stdin = self.connection.makefile("r")
+        self.stdout = self.connection.makefile("w")
+
+    def close(self):
+        self.stdout.close()
+        self.stdin.close()
+        self.connection.close()

--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -37,15 +37,15 @@ except ImportError:
   import readline
 
 class MiniImpacketShell(cmd.Cmd):
-    def __init__(self, smbClient,tcpShell=None):
+    def __init__(self, smbClient, tcpShell=None):
         #If the tcpShell parameter is passed (used in ntlmrelayx),
         # all input and output is redirected to a tcp socket
         # instead of to stdin / stdout
         if tcpShell is not None:
-            cmd.Cmd.__init__(self,stdin=tcpShell,stdout=tcpShell)
-            sys.stdout = tcpShell
-            sys.stdin = tcpShell
-            sys.stderr = tcpShell
+            cmd.Cmd.__init__(self, stdin=tcpShell.stdin, stdout=tcpShell.stdout)
+            sys.stdout = tcpShell.stdout
+            sys.stdin = tcpShell.stdin
+            sys.stderr = tcpShell.stdout
             self.use_rawinput = False
             self.shell = tcpShell
         else:


### PR DESCRIPTION
I kept getting an UnsupportedOperation('not writable') when trying to use the interactive shell with Python 3.7.

It seems like socket.makefile doesn't support reading and writing at the same time.

I created two different files: one for forwarding stdin and one for forwarding stdout/stderr.