### PR TITLE
fix #809

### DIFF
--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -211,9 +211,8 @@ class GetUserNoPreAuth:
             self.request_users_file_TGTs()
             return
 
-
         # Are we asked not to supply a password?
-        if self.__no_pass is True:
+        if self.__doKerberos is False and self.__no_pass is True:
             # Yes, just ask the TGT and exit
             logging.info('Getting TGT for %s' % self.__username)
             entry = self.getTGT(self.__username)
@@ -416,6 +415,10 @@ if __name__ == '__main__':
 
     if options.aesKey is not None:
         options.k = True
+
+    if options.k is False and options.no_pass is True and username == '' and options.usersfile is None:
+        logging.critical('If the -no-pass option was specified, but Kerberos (-k) is not used, then a username or the -usersfile option should be specified!')
+        sys.exit(1)
 
     if options.outputfile is not None:
         options.request = True


### PR DESCRIPTION
Small changes that fix the problem with Kerberos in GetNPUsers.py (described in #809)

Additional check was added to avoid the following error:
```
Impacket v0.9.22.dev1+20200424.150528.c44901d1 - Copyright 2020 SecureAuth Corporation

[*] Getting TGT for
[-] invalid principal syntax
```

It happens when the script is run as follows:
```
GetNPUsers.py -no-pass contoso.com/
```