### PR TITLE
fix the ldap search with paged results

### DIFF
--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -397,8 +397,8 @@ class LDAPConnection:
             for requestControl in requestControls:
                 if responseControls is not None:
                     for responseControl in responseControls:
-                        if requestControl['controlType'] == CONTROL_PAGEDRESULTS:
-                            if responseControl['controlType'] == CONTROL_PAGEDRESULTS:
+                        if str(requestControl['controlType']) == CONTROL_PAGEDRESULTS:
+                            if str(responseControl['controlType']) == CONTROL_PAGEDRESULTS:
                                 if hasattr(responseControl, 'getCookie') is not True:
                                     responseControl = decoder.decode(encoder.encode(responseControl),
                                                                  asn1Spec=KNOWN_CONTROLS[CONTROL_PAGEDRESULTS]())[0]


### PR DESCRIPTION
Hi!

The multi paged results seems to be broken the master branch. Indeed, the following code returns only 10 results on a 1000+ users domain.

```python3
from impacket.ldap import ldap, ldapasn1
ldap_connection = ldap.LDAPConnection('ldap://172.16.0.1', 'dc=domain,dc=com', '172.16.0.1')
ldap_connection.login('user', 'password123', 'domain', '', '')
paged_search_control = ldapasn1.SimplePagedResultsControl(criticality=True,size=10)
attributes=list()
search_filter = '(samAccountType=805306368)'
search_results = ldap_connection.search(searchFilter=search_filter,searchControls=[paged_search_control],attributes=attributes)
```

I dug into the code and found the following comparisons

https://github.com/SecureAuthCorp/impacket/blob/c44901d14f19e444fa19a8c23481f94686062a0f/impacket/ldap/ldap.py#L400-L401

This is a comparison between a `<class 'str'>` and a `<class 'impacket.ldap.ldapasn1.LDAPOID'>` so the code within the first (and the second) `if` is never executed.

This PR fix this by using the `__str__()` method of the LDAPOID class.

:sunflower: 
