### PR TITLE
httpRelayServer: read body content for POST requests

### DIFF
--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -219,6 +219,15 @@ class HTTPRelayServer(Thread):
             return self.do_GET()
 
         def do_GET(self):
+            # Get the body of the request if any
+            # Otherwise, successive requests will not be handled properly
+            if PY2:
+                contentLength = self.headers.getheader("Content-Length")
+            else:
+                contentLength = self.headers.get("Content-Length")
+            if contentLength is not None:
+                body = self.rfile.read(int(contentLength))
+
             messageType = 0
             if self.server.config.mode == 'REDIRECT':
                 self.do_SMBREDIRECT()


### PR DESCRIPTION
Web clients receiving a 401 Unauthorized header as a response, depending
on the Keep-alive header, may authenticate inside the same TCP stream,
or close the first one and open another.
In the first case, if the client was sending a POST request with data in
the content body, the content body was parsed by handle_one_request()
as a new (invalid) request, thus causing an issue with the parsing of the following
request where the Authorization header was actually presented.

To reproduce the issue I have developed a small python script, which connects to our ntlmrelayx HTTP Server, sends a first POST request with a body, and then, if faced to a 401-Unauthorized status code, tries to authenticate using NTLM:
```
#!/usr/bin/env python

import socket

# Open connection with malicious server
sock = socket.socket()
sock.connect(("127.0.0.1",80))

# Send an unauthenticated post Request:
req1 = 'POST /test1 HTTP/1.1\r\n\
Cache-Control: no-cache\r\n\
Connection: Keep-Alive\r\n\
Pragma: no-cache\r\n\
Content-Type: text/xml; charset=utf-8\r\n\
Content-Length: 94\r\n\
Host: test\r\n\
\r\n\
<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body></s:Body></s:Envelope>'

sock.send(req1.encode())
response1 = sock.recv(8069)
print(response1)

# When receiving a 401 Unauthorized, try to authenticate with NTLM
# using the same TCP socket
req2 = 'POST /test2 HTTP/1.1\r\n\
Cache-Control: no-cache\r\n\
Connection: Keep-Alive\r\n\
Pragma: no-cache\r\n\
Content-Type: text/xml; charset=utf-8\r\n\
Content-Length: 0\r\n\
Host: test\r\n\
Authorization: NTLM TlRMTVNTUAABAAAAB4IIogAAAAAAAAAAAAAAAAAAAAAKAGNFAAAADw==\r\n\
\r\n\
'

sock.send(req2.encode())
response2 = sock.recv(8069)
print(response2)

```

On the server side, we can see that the HTTP connection was received but the first single request (/test1) was kind of handled 3 times, whereas the second request (/test2) was not parsed at all:
```
[*] Servers started, waiting for connections
[*] HTTPD: Received connection from 127.0.0.1, attacking target ldap://172.16.200.5
[*] HTTPD: Client requested path: /test1
[*] HTTPD: Client requested path: /test1
[*] HTTPD: Client requested path: /test1

```

In this example, another 401 Unauthorized response is sent, when the client actually tries to authenticate using NTLM, with a valid Authorization header:
![httpServerIssueReproduced](https://user-images.githubusercontent.com/8790185/89042685-527e3c00-d315-11ea-9a3e-bfc87c3fd31d.png)

Actually depending on the body of the first request (test1), the server may not respond to /test2 at all.

Because of this, I believe many POST requests were not properly handled and relayed when they could have been.