### PR TITLE
Decode bytes file before reading them (smb)

### DIFF
--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -2994,6 +2994,8 @@ class SMB(object):
         while read_offset < datasize:
             data = self.read_andx(tid, fid, read_offset, max_buf_size)
 
+            if isinstance(data, bytes):
+                data = data.decode("utf-8")
             callback(data)
             read_offset += len(data)
 


### PR DESCRIPTION
This PR fix encoding problem from CME https://github.com/byt3bl33d3r/CrackMapExec/issues/350 when reading a file encoded as byte

![image](https://user-images.githubusercontent.com/5891788/79990783-c193fb00-84b1-11ea-9a39-1c048798243b.png)
