### PR TITLE
fix issue with switching to RC4

### DIFF
--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -166,7 +166,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
         r = sendReceive(message, domain, kdcHost)
     except KerberosError as e:
         if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
-            if supportedCiphers[0] in (constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value) and aesKey == '':
+            if supportedCiphers[0] in (constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value) and aesKey == b'':
                 supportedCiphers = (int(constants.EncryptionTypes.rc4_hmac.value),)
                 seq_set_iter(reqBody, 'etype', supportedCiphers)
                 message = encoder.encode(asReq)


### PR DESCRIPTION
If AES etypes aren't supported, the `KDC_ERR_ETYPE_NOSUPP` error returns but impacket doesn't switch to RC4 algorithm (etype 23) automatically. The problem is only related to Python 3

```
user@dev:~$ getTGT.py -debug lab/user:password
Impacket v0.9.22.dev1+20200813.221956.1c893884 - Copyright 2020 SecureAuth Corporation

[+] Impacket Library Installation Path: /home/user/.pyenv/versions/3.6.11/lib/python3.6/site-packages/impacket-0.9.22.dev1+20200813.221956.1c893884-py3.6.egg/impacket
[+] Trying to connect to KDC at LAB
Traceback (most recent call last):
  File "/home/user/.pyenv/versions/3.6.11/lib/python3.6/site-packages/impacket-0.9.22.dev1+20200813.221956.1c893884-py3.6.egg/EGG-INFO/scripts/getTGT.py", line 118, in <module>
    executer.run()
  File "/home/user/.pyenv/versions/3.6.11/lib/python3.6/site-packages/impacket-0.9.22.dev1+20200813.221956.1c893884-py3.6.egg/EGG-INFO/scripts/getTGT.py", line 57, in run
    self.__kdcHost)
  File "/home/user/.pyenv/versions/3.6.11/lib/python3.6/site-packages/impacket-0.9.22.dev1+20200813.221956.1c893884-py3.6.egg/impacket/krb5/kerberosv5.py", line 166, in getKerberosTGT
    r = sendReceive(message, domain, kdcHost)
  File "/home/user/.pyenv/versions/3.6.11/lib/python3.6/site-packages/impacket-0.9.22.dev1+20200813.221956.1c893884-py3.6.egg/impacket/krb5/kerberosv5.py", line 78, in sendReceive
    raise krbError
impacket.krb5.kerberosv5.KerberosError: Kerberos SessionError: KDC_ERR_ETYPE_NOSUPP(KDC has no support for encryption type)
Kerberos SessionError: KDC_ERR_ETYPE_NOSUPP(KDC has no support for encryption type)
```