### PR TITLE
Ntlmrelay.px fixes

### DIFF
--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -320,6 +320,7 @@ class SMBRelayServer(Thread):
                                           self.server.getJTRdumpPath())
 
                 connData['Authenticated'] = True
+                del(connData['relayToHost'])
 
                 self.do_attack(client)
                 # Now continue with the server
@@ -372,7 +373,7 @@ class SMBRelayServer(Thread):
                          (connId, self.authUser, connData['ClientIP']))
                 return self.origsmb2TreeConnect (connId, smbServer, recvPacket)
 
-            LOG.info('SMBD-%s: Connection from %s@%s controlled, attacking target %s://%s' % ( connId, self.authUser,
+            LOG.info('SMBD-%s: Connection from %s@%s controlled, attacking target %s://%s' % (connId, self.authUser,
                                                         connData['ClientIP'], self.target.scheme, self.target.netloc))
 
             if self.config.mode.upper() == 'REFLECTION':
@@ -659,6 +660,7 @@ class SMBRelayServer(Thread):
 
         # From now on, the client can ask for other commands
         connData['Authenticated'] = True
+        del(connData['relayToHost'])
 
         smbServer.setConnectionData(connId, connData)
 

--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -177,7 +177,11 @@ class SMBRelayServer(Thread):
         # Are we ready to relay or should we just do local auth?
         if 'relayToHost' not in connData:
             # Just call the original SessionSetup
-            return self.origSmbSessionSetup(connId, smbServer, recvPacket)
+            respCommands, respPackets, errorCode = self.origSmbSessionSetup(connId, smbServer, recvPacket)
+            # We remove the Guest flag
+            if 'SessionFlags' in respCommands[0].fields:
+                respCommands[0]['SessionFlags'] = 0x00
+            return respCommands, respPackets, errorCode
 
         # We have confirmed we want to relay to the target host.
         respSMBCommand = smb3.SMB2SessionSetup_Response()


### PR DESCRIPTION
This PR addresses: 
- Some exploitations or techniques that activate the NTLMrelay, like printerbug.py, have special behaviors that affect the correct functioning of LDAP attacks. 
- Fix relaying on new Windows versions that have SMB guest access disabled by default.

This PR should fix #686, #794, #821