### PR TITLE
Add error handling for hashes extraction in secretsdump.py

### DIFF
--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1213,6 +1213,10 @@ class SAMHashes(OfflineRegistry):
 
             userName = V[userAccount['NameOffset']:userAccount['NameOffset']+userAccount['NameLength']].decode('utf-16le')
 
+            if userAccount['NTHashLength'] == 0:
+                logging.error('SAM hashes extraction for user %s failed. The account doesn\'t have hash information.' % userName)
+                continue
+
             encNTHash = b''
             if V[userAccount['NTHashOffset']:][2:3] == b'\x01':
                 # Old Style hashes


### PR DESCRIPTION
After the Fall Creators Update (version 1709), Windows installations present a special account named WDAGUtilityAccount. This account is part of the Windows Defender Application Guard and is often disabled.
In Windows Server 2019, this account, when WDAG is disabled, doesn't have hash information. For this reason, when secretsdump.py is processing the account, the local SAM hashes extraction fails.
This PR adds error handling in local extractions for accounts that, for some reason, don't have hash information.