### PR TITLE
Change padding between negotiate contexts

### DIFF
--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -504,7 +504,7 @@ class SMB3:
                     negotiateContext['Data'] = preAuthIntegrityCapabilities.getData()
                     negotiateContext['DataLength'] = len(negotiateContext['Data'])
                     contextData['NegotiateContextCount'] += 1
-                    pad = b'\xFF' * (8 - (negotiateContext['DataLength'] % 8))
+                    pad = b'\xFF' * ((8 - (negotiateContext['DataLength'] % 8)) % 8)
 
                     # Add an SMB2_NEGOTIATE_CONTEXT with ContextType as SMB2_ENCRYPTION_CAPABILITIES
                     # to the negotiate request as specified in section 2.2.3.1 and initialize


### PR DESCRIPTION
Since `Subsequent negotiate contexts MUST appear at the first 8-byte aligned offset following the previous negotiate context`, when a negotiate context's end is already 8-byte aligned, I think padding should be 0 and not 8.

Disclaimer: I haven't tested this on Microsoft's implementation, I just read the protocol specifications 