### PR TITLE
Ntlmrelayx and byte strings fixes

### DIFF
--- a/examples/addcomputer.py
+++ b/examples/addcomputer.py
@@ -332,10 +332,10 @@ class ADDCOMPUTER:
 
                 # retrieve user information from CCache file if needed
                 if user == '' and creds is not None:
-                    user = creds['client'].prettyPrint().split(b'@')[0]
+                    user = creds['client'].prettyPrint().split(b'@')[0].decode('utf-8')
                     logging.debug('Username retrieved from CCache: %s' % user)
                 elif user == '' and len(ccache.principal.components) > 0:
-                    user = ccache.principal.components[0]['data']
+                    user = ccache.principal.components[0]['data'].decode('utf-8')
                     logging.debug('Username retrieved from CCache: %s' % user)
 
         # First of all, we need to get a TGT for the user

--- a/examples/atexec.py
+++ b/examples/atexec.py
@@ -268,7 +268,7 @@ if __name__ == '__main__':
         CODEC = options.codec
     else:
         if CODEC is None:
-            CODEC = 'UTF-8'
+            CODEC = 'utf-8'
 
     logging.warning("This will work ONLY on Windows >= Vista")
 

--- a/examples/dcomexec.py
+++ b/examples/dcomexec.py
@@ -557,7 +557,7 @@ if __name__ == '__main__':
         CODEC = options.codec
     else:
         if CODEC is None:
-            CODEC = 'UTF-8'
+            CODEC = 'utf-8'
 
     if ' '.join(options.command) == ' ' and options.nooutput is True:
         logging.error("-nooutput switch and interactive shell not supported")

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -341,7 +341,7 @@ if __name__ == '__main__':
         CODEC = options.codec
     else:
         if CODEC is None:
-            CODEC = 'UTF-8'
+            CODEC = 'utf-8'
 
     if options.debug is True:
         logging.getLogger().setLevel(logging.DEBUG)

--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -378,7 +378,7 @@ if __name__ == '__main__':
         CODEC = options.codec
     else:
         if CODEC is None:
-            CODEC = 'UTF-8'
+            CODEC = 'utf-8'
 
     if ' '.join(options.command) == ' ' and options.nooutput is True:
         logging.error("-nooutput switch and interactive shell not supported")

--- a/impacket/examples/ntlmrelayx/attacks/smbattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/smbattack.py
@@ -39,7 +39,7 @@ class SMBAttack(ProtocolAttack):
             self.__SMBConnection = SMBConnection(existingConnection=SMBClient)
         else:
             self.__SMBConnection = SMBClient
-        self.__answerTMP = ''
+        self.__answerTMP = bytearray()
         if self.config.interactive:
             #Launch locally listening interactive shell
             self.tcpshell = TcpShell()
@@ -100,7 +100,6 @@ class SMBAttack(ProtocolAttack):
                 if self.config.command is not None:
                     remoteOps._RemoteOperations__executeRemote(self.config.command)
                     LOG.info("Executed specified command on host: %s", self.__SMBConnection.getRemoteHost())
-                    self.__answerTMP = ''
                     self.__SMBConnection.getFile('ADMIN$', 'Temp\\__output', self.__answer)
                     self.__SMBConnection.deleteFile('ADMIN$', 'Temp\\__output')
                     print(self.__answerTMP.decode(self.config.encoding, 'replace'))

--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -359,7 +359,7 @@ class CCache:
         for c in self.credentials:
             if c['server'].prettyPrint().upper() == b(server.upper()) or c['server'].prettyPrint().upper().split(b'@')[0] == b(server.upper())\
                     or c['server'].prettyPrint().upper().split(b'@')[0] == b(server.upper().split('@')[0]):
-                LOG.debug('Returning cached credential for %s' % c['server'].prettyPrint().upper())
+                LOG.debug('Returning cached credential for %s' % c['server'].prettyPrint().upper().decode('utf-8'))
                 return c
         LOG.debug('SPN %s not found in cache' % server.upper())
         if anySPN is True:
@@ -373,7 +373,7 @@ class CCache:
                     searchSPN = '%s@%s' % (server.upper().split('/')[1].split('@')[0].split(':')[0],
                                                server.upper().split('/')[1].split('@')[1])
                     if cachedSPN == b(searchSPN):
-                        LOG.debug('Returning cached credential for %s' % c['server'].prettyPrint().upper())
+                        LOG.debug('Returning cached credential for %s' % c['server'].prettyPrint().upper().decode('utf-8'))
                         return c
 
         return None

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -557,10 +557,10 @@ def getKerberosType1(username, password, domain, lmhash, nthash, aesKey='', TGT 
 
                 # retrieve user information from CCache file if needed
                 if username == '' and creds is not None:
-                    username = creds['client'].prettyPrint().split(b'@')[0]
+                    username = creds['client'].prettyPrint().split(b'@')[0].decode('utf-8')
                     LOG.debug('Username retrieved from CCache: %s' % username)
                 elif username == '' and len(ccache.principal.components) > 0:
-                    username = ccache.principal.components[0]['data']
+                    username = ccache.principal.components[0]['data'].decode('utf-8')
                     LOG.debug('Username retrieved from CCache: %s' % username)
 
     # First of all, we need to get a TGT for the user

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -190,10 +190,10 @@ class LDAPConnection:
 
                 # retrieve user information from CCache file if needed
                 if user == '' and creds is not None:
-                    user = creds['client'].prettyPrint().split(b'@')[0]
+                    user = creds['client'].prettyPrint().split(b'@')[0].decode('utf-8')
                     LOG.debug('Username retrieved from CCache: %s' % user)
                 elif user == '' and len(ccache.principal.components) > 0:
-                    user = ccache.principal.components[0]['data']
+                    user = ccache.principal.components[0]['data'].decode('utf-8')
                     LOG.debug('Username retrieved from CCache: %s' % user)
 
         # First of all, we need to get a TGT for the user

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -331,10 +331,10 @@ class SMBConnection:
 
                 # retrieve user information from CCache file if needed
                 if user == '' and creds is not None:
-                    user = creds['client'].prettyPrint().split(b'@')[0]
+                    user = creds['client'].prettyPrint().split(b'@')[0].decode('utf-8')
                     LOG.debug('Username retrieved from CCache: %s' % user)
                 elif user == '' and len(ccache.principal.components) > 0:
-                    user = ccache.principal.components[0]['data']
+                    user = ccache.principal.components[0]['data'].decode('utf-8')
                     LOG.debug('Username retrieved from CCache: %s' % user)
 
         while True:

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -755,10 +755,10 @@ class MSSQL:
 
                 # retrieve user information from CCache file if needed
                 if username == '' and creds is not None:
-                    username = creds['client'].prettyPrint().split(b'@')[0]
+                    username = creds['client'].prettyPrint().split(b'@')[0].decode('utf-8')
                     LOG.debug('Username retrieved from CCache: %s' % username)
                 elif username == '' and len(ccache.principal.components) > 0:
-                    username = ccache.principal.components[0]['data']
+                    username = ccache.principal.components[0]['data'].decode('utf-8')
                     LOG.debug('Username retrieved from CCache: %s' % username)
 
         # First of all, we need to get a TGT for the user


### PR DESCRIPTION
There was a bug with byte strings concatenation in ntlmrelayx.py (see the last lines)

Before the fix

```
root@kali:~# ntlmrelayx.py -t smb://10.0.0.10 -smb2support -c "whoami"
Impacket v0.9.21.dev1+20200302.101613.eae8757f - Copyright 2020 SecureAuth Corporation

[*] Protocol Client HTTP loaded..
[*] Protocol Client HTTPS loaded..
[*] Protocol Client SMB loaded..
[*] Protocol Client LDAPS loaded..
[*] Protocol Client LDAP loaded..
[*] Protocol Client MSSQL loaded..
[*] Protocol Client SMTP loaded..
[*] Protocol Client IMAPS loaded..
[*] Protocol Client IMAP loaded..
[*] Running in relay mode to single host
[*] Setting up SMB Server
[*] Setting up HTTP Server
[*] Servers started, waiting for connections
[*] SMBD-Thread-3: Connection from CONTOSO.COM/ADMIN@10.0.0.5 controlled, attacking target smb://10.0.0.10
[*] Authenticating against smb://10.0.0.10 as CONTOSO.COM/ADMIN SUCCEED
[*] SMBD-Thread-3: Connection from CONTOSO.COM/ADMIN@10.0.0.5 controlled, but there are no more targets left!
[*] Executed specified command on host: 10.0.0.10
[-] can only concatenate str (not "bytes") to str
```

After the fix

```
root@kali:~# ntlmrelayx.py -t smb://10.0.0.10 -smb2support -c "whoami"
Impacket v0.9.21.dev1+20200302.101613.eae8757f - Copyright 2020 SecureAuth Corporation

[*] Protocol Client HTTP loaded..
[*] Protocol Client HTTPS loaded..
[*] Protocol Client SMB loaded..
[*] Protocol Client LDAP loaded..
[*] Protocol Client LDAPS loaded..
[*] Protocol Client MSSQL loaded..
[*] Protocol Client SMTP loaded..
[*] Protocol Client IMAPS loaded..
[*] Protocol Client IMAP loaded..
[*] Running in relay mode to single host
[*] Setting up SMB Server
[*] Setting up HTTP Server
[*] Servers started, waiting for connections
[*] SMBD-Thread-3: Connection from CONTOSO.COM/ADMIN@10.0.0.5 controlled, attacking target smb://10.0.0.10
[*] Authenticating against smb://10.0.0.10 as CONTOSO.COM/ADMIN SUCCEED
[*] SMBD-Thread-3: Connection from CONTOSO.COM/ADMIN@10.0.0.5 controlled, but there are no more targets left!
[*] Executed specified command on host: 10.0.0.10
nt authority\system
```


Also, displaying of byte strings in debug mode was fixed (b'' prefix was removed)

Before

```
root@kali:~# KRB5CCNAME=Administrator.ccache GetUserSPNs.py -k -no-pass contoso.com/ -debug
Impacket v0.9.21.dev1+20200302.101613.eae8757f - Copyright 2020 SecureAuth Corporation

[+] Impacket Library Installation Path: /usr/local/lib/python3.7/dist-packages/impacket
[+] Connecting to DC01.contoso.com, port 389, SSL False
[+] Using Kerberos Cache: Administrator.ccache
[+] SPN LDAP/DC01.CONTOSO.COM@CONTOSO.COM not found in cache
[+] AnySPN is True, looking for another suitable SPN
[+] Returning cached credential for b'KRBTGT/CONTOSO.COM@CONTOSO.COM'
[+] Using TGT from cache
[+] Username retrieved from CCache: b'Administrator'
[+] Trying to connect to KDC at CONTOSO.COM
[+] Total of records returned 3
No entries found!
```

After

```
root@kali:~# KRB5CCNAME=Administrator.ccache GetUserSPNs.py -k -no-pass contoso.com/ -debug
Impacket v0.9.21.dev1+20200302.101613.eae8757f - Copyright 2020 SecureAuth Corporation

[+] Impacket Library Installation Path: /usr/local/lib/python3.7/dist-packages/impacket
[+] Connecting to DC01.contoso.com, port 389, SSL False
[+] Using Kerberos Cache: Administrator.ccache
[+] SPN LDAP/DC01.CONTOSO.COM@CONTOSO.COM not found in cache
[+] AnySPN is True, looking for another suitable SPN
[+] Returning cached credential for KRBTGT/CONTOSO.COM@CONTOSO.COM
[+] Using TGT from cache
[+] Username retrieved from CCache: Administrator
[+] Trying to connect to KDC at CONTOSO.COM
[+] Total of records returned 3
No entries found!
```