### PR TITLE
Add -dc-host option

### DIFF
--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -25,6 +25,7 @@ from __future__ import unicode_literals
 import argparse
 import logging
 import sys
+import re
 from datetime import datetime
 
 from impacket import version
@@ -40,12 +41,14 @@ class GetADUsers:
         self.__username = username
         self.__password = password
         self.__domain = domain
+        self.__target = None
         self.__lmhash = ''
         self.__nthash = ''
         self.__aesKey = cmdLineOptions.aesKey
         self.__doKerberos = cmdLineOptions.k
-        self.__target = None
-        self.__kdcHost = cmdLineOptions.dc_ip
+        #[!] in this script the value of -dc-ip option is self.__kdcIP and the value of -dc-host option is self.__kdcHost
+        self.__kdcIP = cmdLineOptions.dc_ip
+        self.__kdcHost = cmdLineOptions.dc_host
         self.__requestUser = cmdLineOptions.user
         self.__all = cmdLineOptions.all
         if cmdLineOptions.hashes is not None:
@@ -65,14 +68,9 @@ class GetADUsers:
         self.__colLen = [20, 30, 19, 19]
         self.__outputFormat = ' '.join(['{%d:%ds} ' % (num, width) for num, width in enumerate(self.__colLen)])
 
-    def getMachineName(self):
+    def getMachineName(self, target):
         # Python 2: socket.error handling
         from socket import error as SocketError
-
-        if self.__kdcHost is not None:
-            target = self.__kdcHost
-        else:
-            target = self.__domain
 
         try:
             s = SMBConnection(target, target)
@@ -82,7 +80,7 @@ class GetADUsers:
                 raise Exception('The connection is timed out. '
                                 'Probably 445/TCP port is closed. '
                                 'Try to specify corresponding NetBIOS name or FQDN '
-                                'instead of IP address')
+                                'as the value of the -dc-host option')
             else:
                 raise
         except Exception:
@@ -131,32 +129,38 @@ class GetADUsers:
             pass
 
     def run(self):
-        if self.__doKerberos:
-            self.__target = self.getMachineName()
+        if self.__kdcHost is not None:
+            self.__target = self.__kdcHost
         else:
-            if self.__kdcHost is not None:
-                self.__target = self.__kdcHost
+            if self.__kdcIP is not None:
+                self.__target = self.__kdcIP
             else:
                 self.__target = self.__domain
 
+            if self.__doKerberos:
+                logging.info('Getting machine hostname')
+                self.__target = self.getMachineName(self.__target)
+
         # Connect to LDAP
         try:
-            ldapConnection = ldap.LDAPConnection('ldap://%s'%self.__target, self.baseDN, self.__kdcHost)
+            ldapConnection = ldap.LDAPConnection('ldap://%s' % self.__target, self.baseDN, self.__kdcIP)
             if self.__doKerberos is not True:
                 ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
             else:
                 ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
-                                             self.__aesKey, kdcHost=self.__kdcHost)
+                                             self.__aesKey, kdcHost=self.__kdcIP)
         except ldap.LDAPSessionError as e:
             if str(e).find('strongerAuthRequired') >= 0:
                 # We need to try SSL
-                ldapConnection = ldap.LDAPConnection('ldaps://%s' % self.__target, self.baseDN, self.__kdcHost)
+                ldapConnection = ldap.LDAPConnection('ldaps://%s' % self.__target, self.baseDN, self.__kdcIP)
                 if self.__doKerberos is not True:
                     ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
                 else:
                     ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
-                                                 self.__aesKey, kdcHost=self.__kdcHost)
+                                                 self.__aesKey, kdcHost=self.__kdcIP)
             else:
+                if self.__kdcIP is not None and self.__kdcHost is not None:
+                    logging.critical("If the credentials are valid, check the hostname and IP address of KDC. They must match exactly each other")
                 raise
 
         logging.info('Querying %s for information about domain.' % self.__target)
@@ -192,7 +196,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(add_help = True, description = "Queries target domain for users data")
 
-    parser.add_argument('target', action='store', help='domain/username[:password]')
+    parser.add_argument('target', action='store', help='domain[/username[:password]]')
     parser.add_argument('-user', action='store', metavar='username', help='Requests data for specific user ')
     parser.add_argument('-all', action='store_true', help='Return all users, including those with no email '
                                                            'addresses and disabled accounts. When used with -user it '
@@ -201,7 +205,6 @@ if __name__ == '__main__':
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
 
     group = parser.add_argument_group('authentication')
-
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
     group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful for -k)')
     group.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file '
@@ -210,9 +213,14 @@ if __name__ == '__main__':
                                                        'line')
     group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication '
                                                                             '(128 or 256 bits)')
-    group.add_argument('-dc-ip', action='store',metavar = "ip address",  help='IP Address of the domain controller. If '
+
+    group = parser.add_argument_group('connection')
+    group.add_argument('-dc-ip', action='store', metavar='ip address', help='IP Address of the domain controller. If '
                                                                               'ommited it use the domain part (FQDN) '
                                                                               'specified in the target parameter')
+    group.add_argument('-dc-host', action='store', metavar='hostname', help='Hostname of the domain controller to use. '
+                                                                              'If ommited, the domain part (FQDN) '
+                                                                              'specified in the account parameter will be used')
 
     if len(sys.argv)==1:
         parser.print_help()
@@ -230,7 +238,6 @@ if __name__ == '__main__':
     else:
         logging.getLogger().setLevel(logging.INFO)
 
-    import re
     domain, username, password = re.compile('(?:(?:([^/:]*)/)?([^:]*)(?::(.*))?)?').match(options.target).groups('')
 
     if domain == '':

--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -65,18 +65,29 @@ class GetADUsers:
         self.__colLen = [20, 30, 19, 19]
         self.__outputFormat = ' '.join(['{%d:%ds} ' % (num, width) for num, width in enumerate(self.__colLen)])
 
-
-
     def getMachineName(self):
+        # Python 2: socket.error handling
+        from socket import error as SocketError
+
         if self.__kdcHost is not None:
-            s = SMBConnection(self.__kdcHost, self.__kdcHost)
+            target = self.__kdcHost
         else:
-            s = SMBConnection(self.__domain, self.__domain)
+            target = self.__domain
+
         try:
+            s = SMBConnection(target, target)
             s.login('', '')
+        except (SocketError, OSError) as e:
+            if str(e).find('timed out') > 0:
+                raise Exception('The connection is timed out. '
+                                'Probably 445/TCP port is closed. '
+                                'Try to specify corresponding NetBIOS name or FQDN '
+                                'instead of IP address')
+            else:
+                raise
         except Exception:
             if s.getServerName() == '':
-                raise Exception('Error while anonymous logging into %s' % self.__domain)
+                raise Exception('Error while anonymous logging into %s' % target)
         else:
             s.logoff()
         return s.getServerName()

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -99,22 +99,30 @@ class GetUserSPNs:
             self.__kdcHost = None
 
     def getMachineName(self):
+        # Python 2: socket.error handling
+        from socket import error as SocketError
+
         if self.__kdcHost is not None and self.__targetDomain == self.__domain:
-            s = SMBConnection(self.__kdcHost, self.__kdcHost)
+            target = self.__kdcHost
         else:
-            s = SMBConnection(self.__targetDomain, self.__targetDomain)
+            target = self.__targetDomain
+
         try:
+            s = SMBConnection(target, target)
             s.login('', '')
+        except (SocketError, OSError) as e:
+            if str(e).find('timed out') > 0:
+                raise Exception('The connection is timed out. '
+                                'Probably 445/TCP port is closed. '
+                                'Try to specify corresponding NetBIOS name or FQDN '
+                                'instead of IP address')
+            else:
+                raise
         except Exception:
             if s.getServerName() == '':
-                raise 'Error while anonymous logging into %s'
+                raise Exception('Error while anonymous logging into %s' % target)
         else:
-            try:
-                s.logoff()
-            except Exception:
-                # We don't care about exceptions here as we already have the required
-                # information. This also works around the current SMB3 bug
-                pass
+            s.logoff()
         return "%s.%s" % (s.getServerName(), s.getServerDNSDomainName())
 
     @staticmethod

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -151,7 +151,7 @@ class GetUserSPNs:
                 logging.debug('Using TGT from cache')
                 return TGT
             else:
-                logging.debug("No valid credentials found in cache. ")
+                logging.debug("No valid credentials found in cache.")
 
         # No TGT in cache, request it
         userName = Principal(self.__username, type=constants.PrincipalNameType.NT_PRINCIPAL.value)

--- a/examples/findDelegation.py
+++ b/examples/findDelegation.py
@@ -76,22 +76,30 @@ class FindDelegation:
             self.__kdcHost = None
 
     def getMachineName(self):
+        # Python 2: socket.error handling
+        from socket import error as SocketError
+
         if self.__kdcHost is not None and self.__targetDomain == self.__domain:
-            s = SMBConnection(self.__kdcHost, self.__kdcHost)
+            target = self.__kdcHost
         else:
-            s = SMBConnection(self.__targetDomain, self.__targetDomain)
+            target = self.__targetDomain
+
         try:
+            s = SMBConnection(target, target)
             s.login('', '')
+        except (SocketError, OSError) as e:
+            if str(e).find('timed out') > 0:
+                raise Exception('The connection is timed out. '
+                                'Probably 445/TCP port is closed. '
+                                'Try to specify corresponding NetBIOS name or FQDN '
+                                'instead of IP address')
+            else:
+                raise
         except Exception:
             if s.getServerName() == '':
-                raise Exception('Error while anonymous logging into %s')
+                raise Exception('Error while anonymous logging into %s' % target)
         else:
-            try:
-                s.logoff()
-            except Exception:
-                # We don't care about exceptions here as we already have the required
-                # information. This also works around the current SMB3 bug
-                pass
+            s.logoff()
         return "%s.%s" % (s.getServerName(), s.getServerDNSDomainName())
     
 

--- a/examples/findDelegation.py
+++ b/examples/findDelegation.py
@@ -21,6 +21,7 @@ from __future__ import print_function
 import argparse
 import logging
 import sys
+import re
 
 from impacket import version
 from impacket.dcerpc.v5.samr import UF_ACCOUNTDISABLE, UF_TRUSTED_FOR_DELEGATION, UF_TRUSTED_TO_AUTHENTICATE_FOR_DELEGATION
@@ -52,12 +53,15 @@ class FindDelegation:
         self.__username = username
         self.__password = password
         self.__domain = user_domain
+        self.__target = None
         self.__targetDomain = target_domain
         self.__lmhash = ''
         self.__nthash = ''
         self.__aesKey = cmdLineOptions.aesKey
         self.__doKerberos = cmdLineOptions.k
-        self.__kdcHost = cmdLineOptions.dc_ip
+        #[!] in this script the value of -dc-ip option is self.__kdcIP and the value of -dc-host option is self.__kdcHost
+        self.__kdcIP = cmdLineOptions.dc_ip
+        self.__kdcHost = cmdLineOptions.dc_host
         if cmdLineOptions.hashes is not None:
             self.__lmhash, self.__nthash = cmdLineOptions.hashes.split(':')
 
@@ -68,21 +72,17 @@ class FindDelegation:
             self.baseDN += 'dc=%s,' % i
         # Remove last ','
         self.baseDN = self.baseDN[:-1]
-        # We can't set the KDC to a custom IP when requesting things cross-domain
+        # We can't set the KDC to a custom IP or Hostname when requesting things cross-domain
         # because then the KDC host will be used for both
         # the initial and the referral ticket, which breaks stuff.
-        if user_domain != target_domain and self.__kdcHost:
-            logging.warning('DC ip will be ignored because of cross-domain targeting.')
+        if user_domain != self.__targetDomain and (self.__kdcIP or self.__kdcHost):
+            logging.warning('KDC IP address and hostname will be ignored because of cross-domain targeting.')
+            self.__kdcIP = None
             self.__kdcHost = None
 
-    def getMachineName(self):
+    def getMachineName(self, target):
         # Python 2: socket.error handling
         from socket import error as SocketError
-
-        if self.__kdcHost is not None and self.__targetDomain == self.__domain:
-            target = self.__kdcHost
-        else:
-            target = self.__targetDomain
 
         try:
             s = SMBConnection(target, target)
@@ -92,7 +92,7 @@ class FindDelegation:
                 raise Exception('The connection is timed out. '
                                 'Probably 445/TCP port is closed. '
                                 'Try to specify corresponding NetBIOS name or FQDN '
-                                'instead of IP address')
+                                'as the value of the -dc-host option')
             else:
                 raise
         except Exception:
@@ -104,33 +104,38 @@ class FindDelegation:
     
 
     def run(self):
-
-        if self.__doKerberos:
-            target = self.getMachineName()
+        if self.__kdcHost is not None and self.__targetDomain == self.__domain:
+            self.__target = self.__kdcHost
         else:
-            if self.__kdcHost is not None and self.__targetDomain == self.__domain:
-                target = self.__kdcHost
+            if self.__kdcIP is not None and self.__targetDomain == self.__domain:
+                self.__target = self.__kdcIP
             else:
-                target = self.__targetDomain
+                self.__target = self.__targetDomain
+
+            if self.__doKerberos:
+                logging.info('Getting machine hostname')
+                self.__target = self.getMachineName(self.__target)
 
         # Connect to LDAP
         try:
-            ldapConnection = ldap.LDAPConnection('ldap://%s' % target, self.baseDN, self.__kdcHost)
+            ldapConnection = ldap.LDAPConnection('ldap://%s' % self.__target, self.baseDN, self.__kdcIP)
             if self.__doKerberos is not True:
                 ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
             else:
                 ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
-                                             self.__aesKey, kdcHost=self.__kdcHost)
+                                             self.__aesKey, kdcHost=self.__kdcIP)
         except ldap.LDAPSessionError as e:
             if str(e).find('strongerAuthRequired') >= 0:
                 # We need to try SSL
-                ldapConnection = ldap.LDAPConnection('ldaps://%s' % target, self.baseDN, self.__kdcHost)
+                ldapConnection = ldap.LDAPConnection('ldaps://%s' % self.__target, self.baseDN, self.__kdcIP)
                 if self.__doKerberos is not True:
                     ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
                 else:
                     ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
-                                                 self.__aesKey, kdcHost=self.__kdcHost)
+                                                 self.__aesKey, kdcHost=self.__kdcIP)
             else:
+                if self.__kdcIP is not None and self.__kdcHost is not None:
+                    logging.critical("If the credentials are valid, check the hostname and IP address of KDC. They must match exactly each other")
                 raise
 
         searchFilter = "(&(|(UserAccountControl:1.2.840.113556.1.4.803:=16777216)(UserAccountControl:1.2.840.113556.1.4.803:=" \
@@ -233,20 +238,18 @@ class FindDelegation:
 
 # Process command-line arguments.
 if __name__ == '__main__':
-    # Init the example's logger theme
-    logger.init()
     print(version.BANNER)
 
     parser = argparse.ArgumentParser(add_help = True, description = "Queries target domain for delegation relationships ")
 
-    parser.add_argument('target', action='store', help='domain/username[:password]')
+    parser.add_argument('target', action='store', help='domain[/username[:password]]')
     parser.add_argument('-target-domain', action='store', help='Domain to query/request if different than the domain of the user. '
                                                                'Allows for retrieving delegation info across trusts.')
 
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
 
     group = parser.add_argument_group('authentication')
-
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
     group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful for -k)')
     group.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file '
@@ -255,16 +258,24 @@ if __name__ == '__main__':
                                                        'line')
     group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication '
                                                                             '(128 or 256 bits)')
-    group.add_argument('-dc-ip', action='store',metavar = "ip address",  help='IP Address of the domain controller. If '
+
+    group = parser.add_argument_group('connection')
+    group.add_argument('-dc-ip', action='store', metavar='ip address', help='IP Address of the domain controller. If '
                                                                               'ommited it use the domain part (FQDN) '
                                                                               'specified in the target parameter. Ignored'
                                                                               'if -target-domain is specified.')
+    group.add_argument('-dc-host', action='store', metavar='hostname', help='Hostname of the domain controller to use. '
+                                                                              'If ommited, the domain part (FQDN) '
+                                                                              'specified in the account parameter will be used')
 
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
 
     options = parser.parse_args()
+
+    # Init the example's logger theme
+    logger.init(options.ts)
 
     if options.debug is True:
         logging.getLogger().setLevel(logging.DEBUG)
@@ -273,7 +284,6 @@ if __name__ == '__main__':
     else:
         logging.getLogger().setLevel(logging.INFO)
 
-    import re
     userDomain, username, password = re.compile('(?:(?:([^/:]*)/)?([^:]*)(?::(.*))?)?').match(options.target).groups('')
 
     if userDomain == '':

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -1322,4 +1322,4 @@ if __name__ == '__main__':
         logging.critical(str(e))
         if hasattr(e, 'error_code'):
             if e.error_code == 0xc0000073:
-                logging.info("Account not found in domain. (RID:%s)", options.targetRID)
+                logging.info("Account not found in domain. (RID:%s)" % options.targetRID)

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -548,9 +548,20 @@ class RAISECHILD:
 
     @staticmethod
     def getMachineName(machineIP):
-        s = SMBConnection(machineIP, machineIP)
+        # Python 2: socket.error handling
+        from socket import error as SocketError
+
         try:
-            s.login('','')
+            s = SMBConnection(machineIP, machineIP)
+            s.login('', '')
+        except (SocketError, OSError) as e:
+            if str(e).find('timed out') > 0:
+                raise Exception('The connection is timed out. '
+                                'Probably 445/TCP port is closed. '
+                                'Try to specify corresponding NetBIOS name or FQDN '
+                                'instead of IP address')
+            else:
+                raise
         except Exception:
             logging.debug('Error while anonymous logging into %s' % machineIP)
         else:
@@ -559,9 +570,20 @@ class RAISECHILD:
 
     @staticmethod
     def getDNSMachineName(machineIP):
-        s = SMBConnection(machineIP, machineIP)
+        # Python 2: socket.error handling
+        from socket import error as SocketError
+
         try:
-            s.login('','')
+            s = SMBConnection(machineIP, machineIP)
+            s.login('', '')
+        except (SocketError, OSError) as e:
+            if str(e).find('timed out') > 0:
+                raise Exception('The connection is timed out. '
+                                'Probably 445/TCP port is closed. '
+                                'Try to specify corresponding NetBIOS name or FQDN '
+                                'instead of IP address')
+            else:
+                raise
         except Exception:
             logging.debug('Error while anonymous logging into %s' % machineIP)
         else:

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -61,6 +61,7 @@ import logging
 import random
 import string
 import sys
+import re
 import os
 import cmd
 import time
@@ -1240,7 +1241,6 @@ class RAISECHILD:
                 executer.run(self.__target)
 
 if __name__ == '__main__':
-
     print(version.BANNER)
 
     parser = argparse.ArgumentParser(add_help = True, description = "Privilege Escalation from a child domain up to its "
@@ -1258,7 +1258,6 @@ if __name__ == '__main__':
                         'dump credentials. Administrator (500) by default.')
 
     group = parser.add_argument_group('authentication')
-
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
     group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful for -k)')
     group.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file '
@@ -1289,9 +1288,7 @@ if __name__ == '__main__':
     # Init the example's logger theme
     logger.init(options.ts)
 
-    import re
-    domain, username, password = re.compile('(?:(?:([^/:]*)/)?([^:]*)(?::(.*))?)?').match(
-        options.target).groups('')
+    domain, username, password = re.compile('(?:(?:([^/:]*)/)?([^:]*)(?::(.*))?)?').match(options.target).groups('')
 
     if options.debug is True:
         logging.getLogger().setLevel(logging.DEBUG)

--- a/examples/reg.py
+++ b/examples/reg.py
@@ -297,7 +297,7 @@ class RegHandler:
                 print("Unknown Type 0x%x!" % valueType)
                 hexdump(valueData)
         except Exception as e:
-            logging.debug('Exception thrown when printing reg value %s', str(e))
+            logging.debug('Exception thrown when printing reg value %s' % str(e))
             print('Invalid data')
             pass
 

--- a/examples/smbrelayx.py
+++ b/examples/smbrelayx.py
@@ -139,7 +139,7 @@ class doAttack(Thread):
             try:
                 if self.__command is not None:
                     remoteOps._RemoteOperations__executeRemote(self.__command)
-                    logging.info("Executed specified command on host: %s", self.__SMBConnection.getRemoteHost())
+                    logging.info("Executed specified command on host: %s" % self.__SMBConnection.getRemoteHost())
                     self.__answerTMP = b''
                     self.__SMBConnection.getFile('ADMIN$', 'Temp\\__output', self.__answer)
                     logging.debug('Raw answer %r' % self.__answerTMP)
@@ -159,7 +159,7 @@ class doAttack(Thread):
                     samFileName = remoteOps.saveSAM()
                     samHashes = SAMHashes(samFileName, bootKey, isRemote = True)
                     samHashes.dump()
-                    logging.info("Done dumping SAM hashes for host: %s", self.__SMBConnection.getRemoteHost())
+                    logging.info("Done dumping SAM hashes for host: %s" % self.__SMBConnection.getRemoteHost())
             except Exception as e:
                 logging.debug('Exception:', exc_info=True)
                 ATTACKED_HOSTS.remove(self.__SMBConnection.getRemoteHost())


### PR DESCRIPTION
There is a situation when the SMB protocol (in particular 445/TCP port) is blocked/filtered, so these scripts don't work properly in conjunction with Kerberos (doesn't matter which Python version is used)

```
root@kali:~# GetADUsers.py -debug -k -no-pass -user contoso_admin contoso.com/
Impacket v0.9.21 - Copyright 2020 SecureAuth Corporation

[+] Impacket Library Installation Path: /usr/local/lib/python3.8/site-packages/impacket
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/impacket/nmb.py", line 901, in _setup_connection
    sock.connect(sa)
socket.timeout: timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/GetADUsers.py", line 238, in <module>
    executer.run()
  File "/usr/local/bin/GetADUsers.py", line 124, in run
    self.__target = self.getMachineName()
  File "/usr/local/bin/GetADUsers.py", line 74, in getMachineName
    s = SMBConnection(self.__domain, self.__domain)
  File "/usr/local/lib/python3.8/site-packages/impacket/smbconnection.py", line 78, in __init__
    self.negotiateSession(preferredDialect)
  File "/usr/local/lib/python3.8/site-packages/impacket/smbconnection.py", line 114, in negotiateSession
    packet = self.negotiateSessionWildcard(self._myName, self._remoteName, self._remoteHost, self._sess_port,
  File "/usr/local/lib/python3.8/site-packages/impacket/smbconnection.py", line 163, in negotiateSessionWildcard
    self._nmbSession = nmb.NetBIOSTCPSession(myName, remoteName, remoteHost, nmb.TYPE_SERVER, sess_port,
  File "/usr/local/lib/python3.8/site-packages/impacket/nmb.py", line 892, in __init__
    NetBIOSSession.__init__(self, myname, remote_name, remote_host, remote_type=remote_type, sess_port=sess_port,
  File "/usr/local/lib/python3.8/site-packages/impacket/nmb.py", line 752, in __init__
    self._sock = self._setup_connection((remote_host, sess_port), timeout)
  File "/usr/local/lib/python3.8/site-packages/impacket/nmb.py", line 904, in _setup_connection
    raise socket.error("Connection error (%s:%s)" % (peer[0], peer[1]), e)
OSError: [Errno Connection error (contoso.com:445)] timed out
[Errno Connection error (contoso.com:445)] timed out
```

Specifying the -dc-ip option won't help either (expected behaviour)

```
root@kali:~# GetADUsers.py -debug -k -no-pass -user contoso_admin -dc-ip 10.10.10.10 contoso.com/
Impacket v0.9.21 - Copyright 2020 SecureAuth Corporation

[+] Impacket Library Installation Path: /usr/local/lib/python3.8/site-packages/impacket
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/impacket/nmb.py", line 901, in _setup_connection
    sock.connect(sa)
socket.timeout: timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/GetADUsers.py", line 238, in <module>
    executer.run()
  File "/usr/local/bin/GetADUsers.py", line 124, in run
    self.__target = self.getMachineName()
  File "/usr/local/bin/GetADUsers.py", line 72, in getMachineName
    s = SMBConnection(self.__kdcHost, self.__kdcHost)
  File "/usr/local/lib/python3.8/site-packages/impacket/smbconnection.py", line 78, in __init__
    self.negotiateSession(preferredDialect)
  File "/usr/local/lib/python3.8/site-packages/impacket/smbconnection.py", line 114, in negotiateSession
    packet = self.negotiateSessionWildcard(self._myName, self._remoteName, self._remoteHost, self._sess_port,
  File "/usr/local/lib/python3.8/site-packages/impacket/smbconnection.py", line 163, in negotiateSessionWildcard
    self._nmbSession = nmb.NetBIOSTCPSession(myName, remoteName, remoteHost, nmb.TYPE_SERVER, sess_port,
  File "/usr/local/lib/python3.8/site-packages/impacket/nmb.py", line 892, in __init__
    NetBIOSSession.__init__(self, myname, remote_name, remote_host, remote_type=remote_type, sess_port=sess_port,
  File "/usr/local/lib/python3.8/site-packages/impacket/nmb.py", line 752, in __init__
    self._sock = self._setup_connection((remote_host, sess_port), timeout)
  File "/usr/local/lib/python3.8/site-packages/impacket/nmb.py", line 904, in _setup_connection
    raise socket.error("Connection error (%s:%s)" % (peer[0], peer[1]), e)
OSError: [Errno Connection error (10.10.10.10:445)] timed out
[Errno Connection error (10.10.10.10:445)] timed out
```

What if I have the corresponding FQDN (or NetBIOS name)? There should be an option to specify it. I have changed conditions in run() and have added the -dc-host parameter
Now it is possible to connect to specific KDC using its FQDN (or NetBIOS name) without initiating an SMB connection with it. So the first issue is solved

The second one is related to the -dc-ip option. Why not just reuse the -dc-ip option (maybe rename it to -kdc) and allow to specify FQDN (or NetBIOS name) in it and check it in those conditions? This is due to DNS name resolution issue. If the DNS protocol is also blocked/filtered, both FQDN (or NetBIOS name) and IP address should be specified. It is possible to add an entry to /etc/hosts for sure, but if there is an option, why not to use it?

```
root@kali:~# GetADUsers.py -debug -k -no-pass -user contoso_admin -dc-ip dc01 contoso.com/
Impacket v0.9.21 - Copyright 2020 SecureAuth Corporation

[+] Impacket Library Installation Path: /usr/local/lib/python3.8/site-packages/impacket
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/impacket/nmb.py", line 897, in _setup_connection
    af, socktype, proto, canonname, sa = socket.getaddrinfo(peer[0], peer[1], 0, socket.SOCK_STREAM)[0]
  File "/usr/lib/python3.8/socket.py", line 918, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -3] Temporary failure in name resolution

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/GetADUsers.py", line 238, in <module>
    executer.run()
  File "/usr/local/bin/GetADUsers.py", line 124, in run
    self.__target = self.getMachineName()
  File "/usr/local/bin/GetADUsers.py", line 72, in getMachineName
    s = SMBConnection(self.__kdcHost, self.__kdcHost)
  File "/usr/local/lib/python3.8/site-packages/impacket/smbconnection.py", line 78, in __init__
    self.negotiateSession(preferredDialect)
  File "/usr/local/lib/python3.8/site-packages/impacket/smbconnection.py", line 114, in negotiateSession
    packet = self.negotiateSessionWildcard(self._myName, self._remoteName, self._remoteHost, self._sess_port,
  File "/usr/local/lib/python3.8/site-packages/impacket/smbconnection.py", line 163, in negotiateSessionWildcard
    self._nmbSession = nmb.NetBIOSTCPSession(myName, remoteName, remoteHost, nmb.TYPE_SERVER, sess_port,
  File "/usr/local/lib/python3.8/site-packages/impacket/nmb.py", line 892, in __init__
    NetBIOSSession.__init__(self, myname, remote_name, remote_host, remote_type=remote_type, sess_port=sess_port,
  File "/usr/local/lib/python3.8/site-packages/impacket/nmb.py", line 752, in __init__
    self._sock = self._setup_connection((remote_host, sess_port), timeout)
  File "/usr/local/lib/python3.8/site-packages/impacket/nmb.py", line 904, in _setup_connection
    raise socket.error("Connection error (%s:%s)" % (peer[0], peer[1]), e)
OSError: [Errno Connection error (dc01:445)] [Errno -3] Temporary failure in name resolution
[Errno Connection error (dc01:445)] [Errno -3] Temporary failure in name resolution
```


From now in the worst situation the syntax will be the following:

```
root@kali:~# GetADUsers.py -k -no-pass -user contoso_admin -dc-ip 10.10.10.10 -dc-host dc01 contoso.com/
```