### PR TITLE
Remove options.ts on line 54

### DIFF
--- a/examples/smbserver.py
+++ b/examples/smbserver.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
        logging.critical(str(e))
        sys.exit(1)
 
-    logger.init(options.ts)
+    logger.init()
 
     if options.debug is True:
         logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION
This returns the error:
```
Impacket v0.9.20 - Copyright 2019 SecureAuth Corporation

Traceback (most recent call last):
  File "smbserver.py", line 54, in <module>
    logger.init(options.ts)
TypeError: init() takes no arguments (1 given)
```
If removed, the error is fixed