### PR TITLE
Don't read entire user file into memory.

### DIFF
--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -318,9 +318,11 @@ class GetUserNoPreAuth:
     def request_users_file_TGTs(self):
 
         with open(self.__usersFile) as fi:
-            usernames = [line.strip() for line in fi]
+          def _usernames(fi):
+            for line in fi:
+              yield line
 
-        self.request_multiple_TGTs(usernames)
+          self.request_multiple_TGTs(_usernames(fi))
 
     def request_multiple_TGTs(self, usernames):
         if self.__outputFileName is not None:


### PR DESCRIPTION
Instead, use a generator to read it line by line.  This has a number of  benefits:
1. For larger files, we start making requests immediately instead of loading it into memory first
2. We can use larger files period
3. We can use named pipes and stream users in from another tool (my main reason for making this change)

I've tested this change under Python 2.  Should be fine under Python 3 as well.  Let me know if its not and I'll fix it.

I don't have access to a 2012 DC so I can't run the test suite.

If there are similar issues in other scripts let me know and I'll submit PRs for them as well.

Thanks!
