### PR TITLE
Unix Keytabs & silver tickets

### DIFF
--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -65,6 +65,7 @@ from impacket.krb5.asn1 import AS_REP, TGS_REP, ETYPE_INFO2, AuthorizationData, 
 from impacket.krb5.constants import ApplicationTagNumbers, PreAuthenticationDataTypes, EncryptionTypes, \
     PrincipalNameType, ProtocolVersionNumber, TicketFlags, encodeFlags, ChecksumTypes, AuthorizationDataType, \
     KERB_NON_KERB_CKSUM_SALT
+from impacket.krb5.keytab import Keytab
 from impacket.krb5.crypto import Key, _enctype_table
 from impacket.krb5.crypto import _checksum_table, Enctype
 from impacket.krb5.pac import KERB_SID_AND_ATTRIBUTES, PAC_SIGNATURE_DATA, PAC_INFO_BUFFER, PAC_LOGON_INFO, \
@@ -84,6 +85,8 @@ class TICKETER:
             spn = options.spn.split('/')
             self.__service = spn[0]
             self.__server = spn[1]
+            if options.keytab is not None:
+                self.loadKeysFromKeytab(options.keytab)
 
         # we are creating a golden ticket
         else:
@@ -95,6 +98,17 @@ class TICKETER:
         t *= 10000000
         t += 116444736000000000
         return t
+
+    def loadKeysFromKeytab(self, filename):
+        keytab = Keytab.loadFile(filename)
+        keyblock = keytab.getKey("%s@%s" % (options.spn, self.__domain))
+        if keyblock:
+            if keyblock["keytype"] == Enctype.AES256 or keyblock["keytype"] == Enctype.AES128:
+                options.aesKey = keyblock.hexlifiedValue()
+            elif keyblock["keytype"] == Enctype.RC4:
+                options.nthash = keyblock.hexlifiedValue()
+        else:
+            logging.warning("No matching key for SPN '%s' in given keytab found!", options.spn)
 
     def createBasicValidationInfo(self):
         # 1) KERB_VALIDATION_INFO
@@ -722,6 +736,7 @@ if __name__ == '__main__':
     parser.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key used for signing the ticket '
                                                                              '(128 or 256 bits)')
     parser.add_argument('-nthash', action="store", help='NT hash used for signing the ticket')
+    parser.add_argument('-keytab', action="store", help='Read keys for SPN from keytab file (silver ticket only)')
     parser.add_argument('-groups', action="store", default = '513, 512, 520, 518, 519', help='comma separated list of '
                         'groups user will belong to (default = 513, 512, 520, 518, 519)')
     parser.add_argument('-user-id', action="store", default = '500', help='user id for the user the ticket will be '
@@ -773,8 +788,8 @@ if __name__ == '__main__':
         logging.critical('Domain should be specified!')
         sys.exit(1)
 
-    if options.aesKey is None and options.nthash is None:
-        logging.error('You have to specify either a aesKey or nthash')
+    if options.aesKey is None and options.nthash is None and options.keytab is None:
+        logging.error('You have to specify either aesKey, or nthash, or keytab')
         sys.exit(1)
 
     if options.aesKey is not None and options.nthash is not None and options.request is False:

--- a/impacket/krb5/keytab.py
+++ b/impacket/krb5/keytab.py
@@ -198,16 +198,17 @@ class Keytab:
             data += entry.getData()
         return data
 
-
     @classmethod
     def loadFile(cls, fileName):
-        with open(fileName, 'rb') as f:
-            data = f.read()
+        f = open(fileName, 'rb')
+        data = f.read()
+        f.close()
         return cls(data)
 
     def saveFile(self, fileName):
-        with open(fileName, 'wb+') as f:
-            f.write(self.getData())
+        f = open(fileName, 'wb+')
+        f.write(self.getData())
+        f.close()
 
     def prettyPrint(self):
         print("Keytab Entries:")

--- a/impacket/krb5/keytab.py
+++ b/impacket/krb5/keytab.py
@@ -1,0 +1,222 @@
+# Author: Patrick Welzel (@kcirtapw)
+#
+# Description:
+#   Kerberos Keytab format implementation
+#   based on file format described at:
+#   https://repo.or.cz/w/krb5dissect.git/blob_plain/HEAD:/keytab.txt
+#   As the ccache implementation, pretty lame and quick
+#   Feel free to improve
+#
+from datetime import datetime
+from enum import Enum
+from six import b
+
+from binascii import hexlify
+
+from impacket.structure import Structure
+
+
+class Enctype(Enum):
+    DES_CRC = 1
+    DES_MD4 = 2
+    DES_MD5 = 3
+    DES3 = 16
+    AES128 = 17
+    AES256 = 18
+    RC4 = 23
+
+
+class CountedOctetString(Structure):
+    """
+    Note: This is very similar to the CountedOctetString structure in ccache, except:
+      * `length` is uint16 instead of uint32
+    """
+    structure = (
+        ('length','!H=0'),
+        ('_data','_-data','self["length"]'),
+        ('data',':'),
+    )
+
+    def prettyPrint(self, indent=''):
+        return "%s%s" % (indent, hexlify(self['data']))
+
+
+class KeyBlock(Structure):
+    structure = (
+        ('keytype','!H=0'),
+        ('keyvalue',':', CountedOctetString),
+    )
+
+    def prettyPrint(self):
+        try:
+            keytype = Enctype(int(self['keytype'])).name
+        except:
+            keytype = "UNKNOWN:0x%x" % (self['keytype'])
+        return "(%s)%s" % (keytype, hexlify(self['keyvalue']['data']))
+
+
+class KeytabPrincipal:
+    """
+    Note: This is very similar to the principal structure in ccache, except:
+      * `num_components` is just uint16
+      * using other size type for CountedOctetString
+      * `name_type` field follows the other fields behind.
+    """
+    class PrincipalHeader1(Structure):
+        structure = (
+            ('num_components', '!H=0'),
+        )
+
+    class PrincipalHeader2(Structure):
+        structure = (
+            ('name_type', '!L=0'),
+        )
+
+    def __init__(self, data=None):
+        self.components = []
+        self.realm = None
+        if data is not None:
+            self.header1 = self.PrincipalHeader1(data)
+            data = data[len(self.header1):]
+            self.realm = CountedOctetString(data)
+            data = data[len(self.realm):]
+            self.components = []
+            for component in range(self.header1['num_components']):
+                comp = CountedOctetString(data)
+                data = data[len(comp):]
+                self.components.append(comp)
+            self.header2 = self.PrincipalHeader2(data)
+        else:
+            self.header1 = self.PrincipalHeader1()
+            self.header2 = self.PrincipalHeader2()
+
+    def __len__(self):
+        totalLen = len(self.header1) + len(self.header2) + len(self.realm)
+        for i in self.components:
+            totalLen += len(i)
+        return totalLen
+
+    def getData(self):
+        data = self.header1.getData() + self.realm.getData()
+        for component in self.components:
+            data += component.getData()
+        data += self.header2.getData()
+        return data
+
+    def __str__(self):
+        return self.getData()
+
+    def prettyPrint(self):
+        principal = b''
+        for component in self.components:
+            if isinstance(component['data'], bytes) is not True:
+                component = b(component['data'])
+            else:
+                component = component['data']
+            principal += component + b'/'
+
+        principal = principal[:-1]
+        if isinstance(self.realm['data'], bytes):
+            realm = self.realm['data']
+        else:
+            realm = b(self.realm['data'])
+        principal += b'@' + realm
+        return principal
+
+
+class KeytabEntry:
+    class KeytabEntryMainpart(Structure):
+        """
+      keytab_entry {
+          int32_t size;     # wtf, signed size. what could possibly ...
+          uint16_t num_components;    /* sub 1 if version 0x501 */  |\
+          counted_octet_string realm;                               | \  Keytab
+          counted_octet_string components[num_components];          | /  Princial
+          uint32_t name_type;   /* not present if version 0x501 */  |/
+          uint32_t timestamp;
+          uint8_t vno8;
+          keyblock key;
+          uint32_t vno; /* only present if >= 4 bytes left in entry */
+      };
+        """
+        structure = (
+            ('size', '!l=0'),
+            ('principal', ':', KeytabPrincipal),
+            ('timestamp', '!L=0'),
+            ('vno8', '!B=0'),
+            ('keyblock', ':', KeyBlock),
+        )
+
+    def __init__(self, data):
+        self.rest = b''
+        if data:
+            self.main_part = self.KeytabEntryMainpart(data)
+            if self.main_part['size'] > len(self.main_part):
+                rest_size = self.main_part['size'] - len(self.main_part)
+                self.rest = data[len(self.main_part):rest_size]
+        else:
+            self.main_part = self.KeytabEntryMainpart()
+
+    def __len__(self):
+        return max(self.main_part['size'], len(self.main_part))
+
+    def getData(self):
+        data = self.main_part.getData()
+        if self.rest:
+            data += self.rest
+        return data
+
+    def prettyPrint(self, indent=''):
+        text = "%sPrincipal: %s\n" %(indent, self.main_part['principal'].prettyPrint())
+        text += "%sTimestamp: %s\n" % (indent, datetime.fromtimestamp(self.main_part['timestamp']).isoformat())
+        text += "%sKey: %s" % (indent, self.main_part['keyblock'].prettyPrint())
+        if self.rest:
+            text += "\n%sRest: %s" % (indent, self.rest)
+        return text
+
+
+class Keytab:
+    class MiniHeader(Structure):
+        structure = (
+            ('file_format_version', '!H=0x0502'),
+        )
+
+    def __init__(self, data=None):
+        self.miniHeader = None
+        self.entries = []
+        if data is not None:
+            self.miniHeader = self.MiniHeader(data)
+            data = data[len(self.miniHeader):]
+            while len(data):
+                entry = KeytabEntry(data)
+                self.entries.append(entry)
+                data = data[len(entry):]
+
+    def getData(self):
+        data = self.MiniHeader().getData()
+        for entry in self.entries:
+            data += entry.getData()
+        return data
+
+
+    @classmethod
+    def loadFile(cls, fileName):
+        with open(fileName, 'rb') as f:
+            data = f.read()
+        return cls(data)
+
+    def saveFile(self, fileName):
+        with open(fileName, 'wb+') as f:
+            f.write(self.getData())
+
+    def prettyPrint(self):
+        print("Keytab Entries:")
+        for i, entry in enumerate(self.entries):
+            print(("[%d]" % i))
+            print(entry.prettyPrint('\t'))
+
+
+if __name__ == '__main__':
+    import sys
+    keytab = Keytab.loadFile(sys.argv[1])
+    keytab.prettyPrint()


### PR DESCRIPTION
Hi there!

Recently I was looking into some kerberized UNIX (mainly Linux) systems and was missing the usual comfort of impacket when dealing with keytabs. While it can handle Tickets in CCaches all fine, there was no support for keytabs - the very files where credentials get stored in cleartext.

While there is [this project](https://github.com/sosdave/KeyTabExtract) to extract keys from keytabs, it is not parsing keytabs properly and especially fails to get keys for more then the first principal out.

This pull request implements a proper keytab parser and also adds an option to example/ticketer.py to directly use the SPNs keys from a keytab for a silver ticket.