### PR TITLE
Fix: default list shared across all Machine objects

### DIFF
--- a/examples/nmapAnswerMachine.py
+++ b/examples/nmapAnswerMachine.py
@@ -745,7 +745,7 @@ class nmap2_ICMP_2(NMAP2ICMPResponder):
 
 class Machine:
    AssumedTimeIntervalPerPacket = 0.11 # seconds
-   def __init__(self, emmulating, interface, ipAddress, macAddress, openTCPPorts = [], openUDPPorts = [], nmapOSDB = 'nmap-os-db'):
+   def __init__(self, emmulating, interface, ipAddress, macAddress, openTCPPorts = None, openUDPPorts = None, nmapOSDB = 'nmap-os-db'):
        self.interface = interface
        self.ipAddress = ipAddress
        self.macAddress = macAddress
@@ -756,7 +756,11 @@ class Machine:
        self.initFingerprint(emmulating, nmapOSDB)
 
        self.initSequenceGenerators()
+       if openTCPPorts is None:
+           openTCPPorts = []
        self.openTCPPorts = openTCPPorts
+       if openUDPPorts is None:
+           openUDPPorts = []
        self.openUDPPorts = openUDPPorts
        print(self)
 


### PR DESCRIPTION
Hello,
I am a security engineer at r2c.dev. We are working to write code
checks for security in open source code.

In python, the default values of function parameters are instantiated
at function definition time. All calls to that function that use the
default value all point to the same global object. e.g.:

```
def func(x=[]):
   x.append(1)
   print(x)

func() # [1]
func() # [1 , 1]
```

Because of this, two instances of Machine (initialized without passing
in a protocol_config option) actually have self.openUDPPorts point to
the same list. So calling openUDPPort on one Machine object will also
possibly add that port to another Machine object.

It looks like this is just example code anyway so it doesn't really matter
but I went ahead and made a PR to address this.

Fix:
The recommended solution is to either set default to None and assign
a new empty object when the variable is None.

I went ahead and proactively made openTCPPorts follow the same safer
pattern.

We have an open-source tool called Bento you can use for your project that continuously detects problems like this one. The check that identified this will be available in the very near future.

Thanks, and I hope this helps! Let me know if you have any questions.