### PR TITLE
ldapattack: fix error when trying to escalate with machine account

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -301,8 +301,12 @@ class LDAPAttack(ProtocolAttack):
         restoredata = {}
 
         # Query for the sid of our user
-        self.client.search(userDn, '(objectCategory=user)', attributes=['sAMAccountName', 'objectSid'])
-        entry = self.client.entries[0]
+        try:
+            self.client.search(userDn, '(objectClass=user)', attributes=['sAMAccountName', 'objectSid'])
+            entry = self.client.entries[0]
+        except IndexError:
+            LOG.error('Could not retrieve infos for user: %s' % userDn)
+            return
         username = entry['sAMAccountName'].value
         usersid = entry['objectSid'].value
         LOG.debug('Found sid for user %s: %s' % (username, usersid))


### PR DESCRIPTION
When relaying to ldap/ldaps and trying to escalate with a machine
account, the machine account is found by getUserInfo() but not by
aclAttack(). aclAttack assumes that the objectCategory=user which
machine accounts are not. By being a little more generic,
objectClass=user will allow to use both categories of objects.

```
# ntlmrelayx.py -smb2support -t  ldap://dc.domain.com --escalate-user 'testMachine$'
[...]
TypeName: {'ACCESS_ALLOWED_ACE'}
[*] HTTPD: Client requested path: /blahblah
[*] User privileges found: Create user
[*] User privileges found: Adding user to a privileged group (Enterprise Admins)
[*] User privileges found: Modifying domain ACL
Exception in thread Thread-5:
Traceback (most recent call last):
  File "/usr/lib/python3.7/threading.py", line 926, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.7/dist-packages/impacket-0.9.22.dev1+20200629.145357.5d4ad6cc-py3.7.egg/impacket/examples/ntlmrelayx/attacks/ldapattack.py", line 593, in run
    self.aclAttack(userDn, domainDumper)
  File "/usr/local/lib/python3.7/dist-packages/impacket-0.9.22.dev1+20200629.145357.5d4ad6cc-py3.7.egg/impacket/examples/ntlmrelayx/attacks/ldapattack.py", line 305, in aclAttack
    entry = self.client.entries[0]
IndexError: list index out of range
```

After trying the same thing with the patch, everything works well and the machine account gets DA privileges both with ACL and is added to privileged group.