### PR TITLE
fix connection issue in smbexec.py and samrdump.py

### DIFF
--- a/examples/samrdump.py
+++ b/examples/samrdump.py
@@ -26,7 +26,7 @@ from impacket import version
 from impacket.nt_errors import STATUS_MORE_ENTRIES
 from impacket.dcerpc.v5 import transport, samr
 from impacket.dcerpc.v5.rpcrt import DCERPCException
-from impacket.smb import SMB_DIALECT
+#from impacket.smb import SMB_DIALECT
 
 class ListUsersException(Exception):
     pass
@@ -70,8 +70,8 @@ class SAMRDump:
         rpctransport.set_dport(self.__port)
         rpctransport.setRemoteHost(remoteHost)
 
-        if hasattr(rpctransport,'preferred_dialect'):
-            rpctransport.preferred_dialect(SMB_DIALECT)
+#        if hasattr(rpctransport,'preferred_dialect'):
+#            rpctransport.preferred_dialect(SMB_DIALECT)
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
             rpctransport.set_credentials(self.__username, self.__password, self.__domain, self.__lmhash,

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -42,7 +42,7 @@ from threading import Thread
 
 from impacket.examples import logger
 from impacket import version, smbserver
-from impacket.smbconnection import SMB_DIALECT
+#from impacket.smbconnection import SMB_DIALECT
 from impacket.dcerpc.v5 import transport, scmr
 
 OUTPUT_FILENAME = '__output'
@@ -136,8 +136,8 @@ class CMDEXEC:
         rpctransport = transport.DCERPCTransportFactory(stringbinding)
         rpctransport.set_dport(self.__port)
         rpctransport.setRemoteHost(remoteHost)
-        if hasattr(rpctransport,'preferred_dialect'):
-            rpctransport.preferred_dialect(SMB_DIALECT)
+#        if hasattr(rpctransport,'preferred_dialect'):
+#            rpctransport.preferred_dialect(SMB_DIALECT)
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
             rpctransport.set_credentials(self.__username, self.__password, self.__domain, self.__lmhash,


### PR DESCRIPTION
smbexec.py and samrdump.py modules always use "NT LM 0.12" dialect of SMB while connecting to a remote host. So, if the host supports a minimum SMB version higher than SMB1, then the following error occurs:

```
Impacket v0.9.21-dev - Copyright 2019 SecureAuth Corporation

[-] [Errno 104] Connection reset by peer
```

Before the fix

![x0](https://user-images.githubusercontent.com/2904679/72563862-9a7cca80-38bf-11ea-99da-6bf5114700fa.png)

After the fix

![x1](https://user-images.githubusercontent.com/2904679/72563863-9b156100-38bf-11ea-883b-d0a7221af79a.png)
