### PR TITLE
Single-source the version and standardize

### DIFF
--- a/impacket/version.py
+++ b/impacket/version.py
@@ -4,8 +4,7 @@
 # of the Apache Software License. See the accompanying LICENSE file
 # for more information.
 #
+import pkg_resources
 
-VER_MAJOR = "0"
-VER_MINOR = "9.21-dev"
 
-BANNER = "Impacket v%s.%s - Copyright 2019 SecureAuth Corporation\n" % (VER_MAJOR,VER_MINOR)
+BANNER = "Impacket v{} - Copyright 2019 SecureAuth Corporation\n".format(pkg_resources.get_distribution('impacket').version)

--- a/setup.py
+++ b/setup.py
@@ -17,9 +17,16 @@ VER_PREREL = "dev1"
 if call(["git", "branch"], stderr=STDOUT, stdout=open(os.devnull, 'w')) == 0:
     p = Popen("git log -1 --format=%cd --date=format:%Y%m%d.%H%M%S", shell=True, stdin=PIPE, stderr=PIPE, stdout=PIPE)
     (outstr, errstr) = p.communicate()
-    VER_TSTAMP = "+" + outstr.strip().decode("utf-8")
+    (VER_CDATE,VER_CTIME) = outstr.strip().decode("utf-8").split('.')
+
+    p = Popen("git rev-parse --short HEAD", shell=True, stdin=PIPE, stderr=PIPE, stdout=PIPE)
+    (outstr, errstr) = p.communicate()
+    VER_CHASH = outstr.strip().decode("utf-8")
+    
+    VER_LOCAL = "+{}.{}.{}".format(VER_CDATE, VER_CTIME, VER_CHASH)
+
 else:
-    VER_TSTAMP = ""
+    VER_LOCAL = ""
 
 if platform.system() != 'Darwin':
     data_files = [(os.path.join('share', 'doc', PACKAGE_NAME), ['README.md', 'LICENSE']+glob.glob('doc/*'))]
@@ -30,7 +37,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(name = PACKAGE_NAME,
-      version = "{}.{}.{}.{}{}".format(VER_MAJOR,VER_MINOR,VER_MAINT,VER_PREREL,VER_TSTAMP),
+      version = "{}.{}.{}.{}{}".format(VER_MAJOR,VER_MINOR,VER_MAINT,VER_PREREL,VER_LOCAL),
       description = "Network protocols Constructors and Dissectors",
       url = "https://www.secureauth.com/labs/open-source-tools/impacket",
       author = "SecureAuth Corporation",

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,20 @@ import os
 import platform
 
 from setuptools import setup
+from subprocess import *
 
 PACKAGE_NAME = "impacket"
+
+VER_MAJOR = 0
+VER_MINOR = 9
+VER_MAINT = 21
+VER_PREREL = "dev1"
+if call(["git", "branch"], stderr=STDOUT, stdout=open(os.devnull, 'w')) == 0:
+    p = Popen("git log -1 --format=%cd --date=format:%Y%m%d.%H%M%S", shell=True, stdin=PIPE, stderr=PIPE, stdout=PIPE)
+    (outstr, errstr) = p.communicate()
+    VER_TSTAMP = "+" + outstr.strip().decode("utf-8")
+else:
+    VER_TSTAMP = ""
 
 if platform.system() != 'Darwin':
     data_files = [(os.path.join('share', 'doc', PACKAGE_NAME), ['README.md', 'LICENSE']+glob.glob('doc/*'))]
@@ -18,7 +30,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(name = PACKAGE_NAME,
-      version = "0.9.21-dev",
+      version = "{}.{}.{}.{}{}".format(VER_MAJOR,VER_MINOR,VER_MAINT,VER_PREREL,VER_TSTAMP),
       description = "Network protocols Constructors and Dissectors",
       url = "https://www.secureauth.com/labs/open-source-tools/impacket",
       author = "SecureAuth Corporation",


### PR DESCRIPTION
Addresses Issue #760 
* Single source the version number so that the version in setup.py is used for the banner
* Standardize on Symantic + Pre-Release + Local versioning (see https://bit.ly/36QdfJX )
* Make setup.py detect whether it is in a git directory, and if so set the Local version to a date/time stamp corresponding to the last commit timestamp
* If not in a git directory, setup.py will not utilize the Local portion of the versioning
* Ensures that no two git pulls will display the same version in the banner.