### PR TITLE
smbserver.py: check case insensitive NTLM username

### DIFF
--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -2424,7 +2424,7 @@ class SMBCommands:
                 authenticateMessage['host_name'].decode('utf-16le')))
                 # Do we have credentials to check?
                 if len(smbServer.getCredentials()) > 0:
-                    identity = authenticateMessage['user_name'].decode('utf-16le')
+                    identity = authenticateMessage['user_name'].decode('utf-16le').lower()
                     # Do we have this user's credentials?
                     if identity in smbServer.getCredentials():
                         # Process data:
@@ -2801,7 +2801,7 @@ class SMB2Commands:
             # Do we have credentials to check?
             if len(smbServer.getCredentials()) > 0:
                 isGuest = False
-                identity = authenticateMessage['user_name'].decode('utf-16le')
+                identity = authenticateMessage['user_name'].decode('utf-16le').lower()
                 # Do we have this user's credentials?
                 if identity in smbServer.getCredentials():
                     # Process data:
@@ -4435,7 +4435,7 @@ smb.SMB.TRANS_TRANSACT_NMPIPE          :self.__smbTransHandler.transactNamedPipe
                 nthash = a2b_hex(nthash)
             except:
                 pass
-        self.__credentials[name] = (uid, lmhash, nthash)
+        self.__credentials[name.lower()] = (uid, lmhash, nthash)
 
 # For windows platforms, opening a directory is not an option, so we set a void FD
 VOID_FILE_DESCRIPTOR = -1


### PR DESCRIPTION
I believe Windows usernames are case insensitive. In smbserver credentials are
stored in the server in the exact manner they are provided by the user and fetched
using the username provided in the AUTH message as the key of the
dictionnary. If there is a difference in the case, credentials are not
found and the authentication fails.
Should not credentials be checked case insensitive ?