### PR TITLE
Fix warning with python3.8

### DIFF
--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -2461,7 +2461,7 @@ class SMBCommands:
                                                             authenticateMessage['domain_name'],
                                                             authenticateMessage['lanman'], authenticateMessage['ntlm'])
                         smbServer.log(ntlm_hash_data['hash_string'])
-                        if jtr_dump_path is not '':
+                        if jtr_dump_path != '':
                             writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'], jtr_dump_path)
                     except:
                         smbServer.log("Could not write NTLM Hashes to the specified JTR_Dump_Path %s" % jtr_dump_path)
@@ -2497,7 +2497,7 @@ class SMBCommands:
                 jtr_dump_path = smbServer.getJTRdumpPath()
                 ntlm_hash_data = outputToJohnFormat( b'', sessionSetupData['Account'], sessionSetupData['PrimaryDomain'], sessionSetupData['AnsiPwd'], sessionSetupData['UnicodePwd'] )
                 smbServer.log(ntlm_hash_data['hash_string'])
-                if jtr_dump_path is not '':
+                if jtr_dump_path != '':
                     writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'], jtr_dump_path)
             except:
                 smbServer.log("Could not write NTLM Hashes to the specified JTR_Dump_Path %s" % jtr_dump_path)
@@ -2839,7 +2839,7 @@ class SMB2Commands:
                                                         authenticateMessage['domain_name'],
                                                         authenticateMessage['lanman'], authenticateMessage['ntlm'])
                     smbServer.log(ntlm_hash_data['hash_string'])
-                    if jtr_dump_path is not '':
+                    if jtr_dump_path != '':
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
                                               jtr_dump_path)
                 except:
@@ -4413,7 +4413,7 @@ smb.SMB.TRANS_TRANSACT_NMPIPE          :self.__smbTransHandler.transactNamedPipe
 
         # Process the credentials
         credentials_fname = self.__serverConfig.get('global','credentials_file')
-        if credentials_fname is not "":
+        if credentials_fname != "":
             cred = open(credentials_fname)
             line = cred.readline()
             while line:


### PR DESCRIPTION
When installing impacket :) 

![image](https://user-images.githubusercontent.com/5891788/79871794-33524300-83e5-11ea-9a6e-11e96967536f.png)


https://docs.python.org/3.8/whatsnew/3.8.html#changes-in-python-behavior

> The compiler now produces a SyntaxWarning when identity checks (is and is not) are used with certain types of literals (e.g. strings, numbers). These can often work by accident in CPython, but are not guaranteed by the language spec. The warning advises users to use equality tests (== and !=) instead. (Contributed by Serhiy Storchaka in bpo-34850.)