### PR TITLE
Add smbpasswd.py script

### DIFF
--- a/examples/smbpasswd.py
+++ b/examples/smbpasswd.py
@@ -57,7 +57,7 @@ def hSamrUnicodeChangePasswordUser2(username, currpass, newpass, target):
 		if resp['ErrorCode'] == 0:
 			print('[+] Password was changed successfully.')
 		else:
-			print('[?] Non-zero return code, something weird happend.')
+			print('[?] Non-zero return code, something weird happened.')
 			resp.dump()
 
 
@@ -87,8 +87,7 @@ if __name__ == '__main__':
 
 	if args.newpass is None:
 		newpass = getpass('New SMB password: ')
-		newpass_verify = getpass('Retype new SMB password: ')
-		if newpass != newpass_verify:
+		if newpass != getpass('Retype new SMB password: '):
 			print('Password does not match, try again.')
 			sys.exit(2)
 	else:

--- a/examples/smbpasswd.py
+++ b/examples/smbpasswd.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+#
+# SECUREAUTH LABS. Copyright 2018 SecureAuth Corporation. All rights reserved.
+#
+# This software is provided under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Description:
+#  This script is an alternative to smbpasswd tool for changing Windows
+#  passwords over SMB (MSRPC-SAMR) remotely from Linux with a single shot to
+#  SamrUnicodeChangePasswordUser2 function (Opnum 55).
+#
+# Author:
+#  Sam Freeside (@snovvcrash)
+#
+# References:
+#  https://github.com/samba-team/samba/blob/master/source3/utils/smbpasswd.c
+#  https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/acb3204a-da8b-478e-9139-1ea589edb880
+
+from argparse import ArgumentParser
+
+from impacket.dcerpc.v5 import transport, samr
+
+
+def connect(host_name_or_ip):
+	rpctransport = transport.SMBTransport(host_name_or_ip, filename=r'\samr')
+	if hasattr(rpctransport, 'set_credentials'):
+		rpctransport.set_credentials(username='', password='', domain='', lmhash='', nthash='', aesKey='') # null session
+
+	dce = rpctransport.get_dce_rpc()
+	dce.connect()
+	dce.bind(samr.MSRPC_UUID_SAMR)
+
+	return dce
+
+
+def hSamrUnicodeChangePasswordUser2(username, oldpass, newpass, target):
+	dce = connect(target)
+	resp = samr.hSamrUnicodeChangePasswordUser2(dce, '\x00', username, oldpass, newpass)
+	resp.dump()
+
+
+parser = ArgumentParser()
+parser.add_argument('username', help='username to change password for')
+parser.add_argument('oldpass', help='old password')
+parser.add_argument('newpass', help='new password')
+parser.add_argument('target', help='hostname or IP')
+args = parser.parse_args()
+
+hSamrUnicodeChangePasswordUser2(args.username, args.oldpass, args.newpass, args.target)

--- a/examples/smbpasswd.py
+++ b/examples/smbpasswd.py
@@ -15,7 +15,7 @@
 #  Sam Freeside (@snovvcrash)
 #
 # Example:
-#  python smbpasswd.py 'j.doe:Passw0rd!'@pc1.megacorp.local
+#  python smbpasswd.py 'j.doe'@pc1.megacorp.local
 #  python smbpasswd.py 'j.doe:Passw0rd!'@10.10.13.37 -newpass 'N3wPassw0rd!'
 #
 # References:
@@ -86,7 +86,7 @@ if __name__ == '__main__':
 		newpass = getpass('New SMB password: ')
 		newpass_verify = getpass('Retype new SMB password: ')
 		if newpass != newpass_verify:
-			print('[-] Password does not match, try again.')
+			print('Password does not match, try again.')
 			sys.exit(2)
 	else:
 		newpass = args.newpass

--- a/examples/smbpasswd.py
+++ b/examples/smbpasswd.py
@@ -46,7 +46,6 @@ def hSamrUnicodeChangePasswordUser2(username, currpass, newpass, target):
 
 	try:
 		resp = samr.hSamrUnicodeChangePasswordUser2(dce, '\x00', username, currpass, newpass)
-		#resp.dump()
 	except Exception as e:
 		if 'STATUS_WRONG_PASSWORD' in str(e):
 			print('[-] Current SMB password is not correct.')
@@ -55,7 +54,11 @@ def hSamrUnicodeChangePasswordUser2(username, currpass, newpass, target):
 		else:
 			raise e
 	else:
-		print('[+] Password was changed successfully.')
+		if resp['ErrorCode'] == 0:
+			print('[+] Password was changed successfully.')
+		else:
+			print('[?] Non-zero return code, something weird happend.')
+			resp.dump()
 
 
 def parse_target(target):

--- a/examples/smbpasswd.py
+++ b/examples/smbpasswd.py
@@ -35,10 +35,21 @@ def connect(host_name_or_ip):
 	return dce
 
 
-def hSamrUnicodeChangePasswordUser2(username, oldpass, newpass, target):
+def hSamrUnicodeChangePasswordUser2(username, currpass, newpass, target):
 	dce = connect(target)
-	resp = samr.hSamrUnicodeChangePasswordUser2(dce, '\x00', username, oldpass, newpass)
-	resp.dump()
+
+	try:
+		resp = samr.hSamrUnicodeChangePasswordUser2(dce, '\x00', username, currpass, newpass)
+		#resp.dump()
+	except Exception as e:
+		if 'STATUS_WRONG_PASSWORD' in str(e):
+			print('[-] Current SMB password is not correct.')
+		elif 'STATUS_PASSWORD_RESTRICTION' in str(e):
+			print('[-] Some password update rule has been violated. For example, the password may not meet length criteria.')
+		else:
+			raise e
+	else:
+		print('[+] Password was changed successfully.')
 
 
 parser = ArgumentParser()

--- a/examples/smbpasswd.py
+++ b/examples/smbpasswd.py
@@ -22,6 +22,8 @@
 #  https://github.com/samba-team/samba/blob/master/source3/utils/smbpasswd.c
 #  https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/acb3204a-da8b-478e-9139-1ea589edb880
 
+import sys
+from getpass import getpass
 from argparse import ArgumentParser
 
 from impacket.dcerpc.v5 import transport, samr


### PR DESCRIPTION
Added a script for changing Windows passwords over SMB (MSRPC-SAMR) remotely from Linux as an alternative to one of [smbpasswd](https://github.com/samba-team/samba/blob/master/source3/utils/smbpasswd.c) capabilities. The whole process can be done using CLI arguments without the need to jump into interactive prompt (like with smbpasswd). If the password is actually expired (`STATUS_PASSWORD_MUST_CHANGE (0xC0000224)` is raised), I have found no other tools except smbpasswd to make such a password change remotely.

The script binds to the `\samr` pipe with a null session and calls [SamrUnicodeChangePasswordUser2](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/acb3204a-da8b-478e-9139-1ea589edb880) to trigger the password change.