### PR TITLE
NDR Parser Optimization

### DIFF
--- a/impacket/dcerpc/v5/dcomrt.py
+++ b/impacket/dcerpc/v5/dcomrt.py
@@ -333,7 +333,7 @@ class DUALSTRINGARRAYPACKED(NDRSTRUCT):
         ('wSecurityOffset',USHORT),
         ('aStringArray',':'),
     )
-    def getDataLen(self, data):
+    def getDataLen(self, data, offset=0):
         return self['wNumEntries']*2
 
 # 2.2.18.7 OBJREF_EXTENDED

--- a/impacket/dcerpc/v5/drsuapi.py
+++ b/impacket/dcerpc/v5/drsuapi.py
@@ -625,7 +625,7 @@ class DSNAME(NDRSTRUCT):
         ('NameLen',ULONG),
         ('StringName', WCHAR_ARRAY),
     )
-    def getDataLen(self, data):
+    def getDataLen(self, data, offset=0):
         return self['NameLen']
     def getData(self, soFar = 0):
         return NDRSTRUCT.getData(self, soFar)

--- a/impacket/dcerpc/v5/dtypes.py
+++ b/impacket/dcerpc/v5/dtypes.py
@@ -59,8 +59,8 @@ class PCHAR(NDRPOINTER):
     )
 
 class WIDESTR(NDRUniFixedArray):
-    def getDataLen(self, data):
-        return data.find(b'\x00\x00\x00')+3
+    def getDataLen(self, data, offset=0):
+        return data.find(b'\x00\x00\x00', offset)+3-offset
 
     def __setitem__(self, key, value):
         if key == 'Data':
@@ -130,7 +130,7 @@ class STR(NDRSTRUCT):
         else:
             return NDR.__getitem__(self,key)
 
-    def getDataLen(self, data):
+    def getDataLen(self, data, offset=0):
         return self["ActualCount"]
 
 class LPSTR(NDRPOINTER):
@@ -161,7 +161,7 @@ class WSTR(NDRSTRUCT):
         # Here just print the data
         print(" %r" % (self['Data']), end=' ')
 
-    def getDataLen(self, data):
+    def getDataLen(self, data, offset=0):
         return self["ActualCount"]*2 
 
     def __setitem__(self, key, value):
@@ -446,7 +446,7 @@ class DWORD_ARRAY(NDRUniConformantArray):
 class RPC_SID_IDENTIFIER_AUTHORITY(NDRUniFixedArray):
     align = 1
     align64 = 1
-    def getDataLen(self, data):
+    def getDataLen(self, data, offset=0):
         return 6
 
 class RPC_SID(NDRSTRUCT):

--- a/impacket/dcerpc/v5/ndr.py
+++ b/impacket/dcerpc/v5/ndr.py
@@ -16,7 +16,7 @@ from __future__ import division
 from __future__ import print_function
 import random
 import inspect
-from struct import pack, unpack, calcsize
+from struct import pack, unpack_from, calcsize
 from six import with_metaclass, PY3
 
 from impacket import LOG
@@ -143,8 +143,8 @@ class NDR(object):
         # XXX: improve
         return len(self.getData())
 
-    def getDataLen(self, data):
-        return len(data)
+    def getDataLen(self, data, offset=0):
+        return len(data) - offset
 
     @staticmethod
     def isNDR(field):
@@ -197,9 +197,9 @@ class NDR(object):
 
     @staticmethod
     def calculatePad(fieldType, soFar):
-        try:
+        if isinstance(fieldType, str) and '=' in fieldType:
             alignment = calcsize(fieldType.split('=')[0])
-        except:
+        else:
             alignment = 0
 
         if alignment > 0:
@@ -238,8 +238,8 @@ class NDR(object):
 
         return data
 
-    def fromString(self, data, soFar = 0):
-        soFar0 = soFar
+    def fromString(self, data, offset=0):
+        offset0 = offset
         for fieldName, fieldTypeOrClass in self.commonHdr+self.structure:
             try:
                 # Alignment of Primitive Types
@@ -251,20 +251,14 @@ class NDR(object):
                 # from the first octet in the stream. Where necessary, an alignment gap, consisting of
                 # octets of unspecified value, precedes the representation of a primitive. The gap is
                 # of the smallest size sufficient to align the primitive.
-                pad = self.calculatePad(fieldTypeOrClass, soFar)
-                if pad > 0:
-                    soFar += pad
-                    data = data[pad:]
+                offset += self.calculatePad(fieldTypeOrClass, offset)
 
-                size = self.unpack(fieldName, fieldTypeOrClass, data, soFar)
-
-                data = data[size:]
-                soFar += size
+                offset += self.unpack(fieldName, fieldTypeOrClass, data, offset)
             except Exception as e:
                 LOG.error(str(e))
-                LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[:256]))
+                LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[offset:offset+256]))
                 raise
-        return soFar - soFar0
+        return offset - offset0
 
     def pack(self, fieldName, fieldTypeOrClass, soFar = 0):
         if isinstance(self.fields[fieldName], NDR):
@@ -296,29 +290,28 @@ class NDR(object):
         # struct like specifier
         return pack(fieldTypeOrClass, data)
 
-    def unpack(self, fieldName, fieldTypeOrClass, data, soFar = 0):
-        size = self.calcUnPackSize(fieldTypeOrClass, data)
-        data = data[:size]
+    def unpack(self, fieldName, fieldTypeOrClass, data, offset=0):
         if isinstance(self.fields[fieldName], NDR):
-            return self.fields[fieldName].fromString(data, soFar)
+            return self.fields[fieldName].fromString(data, offset)
 
         # code specifier
         two = fieldTypeOrClass.split('=')
         if len(two) >= 2:
-            return self.unpack(fieldName,two[0], data, soFar)
+            return self.unpack(fieldName, two[0], data, offset)
 
         # literal specifier
         if fieldTypeOrClass == ':':
             if isinstance(fieldTypeOrClass, NDR):
-                return self.fields[fieldName].fromString(data, soFar)
+                return self.fields[fieldName].fromString(data, offset)
             else:
-                dataLen = self.getDataLen(data)
-                self.fields[fieldName] =  data[:dataLen]
+                dataLen = self.getDataLen(data, offset)
+                self.fields[fieldName] =  data[offset:offset+dataLen]
                 return dataLen
 
         # struct like specifier
-        self.fields[fieldName] = unpack(fieldTypeOrClass, data)[0]
-        return size
+        self.fields[fieldName] = unpack_from(fieldTypeOrClass, data, offset)[0]
+
+        return calcsize(fieldTypeOrClass)
 
     def calcPackSize(self, fieldTypeOrClass, data):
         if isinstance(fieldTypeOrClass, str) is False:
@@ -336,23 +329,23 @@ class NDR(object):
         # struct like specifier
         return calcsize(fieldTypeOrClass)
 
-    def calcUnPackSize(self, fieldTypeOrClass, data):
+    def calcUnPackSize(self, fieldTypeOrClass, data, offset=0):
         if isinstance(fieldTypeOrClass, str) is False:
-            return len(data)
+            return len(data) - offset
 
         # code specifier
         two = fieldTypeOrClass.split('=')
         if len(two) >= 2:
-            return self.calcUnPackSize(two[0], data)
+            return self.calcUnPackSize(two[0], data, offset)
 
         # array specifier
         two = fieldTypeOrClass.split('*')
         if len(two) == 2:
-            return len(data)
+            return len(data) - offset
 
         # literal specifier
         if fieldTypeOrClass[:1] == ':':
-            return len(data)
+            return len(data) - offset
 
         # struct like specifier
         return calcsize(fieldTypeOrClass)
@@ -581,7 +574,7 @@ class NDRCONSTRUCTEDTYPE(NDR):
         else:
             return self.fields[fieldName].getArraySize()
 
-    def getArraySize(self,fieldName, data, soFar):
+    def getArraySize(self, fieldName, data, offset=0):
         if self._isNDR64:
             arrayItemSize = 8
             arrayUnPackStr = '<Q'
@@ -589,45 +582,39 @@ class NDRCONSTRUCTEDTYPE(NDR):
             arrayItemSize = 4
             arrayUnPackStr = '<L'
 
-        pad0 = (arrayItemSize - (soFar % arrayItemSize)) % arrayItemSize
-        if pad0 > 0:
-            soFar += pad0
-            data = data[pad0:]
+        pad = (arrayItemSize - (offset % arrayItemSize)) % arrayItemSize
+        offset += pad
 
         if isinstance(self.fields[fieldName], NDRUniConformantArray):
             # Array Size is at the very beginning
-            arraySize = unpack(arrayUnPackStr, data[:arrayItemSize])[0]
+            arraySize = unpack_from(arrayUnPackStr, data, offset)[0]
         elif isinstance(self.fields[fieldName], NDRUniConformantVaryingArray):
             # NDRUniConformantVaryingArray Array
             # Unpack the Maximum Count
-            maximumCount = unpack(arrayUnPackStr, data[:arrayItemSize])[0]
+            maximumCount = unpack_from(arrayUnPackStr, data, offset)[0]
             # Let's store the Maximum Count for later use
             self.fields[fieldName].fields['MaximumCount'] = maximumCount
             # Unpack the Actual Count
-            arraySize = unpack(arrayUnPackStr, data[arrayItemSize*2:][:arrayItemSize])[0]
+            arraySize = unpack_from(arrayUnPackStr, data, offset+arrayItemSize*2)[0]
         else:
             # NDRUniVaryingArray Array
-            arraySize = unpack(arrayUnPackStr, data[arrayItemSize:][:arrayItemSize])[0]
+            arraySize = unpack_from(arrayUnPackStr, data, offset+arrayItemSize)[0]
 
-        return arraySize, arrayItemSize+pad0
+        return arraySize, arrayItemSize+pad
 
-    def fromStringReferents(self, data, soFar = 0):
-        soFar0 = soFar
+    def fromStringReferents(self, data, offset=0):
+        offset0 = offset
         for fieldName, fieldTypeOrClass in self.commonHdr+self.structure:
             if isinstance(self.fields[fieldName], NDRCONSTRUCTEDTYPE):
-                size = self.fields[fieldName].fromStringReferents(data, soFar)
-                data = data[size:]
-                soFar += size
-                size = self.fields[fieldName].fromStringReferent(data, soFar)
-                soFar += size
-                data = data[size:]
-        return soFar - soFar0
+                offset += self.fields[fieldName].fromStringReferents(data, offset)
+                offset += self.fields[fieldName].fromStringReferent(data, offset)
+        return offset - offset0
 
-    def fromStringReferent(self, data, soFar = 0):
+    def fromStringReferent(self, data, offset=0):
         if hasattr(self, 'referent') is not True:
             return 0
 
-        soFar0 = soFar
+        offset0 = offset
 
         if 'ReferentID' in self.fields:
             if self['ReferentID'] == 0:
@@ -638,43 +625,38 @@ class NDRCONSTRUCTEDTYPE(NDR):
             try:
                 if isinstance(self.fields[fieldName], NDRUniConformantArray) or isinstance(self.fields[fieldName], NDRUniConformantVaryingArray):
                     # Get the array size
-                    arraySize, advanceStream = self.getArraySize(fieldName, data, soFar)
-                    soFar += advanceStream
-                    data = data[advanceStream:]
+                    arraySize, advanceStream = self.getArraySize(fieldName, data, offset)
+                    offset += advanceStream
 
                     # Let's tell the array how many items are available
                     self.fields[fieldName].setArraySize(arraySize)
-                    size = self.fields[fieldName].fromString(data, soFar)
+                    size = self.fields[fieldName].fromString(data, offset)
                 else:
                     # ToDo: Align only if not NDR
-                    pad = self.calculatePad(fieldTypeOrClass, soFar)
-                    if pad > 0:
-                        soFar += pad
-                        data = data[pad:]
+                    offset += self.calculatePad(fieldTypeOrClass, offset)
 
-                    size = self.unpack(fieldName, fieldTypeOrClass, data, soFar)
+                    size = self.unpack(fieldName, fieldTypeOrClass, data, offset)
 
                 if isinstance(self.fields[fieldName], NDRCONSTRUCTEDTYPE):
-                    size += self.fields[fieldName].fromStringReferents(data[size:], soFar + size)
-                    size += self.fields[fieldName].fromStringReferent(data[size:], soFar + size)
-                data = data[size:]
-                soFar += size
+                    size += self.fields[fieldName].fromStringReferents(data, offset+size)
+                    size += self.fields[fieldName].fromStringReferent(data, offset+size)
+                offset += size
             except Exception as e:
                 LOG.error(str(e))
-                LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[:256]))
+                LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[offset:offset+256]))
                 raise
 
-        return soFar-soFar0
+        return offset-offset0
 
-    def calcUnPackSize(self, fieldTypeOrClass, data):
+    def calcUnPackSize(self, fieldTypeOrClass, data, offset=0):
         if isinstance(fieldTypeOrClass, str) is False:
-            return len(data)
+            return len(data) - offset
 
         two = fieldTypeOrClass.split('*')
         if len(two) == 2:
-            return len(data)
+            return len(data) - offset
         else:
-            return NDR.calcUnPackSize(self, fieldTypeOrClass, data)
+            return NDR.calcUnPackSize(self, fieldTypeOrClass, data, offset)
 
 # Uni-dimensional Fixed Arrays
 class NDRArray(NDRCONSTRUCTEDTYPE):
@@ -793,34 +775,29 @@ class NDRArray(NDRCONSTRUCTEDTYPE):
         else:
             return NDRCONSTRUCTEDTYPE.pack(self, fieldName, fieldTypeOrClass, soFar)
 
-    def fromString(self, data, soFar = 0):
-        soFar0 = soFar
+    def fromString(self, data, offset=0):
+        offset0 = offset
         for fieldName, fieldTypeOrClass in self.commonHdr+self.structure:
             try:
                 if self.isNDR(fieldTypeOrClass) is False:
                     # If the item is not NDR (e.g. ('MaximumCount', '<L=len(Data)'))
                     # we have to align it
-                    pad = self.calculatePad(fieldTypeOrClass, soFar)
-                    if pad > 0:
-                        soFar += pad
-                        data = data[pad:]
+                    offset += self.calculatePad(fieldTypeOrClass, offset)
 
-                size = self.unpack(fieldName, fieldTypeOrClass, data, soFar)
-
-                data = data[size:]
-                soFar += size
+                size = self.unpack(fieldName, fieldTypeOrClass, data, offset)
+                offset += size
             except Exception as e:
                 LOG.error(str(e))
-                LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[:256]))
+                LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[offset:offset+256]))
                 raise
-        return soFar - soFar0
+        return offset - offset0
 
-    def unpack(self, fieldName, fieldTypeOrClass, data, soFar = 0):
+    def unpack(self, fieldName, fieldTypeOrClass, data, offset=0):
         # array specifier
         two = fieldTypeOrClass.split('*')
         answer = []
         soFarItems = 0
-        soFar0 = soFar
+        offset0 = offset
         if len(two) == 2:
             if isinstance(self, NDRUniConformantArray):
                 # First field points to a field with the amount of items
@@ -844,16 +821,16 @@ class NDRArray(NDRCONSTRUCTEDTYPE):
                 self.fields['_tmpItem'] = item
 
             nsofar = 0
-            while numItems and soFarItems < len(data):
-                pad = self.calculatePad(self.item, soFarItems+soFar)
+            while numItems and soFarItems < len(data) - offset:
+                pad = self.calculatePad(self.item, soFarItems+offset)
                 if pad > 0:
                     soFarItems +=pad
                 if dataClassOrCode is None:
                     nsofar = soFarItems + calcsize(item)
-                    answer.append(unpack(item, data[soFarItems:nsofar])[0])
+                    answer.append(unpack_from(item, data, offset+soFarItems)[0])
                 else:
                     itemn = dataClassOrCode(isNDR64=self._isNDR64)
-                    size = itemn.fromString(data[soFarItems:], soFar+soFarItems)
+                    size = itemn.fromString(data, offset+soFarItems)
                     answer.append(itemn)
                     nsofar += size + pad
                 numItems -= 1
@@ -861,15 +838,12 @@ class NDRArray(NDRCONSTRUCTEDTYPE):
 
             if dataClassOrCode is not None and isinstance(dataClassOrCode(), NDRCONSTRUCTEDTYPE):
                 # We gotta go over again, asking for the referents
-                data = data[soFarItems:]
                 answer2 = []
                 for itemn in answer:
-                    size = itemn.fromStringReferents(data, soFarItems+soFar)
+                    size = itemn.fromStringReferents(data, soFarItems+offset)
                     soFarItems += size
-                    data = data[size:]
-                    size = itemn.fromStringReferent(data, soFarItems+soFar)
+                    size = itemn.fromStringReferent(data, soFarItems+offset)
                     soFarItems += size
-                    data = data[size:]
                     answer2.append(itemn)
                 answer = answer2
                 del answer2
@@ -877,9 +851,9 @@ class NDRArray(NDRCONSTRUCTEDTYPE):
             del(self.fields['_tmpItem'])
 
             self.fields[fieldName] = answer
-            return soFarItems + soFar - soFar0
+            return soFarItems + offset - offset0
         else:
-            return NDRCONSTRUCTEDTYPE.unpack(self, fieldName, fieldTypeOrClass, data, soFar)
+            return NDRCONSTRUCTEDTYPE.unpack(self, fieldName, fieldTypeOrClass, data, offset)
 
 class NDRUniFixedArray(NDRArray):
     structure = (
@@ -990,8 +964,8 @@ class NDRVaryingString(NDRUniVaryingArray):
                 self["Data"] = b''.join(self["Data"]) + b'\x00'
         return NDRUniVaryingArray.getData(self, soFar)
 
-    def fromString(self, data, soFar = 0):
-        ret = NDRUniVaryingArray.fromString(self,data)
+    def fromString(self, data, offset = 0):
+        ret = NDRUniVaryingArray.fromString(self, data, offset)
         # Let's take out the last item
         self["Data"] = self["Data"][:-1] 
         return ret
@@ -1107,8 +1081,8 @@ class NDRSTRUCT(NDRCONSTRUCTEDTYPE):
 #            print self.__class__ , alignment, pad, hex(soFar)
         return data
 
-    def fromString(self, data, soFar = 0 ):
-        soFar0 = soFar
+    def fromString(self, data, offset = 0 ):
+        offset0 = offset
         # 14.3.7.1 Structures Containing a Conformant Array
         # A structure can contain a conformant array only as its last member.
         # In the NDR representation of a structure that contains a conformant array, 
@@ -1122,13 +1096,31 @@ class NDRSTRUCT(NDRCONSTRUCTEDTYPE):
         # but the offsets and actual counts remain in place at the end of the structure, 
         # immediately preceding the array elements
         lastItem = (self.commonHdr+self.structure)[-1][0]
+
+        # If it's a pointer, let's parse it here because
+        # we are going to parse the next MaximumCount field(s) manually
+        # when it's a Conformant or Conformant and Varying array
+        if isinstance(self, NDRPOINTER):
+            structureFields = self.structure
+
+            alignment = self.getAlignment()
+            if alignment > 0:
+                offset += (alignment - (offset % alignment)) % alignment
+
+            for fieldName, fieldTypeOrClass in self.commonHdr:
+                offset += self.unpack(fieldName, fieldTypeOrClass, data, offset)
+        else:
+            structureFields = self.commonHdr+self.structure
+
         if isinstance(self.fields[lastItem], NDRUniConformantArray) or isinstance(self.fields[lastItem], NDRUniConformantVaryingArray):
             # So we have an array, first item in the structure must be the array size, although we
             # will need to build it later.
             if self._isNDR64:
                 arrayItemSize = 8
+                arrayUnPackStr = '<Q'
             else:
                 arrayItemSize = 4
+                arrayUnPackStr = '<L'
 
             # The size information is itself aligned according to the alignment rules for
             # primitive data types. (See Section 14.2.2 on page 620.) The data of the constructed 
@@ -1136,24 +1128,19 @@ class NDRSTRUCT(NDRCONSTRUCTEDTYPE):
             # In other words, the size information precedes the structure and is aligned 
             # independently of the structure alignment.
             # We need to check whether we need padding or not
-            pad0 = (arrayItemSize - (soFar % arrayItemSize)) % arrayItemSize
-            if pad0 > 0:
-                soFar += pad0
-                data = data[pad0:]
-            # And now, let's pretend we put the item in
-            soFar += arrayItemSize
-            # And let's extract the array size for later use, if it is a pointer, it is after the referent ID
-            if isinstance(self, NDRPOINTER):
-                # ToDo: Check if we have to align the arrayItemSize
-                # I guess is it aligned since the NDRPOINTER is aligned already
-                pointerData = data[:arrayItemSize]
-                arraySize, advanceStream = self.getArraySize(lastItem, data[arrayItemSize:], soFar+arrayItemSize)
-                data = pointerData + data[arrayItemSize*2:]
+            offset += (arrayItemSize - (offset % arrayItemSize)) % arrayItemSize
+
+            # And let's extract the array size for later use
+            if isinstance(self.fields[lastItem], NDRUniConformantArray):
+                # NDRUniConformantArray
+                arraySize = unpack_from(arrayUnPackStr, data, offset)[0]
+                self.fields[lastItem].setArraySize(arraySize)
             else:
-                arraySize, advanceStream = self.getArraySize(lastItem, data, soFar)
-                data = data[arrayItemSize:]
-            # Let's tell the array how many items are available
-            self.fields[lastItem].setArraySize(arraySize)
+                # NDRUniConformantVaryingArray
+                maximumCount = unpack_from(arrayUnPackStr, data, offset)[0]
+                self.fields[lastItem].fields['MaximumCount'] = maximumCount
+
+            offset += arrayItemSize
 
         # Now we need to align the structure
         # The alignment of a structure in the octet stream is the largest of the alignments of the fields it
@@ -1161,23 +1148,18 @@ class NDRSTRUCT(NDRCONSTRUCTEDTYPE):
         # recursively to nested constructed types.
         alignment = self.getAlignment()
         if alignment > 0:
-            pad = (alignment - (soFar % alignment)) % alignment
-            if pad > 0:
-                soFar += pad
-                data = data[pad:]
+            offset += (alignment - (offset % alignment)) % alignment
 
-        for fieldName, fieldTypeOrClass in self.commonHdr+self.structure:
+        for fieldName, fieldTypeOrClass in structureFields:
             try:
-                size = self.unpack(fieldName, fieldTypeOrClass, data, soFar)
-
-                data = data[size:]
-                soFar += size
+                size = self.unpack(fieldName, fieldTypeOrClass, data, offset)
+                offset += size
             except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[:256]))
                 raise
 
-        return soFar - soFar0
+        return offset - offset0
 
     def getAlignment(self):
         # Alignment of Constructed Types
@@ -1353,23 +1335,22 @@ class NDRUNION(NDRCONSTRUCTEDTYPE):
 
         return data
 
-    def fromString(self, data, soFar = 0 ):
-        soFar0 = soFar
+    def fromString(self, data, offset=0):
+        offset0 = offset
         # Let's align ourselves
         alignment = self.getAlignment()
         if alignment > 0:
-            pad = (alignment - (soFar % alignment)) % alignment
+            pad = (alignment - (offset % alignment)) % alignment
         else:
             pad = 0
         if pad > 0:
-            soFar += pad
-            data = data[pad:]
+            offset += pad
 
-        if len(data) > 4:
+        if len(data)-offset > 4:
             # First off, let's see what the tag is:
             # We need to know the tag type and unpack it
             tagtype = self.commonHdr[0][1].structure[0][1].split('=')[0]
-            tag = unpack(tagtype, data[:calcsize(tagtype)])[0]
+            tag = unpack_from(tagtype, data, offset)[0]
             if tag in self.union:
                 self.structure = (self.union[tag]),
                 self.__init__(None, isNDR64=self._isNDR64, topLevel = self.topLevel)
@@ -1388,18 +1369,11 @@ class NDRUNION(NDRCONSTRUCTEDTYPE):
 
         for fieldName, fieldTypeOrClass in self.commonHdr:
             try:
-                pad = self.calculatePad(fieldTypeOrClass, soFar)
-                if pad > 0:
-                    soFar += pad
-                    data = data[pad:]
-
-                size = self.unpack(fieldName, fieldTypeOrClass, data, soFar)
-
-                data = data[size:]
-                soFar += size
+                offset += self.calculatePad(fieldTypeOrClass, offset)
+                offset += self.unpack(fieldName, fieldTypeOrClass, data, offset)
             except Exception as e:
                 LOG.error(str(e))
-                LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[:256]))
+                LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[offset:offset+256]))
                 raise
 
         # WARNING
@@ -1415,31 +1389,21 @@ class NDRUNION(NDRCONSTRUCTEDTYPE):
             else:
                 align = 4
 
-        pad = (align - (soFar % align)) % align
-        if pad > 0:
-            data = data[pad:]
-            soFar += pad
+        offset += (align - (offset % align)) % align
 
         if self.structure == ():
-            return soFar-soFar0
+            return offset-offset0
 
         for fieldName, fieldTypeOrClass in self.structure:
             try:
-                pad = self.calculatePad(fieldTypeOrClass, soFar)
-                if pad > 0:
-                    soFar += pad
-                    data = data[pad:]
-
-                size = self.unpack(fieldName, fieldTypeOrClass, data, soFar)
-
-                data = data[size:]
-                soFar += size
+                offset += self.calculatePad(fieldTypeOrClass, offset)
+                offset += self.unpack(fieldName, fieldTypeOrClass, data, offset)
             except Exception as e:
                 LOG.error(str(e))
-                LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[:256]))
+                LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[offset:offset+256]))
                 raise
 
-        return soFar - soFar0
+        return offset - offset0
 
     def getAlignment(self):
         # Union alignment is the largest alignment of the union discriminator 
@@ -1556,12 +1520,10 @@ class NDRPOINTER(NDRSTRUCT):
 
         return data + NDRSTRUCT.getData(self, soFar)
 
-    def fromString(self,data,soFar = 0):
+    def fromString(self, data, offset=0):
         # First of all we need to align ourselves
-        pad = self.calculatePad(self.commonHdr[0][1], soFar)
-        if pad > 0:
-            soFar += pad
-            data = data[pad:]
+        pad = self.calculatePad(self.commonHdr[0][1], offset)
+        offset += pad
 
         # Do we have a Referent ID == 0?
         if self._isNDR64 is True:
@@ -1569,7 +1531,7 @@ class NDRPOINTER(NDRSTRUCT):
         else:
             unpackStr = '<L'
 
-        if unpack(unpackStr, data[:calcsize(unpackStr)])[0] == 0:
+        if unpack_from(unpackStr, data, offset)[0] == 0:
             # Let's save the value
             self['ReferentID'] = 0
             self.fields['Data'] = b''
@@ -1578,7 +1540,7 @@ class NDRPOINTER(NDRSTRUCT):
             else:
                 return pad + 4
         else:
-            retVal =  NDRSTRUCT.fromString(self,data, soFar)
+            retVal = NDRSTRUCT.fromString(self, data, offset)
             return retVal + pad
 
     def dump(self, msg = None, indent = 0):
@@ -1714,33 +1676,31 @@ class NDRCALL(NDRCONSTRUCTEDTYPE):
 
         return data
 
-    def fromString(self, data, soFar = 0):
-        soFar0 = soFar
+    def fromString(self, data, offset=0):
+        offset0 = offset
         for fieldName, fieldTypeOrClass in self.commonHdr+self.structure:
             try:
                 # Are we dealing with an array?
                 if isinstance(self.fields[fieldName], NDRUniConformantArray) or isinstance(self.fields[fieldName],
                               NDRUniConformantVaryingArray):
                     # Yes, get the array size
-                    arraySize, advanceStream = self.getArraySize(fieldName, data, soFar)
+                    arraySize, advanceStream = self.getArraySize(fieldName, data, offset)
                     self.fields[fieldName].setArraySize(arraySize)
-                    soFar += advanceStream
-                    data = data[advanceStream:]
+                    offset += advanceStream
 
-                size = self.unpack(fieldName, fieldTypeOrClass, data, soFar)
+                size = self.unpack(fieldName, fieldTypeOrClass, data, offset)
 
                 # Any referent information to unpack?
                 if isinstance(self.fields[fieldName], NDRCONSTRUCTEDTYPE):
-                    size += self.fields[fieldName].fromStringReferents(data[size:], soFar + size)
-                    size += self.fields[fieldName].fromStringReferent(data[size:], soFar + size)
-                data = data[size:]
-                soFar += size
+                    size += self.fields[fieldName].fromStringReferents(data, offset+size)
+                    size += self.fields[fieldName].fromStringReferent(data, offset+size)
+                offset += size
             except Exception as e:
                 LOG.error(str(e))
-                LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[:256]))
+                LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[offset:offset+256]))
                 raise
 
-        return soFar - soFar0
+        return offset - offset0
 
 # Top Level Struct == NDRCALL
 NDRTLSTRUCT = NDRCALL

--- a/impacket/dcerpc/v5/ndr.py
+++ b/impacket/dcerpc/v5/ndr.py
@@ -1152,8 +1152,7 @@ class NDRSTRUCT(NDRCONSTRUCTEDTYPE):
 
         for fieldName, fieldTypeOrClass in structureFields:
             try:
-                size = self.unpack(fieldName, fieldTypeOrClass, data, offset)
-                offset += size
+                offset += self.unpack(fieldName, fieldTypeOrClass, data, offset)
             except Exception as e:
                 LOG.error(str(e))
                 LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[offset:offset+256]))

--- a/impacket/dcerpc/v5/ndr.py
+++ b/impacket/dcerpc/v5/ndr.py
@@ -197,8 +197,11 @@ class NDR(object):
 
     @staticmethod
     def calculatePad(fieldType, soFar):
-        if isinstance(fieldType, str) and '=' in fieldType:
-            alignment = calcsize(fieldType.split('=')[0])
+        if isinstance(fieldType, str):
+            try:
+                alignment = calcsize(fieldType.split('=')[0])
+            except:
+                alignment = 0
         else:
             alignment = 0
 

--- a/impacket/dcerpc/v5/ndr.py
+++ b/impacket/dcerpc/v5/ndr.py
@@ -1156,7 +1156,7 @@ class NDRSTRUCT(NDRCONSTRUCTEDTYPE):
                 offset += size
             except Exception as e:
                 LOG.error(str(e))
-                LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[:256]))
+                LOG.error("Error unpacking field '%s | %s | %r'" % (fieldName, fieldTypeOrClass, data[offset:offset+256]))
                 raise
 
         return offset - offset0

--- a/impacket/dcerpc/v5/nrpc.py
+++ b/impacket/dcerpc/v5/nrpc.py
@@ -150,7 +150,7 @@ from impacket.dcerpc.v5.lsad import STRING
 
 # 2.2.1.1.3 LM_OWF_PASSWORD
 class CYPHER_BLOCK_ARRAY(NDRUniFixedArray):
-    def getDataLen(self, data):
+    def getDataLen(self, data, offset=0):
         return len(CYPHER_BLOCK())*2
 
 class LM_OWF_PASSWORD(NDRSTRUCT):
@@ -165,7 +165,7 @@ ENCRYPTED_NT_OWF_PASSWORD = NT_OWF_PASSWORD
 # 2.2.1.3.4 NETLOGON_CREDENTIAL
 class UCHAR_FIXED_ARRAY(NDRUniFixedArray):
     align = 1
-    def getDataLen(self, data):
+    def getDataLen(self, data, offset=0):
         return len(CYPHER_BLOCK())
 
 class NETLOGON_CREDENTIAL(NDRSTRUCT):
@@ -338,7 +338,7 @@ class PNETLOGON_WORKSTATION_INFO(NDRPOINTER):
 
 # 2.2.1.3.7 NL_TRUST_PASSWORD
 class WCHAR_ARRAY(NDRUniFixedArray):
-    def getDataLen(self, data):
+    def getDataLen(self, data, offset=0):
         return 512
 
 class NL_TRUST_PASSWORD(NDRSTRUCT):
@@ -449,7 +449,7 @@ class NETLOGON_CAPABILITIES(NDRUNION):
 
 # 2.2.1.3.15 NL_OSVERSIONINFO_V1
 class UCHAR_FIXED_ARRAY(NDRUniFixedArray):
-    def getDataLen(self, data):
+    def getDataLen(self, data, offset=0):
         return 128
 
 class NL_OSVERSIONINFO_V1(NDRSTRUCT):
@@ -515,7 +515,7 @@ class NL_OUT_CHAIN_SET_CLIENT_ATTRIBUTES(NDRUNION):
 
 # 2.2.1.4.1 LM_CHALLENGE
 class CHAR_FIXED_8_ARRAY(NDRUniFixedArray):
-    def getDataLen(self, data):
+    def getDataLen(self, data, offset=0):
         return 8
 
 class LM_CHALLENGE(NDRSTRUCT):
@@ -654,7 +654,7 @@ class PGROUP_MEMBERSHIP_ARRAY(NDRPOINTER):
 
 # 2.2.1.4.11 NETLOGON_VALIDATION_SAM_INFO
 class LONG_ARRAY(NDRUniFixedArray):
-    def getDataLen(self, data):
+    def getDataLen(self, data, offset=0):
         return 4*10
 
 class NETLOGON_VALIDATION_SAM_INFO(NDRSTRUCT):
@@ -1547,7 +1547,7 @@ class NETLOGON_DUMMY1(NDRUNION):
 
 # 3.5.4.8.2 NetrLogonComputeServerDigest (Opnum 24)
 class CHAR_FIXED_16_ARRAY(NDRUniFixedArray):
-    def getDataLen(self, data):
+    def getDataLen(self, data, offset=0):
         return 16
 
 

--- a/impacket/dcerpc/v5/srvs.py
+++ b/impacket/dcerpc/v5/srvs.py
@@ -1781,7 +1781,7 @@ class WCHAR_ARRAY(NDRSTRUCT):
         else:
             return NDR.__getitem__(self,key)
 
-    def getDataLen(self, data):
+    def getDataLen(self, data, offset=0):
         return self["ActualCount"]*2 
 
 
@@ -1889,7 +1889,7 @@ class LPSERVER_TRANSPORT_INFO_2_ARRAY(NDRPOINTER):
 
 # 2.2.4.96 SERVER_TRANSPORT_INFO_3
 class PASSWORD_ARRAY(NDRUniFixedArray):
-    def getDataLen(self, data):
+    def getDataLen(self, data, offset=0):
         return 256
 
 class SERVER_TRANSPORT_INFO_3(NDRSTRUCT):

--- a/impacket/dcerpc/v5/wkst.py
+++ b/impacket/dcerpc/v5/wkst.py
@@ -467,11 +467,11 @@ class WKSTA_TRANSPORT_ENUM_STRUCT(NDRSTRUCT):
 
 # 2.2.5.17 JOINPR_USER_PASSWORD
 class WCHAR_ARRAY(WIDESTR):
-    def getDataLen(self, data):
+    def getDataLen(self, data, offset=0):
         return JOIN_MAX_PASSWORD_LENGTH
 
 class CHAR_ARRAY(NDRUniFixedArray):
-    def getDataLen(self, data):
+    def getDataLen(self, data, offset=0):
         return JOIN_OBFUSCATOR_LENGTH
 
 class JOINPR_USER_PASSWORD(NDRSTRUCT):


### PR DESCRIPTION
Hello @asolino, @0xdeaddood!

I was just playing with MS-OXNSPI where operations can return huge NDR blobs, and I witnessed that for data >= 2M impacket consumes 100% of CPU and provides no output in 10 minutes.

I have known that Impacket uses "eval" for parsing, but I've decided to run a profiler anyway:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
 55130/94    7.753    0.000   35.386    0.376 ndr.py:1110(fromString)
    73157    6.805    0.000    7.711    0.000 ndr.py:241(fromString)
    19328    4.701    0.000   11.112    0.001 ndr.py:1356(fromString)
   6108/9    3.586    0.001   35.396    3.933 ndr.py:818(unpack)
80560/1243    2.566    0.000   34.000    0.027 ndr.py:626(fromStringReferent)
   154444    2.131    0.000    2.186    0.000 {eval}
80560/620    1.404    0.000   34.037    0.055 ndr.py:614(fromStringReferents)
     2690    0.833    0.000    0.833    0.000 {method 'read' of '_ssl._SSLSocket' objects}
```
It turns out that the problem is actually unclear. After visual profiling, I found that the lines, as in the example below, are causing the problem:
```
... data[soFarItems:] ...
... unpack(unpackStr, data[:calcsize(unpackStr)]) ...
```
Python doesn't optimize addressing to the data variable, and such operations means malloc/memcpy/free functions will be called in C terms.

So, I've adapted the parser to work with a single input variable throughout the whole parsing, and the profiler shows a much better result for the same input:
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     2690    2.707    0.001    2.707    0.001 {method 'read' of '_ssl._SSLSocket' objects}
   154444    1.305    0.000    1.352    0.000 {eval}
161367/65781    0.662    0.000    2.703    0.000 ndr.py:45(__init__)
   6108/9    0.536    0.000    5.938    0.660 ndr.py:795(unpack)
2478933/2478932    0.477    0.000    0.477    0.000 {isinstance}
382393/193    0.431    0.000    5.924    0.031 ndr.py:293(unpack)
    39882    0.273    0.000    1.840    0.000 ndr.py:1212(__init__)
   565510    0.241    0.000    0.331    0.000 ndr.py:198(calculatePad)
    39139    0.230    0.000    0.230    0.000 {print}
```
Tests are passing for this code.