### PR TITLE
Introduce the [MS-NLMP] 2.2.2.10 VERSION structure in NTLMAuthNegotiate messages

### DIFF
--- a/impacket/ntlm.py
+++ b/impacket/ntlm.py
@@ -261,7 +261,20 @@ class NTLMAuthMixin:
             build_v = struct.unpack('H',self['os_version'][2:4])
             return mayor_v,minor_v,build_v
         
-class NTLMAuthNegotiate(Structure, NTLMAuthMixin):
+# [MS-NLMP] 2.2.2.10 VERSION
+# https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/b1a6ceb2-f8ad-462b-b5af-f18527c48175
+class VERSION(Structure):
+    NTLMSSP_REVISION_W2K3 = 0x0F
+
+    structure = (
+        ('ProductMajorVersion', '<B=0'),
+        ('ProductMinorVersion', '<B=0'),
+        ('ProductBuild', '<H=0'),
+        ('Reserved', '3s=""'),
+        ('NTLMRevisionCurrent', '<B=self.NTLMSSP_REVISION_W2K3'),
+    )
+
+class NTLMAuthNegotiate(Structure):
 
     structure = (
         ('','"NTLMSSP\x00'),
@@ -301,17 +314,19 @@ class NTLMAuthNegotiate(Structure, NTLMAuthMixin):
     def getWorkstation(self):
         return self._workstation
 
+    def __hasNegotiateVersion(self):
+        return (self['flags'] & NTLMSSP_NEGOTIATE_VERSION) == NTLMSSP_NEGOTIATE_VERSION
+
     def getData(self):
         if len(self.fields['host_name']) > 0:
             self['flags'] |= NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED
         if len(self.fields['domain_name']) > 0:
             self['flags'] |= NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED
-        if len(self.fields['os_version']) > 0:
+        version_len = len(self.fields['os_version'])
+        if version_len > 0:
             self['flags'] |= NTLMSSP_NEGOTIATE_VERSION
-        if (self['flags'] & NTLMSSP_NEGOTIATE_VERSION) == NTLMSSP_NEGOTIATE_VERSION:
-            version_len = 8
-        else:
-            version_len = 0
+        elif self.__hasNegotiateVersion():
+            raise Exception('Must provide the os_version field if the NTLMSSP_NEGOTIATE_VERSION flag is set')
         if (self['flags'] & NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED) == NTLMSSP_NEGOTIATE_OEM_WORKSTATION_SUPPLIED:
             self['host_offset']=32 + version_len
         if (self['flags'] & NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED) == NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED:
@@ -329,9 +344,8 @@ class NTLMAuthNegotiate(Structure, NTLMAuthMixin):
         host_end    = self['host_len'] + host_offset
         self['host_name'] = data[ host_offset : host_end ]
 
-        hasOsInfo = self['flags'] & NTLMSSP_NEGOTIATE_VERSION
-        if len(data) >= 36 and hasOsInfo:
-            self['os_version'] = data[32:40]
+        if len(data) >= 36 and self.__hasNegotiateVersion():
+            self['os_version'] = VERSION(data[32:])
         else:
             self['os_version'] = ''
 

--- a/impacket/ntlm.py
+++ b/impacket/ntlm.py
@@ -251,16 +251,6 @@ class AV_PAIRS:
 
         return ans
 
-class NTLMAuthMixin:
-    def get_os_version(self):
-        if self['os_version'] == '':
-            return None
-        else:
-            mayor_v = struct.unpack('B',self['os_version'][0])[0]
-            minor_v = struct.unpack('B',self['os_version'][1])[0]
-            build_v = struct.unpack('H',self['os_version'][2:4])
-            return mayor_v,minor_v,build_v
-        
 # [MS-NLMP] 2.2.2.10 VERSION
 # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/b1a6ceb2-f8ad-462b-b5af-f18527c48175
 class VERSION(Structure):
@@ -387,7 +377,7 @@ class NTLMAuthChallenge(Structure):
         self['TargetInfoFields'] = data[self['TargetInfoFields_offset']:][:self['TargetInfoFields_len']]
         return self
         
-class NTLMAuthChallengeResponse(Structure, NTLMAuthMixin):
+class NTLMAuthChallengeResponse(Structure):
 
     structure = (
         ('','"NTLMSSP\x00'),
@@ -505,11 +495,6 @@ class NTLMAuthChallengeResponse(Structure, NTLMAuthMixin):
         lanman_offset = self['lanman_offset'] 
         lanman_end    = self['lanman_len'] + lanman_offset
         self['lanman'] = data[ lanman_offset : lanman_end]
-
-        #if len(data) >= 36: 
-        #    self['os_version'] = data[32:36]
-        #else:
-        #    self['os_version'] = ''
 
 class ImpacketStructure(Structure):
     def set_parent(self, other):

--- a/tests/SMB_RPC/test_ntlm.py
+++ b/tests/SMB_RPC/test_ntlm.py
@@ -26,9 +26,6 @@ class NTLMTests(unittest.TestCase):
         self.nonce = b('\x00'*16)
         self.plaintext = 'Plaintext'.encode('utf-16le')
 
-        print("## BEFORE RUNNING THESE TESTS")
-        print("Don't forget to set up aTime = '\\x00'*8 in computeResponseNTLMv2 otherwise the results won't be right. ")
-        print("Look for that in ntlm.py and uncomment the lines, comment the other ones and don't forget to revert everything back whenever finished testing")
         print("Flags")
         hexdump(struct.pack('<L',self.flags))
 

--- a/tests/SMB_RPC/test_ntlm.py
+++ b/tests/SMB_RPC/test_ntlm.py
@@ -294,6 +294,44 @@ class NTLMTests(unittest.TestCase):
         #raise
         print("\n")
 
+    def __pack_and_parse(self, message, expected):
+        data = message.getData()
+        hexdump(data)
+        self.assertEqual(data, expected)
+        parsed = ntlm.NTLMAuthNegotiate()
+        parsed.fromString(data)
+        return parsed
+
+    def test_refactor_negotiate_message(self):
+        print('#### Pack and parse, without version')
+        negoMsgToPack = ntlm.NTLMAuthNegotiate()
+        negoMsgParsed = self.__pack_and_parse(negoMsgToPack, bytearray(
+            b'NTLMSSP\x00\x01\x00\x00\x001\x02\x00`\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+        ))
+        self.assertEqual(negoMsgParsed['flags'] & ntlm.NTLMSSP_NEGOTIATE_VERSION, 0)
+        self.assertEqual(negoMsgParsed['os_version'], '')
+
+        print('#### Pack and parse, with version')
+        major, minor, build = 10, 0, 19041
+        version = ntlm.VERSION()
+        version['ProductMajorVersion'], version['ProductMinorVersion'], version['ProductBuild'] = major, minor, build
+        negoMsgToPack = ntlm.NTLMAuthNegotiate()
+        negoMsgToPack['os_version'] = version
+        negoMsgParsed = self.__pack_and_parse(negoMsgToPack, bytearray(
+            b'NTLMSSP\x00\x01\x00\x00\x001\x02\x00b\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+            b'\x0a\x00aJ\x00\x00\x00\x0f'
+        ))
+        self.assertEqual(negoMsgParsed['flags'] & ntlm.NTLMSSP_NEGOTIATE_VERSION, ntlm.NTLMSSP_NEGOTIATE_VERSION)
+        self.assertEqual(negoMsgParsed['os_version']['ProductMajorVersion'], major)
+        self.assertEqual(negoMsgParsed['os_version']['ProductMinorVersion'], minor)
+        self.assertEqual(negoMsgParsed['os_version']['ProductBuild'], build)
+
+        print('#### Try to set the NTLMSSP_NEGOTIATE_VERSION flag without specifying os_version')
+        negoMsgToPack = ntlm.NTLMAuthNegotiate()
+        negoMsgToPack['flags'] |= ntlm.NTLMSSP_NEGOTIATE_VERSION
+        self.assertRaises(Exception, negoMsgToPack.getData)
+
+
 if __name__ == '__main__':
     import sys
     if len(sys.argv) > 1:


### PR DESCRIPTION
While making some tests to *Core Impact* (at the @HelpSystems' development team), we found a little issue in [impacket/ntlm.py:261](/SecureAuthCorp/impacket/blob/b5fa089b058b097037efd79760d71bae39524948/impacket/ntlm.py#L261), introduced in 8c440da2. This code was internally tracked and found to be initially written in this way, with the missing `[0]` at the end of `struct.unpack(...)` (we can see that it isn't missing in the two previous `struct.unpack` calls).

Instead of adding the missing `[0]`, we found that this binary data belongs to the [2.2.2.10 VERSION structure](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/b1a6ceb2-f8ad-462b-b5af-f18527c48175) and decided to fix the issue by implementing it.

We also include a little test where the expected assertion data of the first check (`#### Pack and parse, without version`) was generated using the previous version of the code (without this *pull-request* changes).

We don't think that there is any client of this code besides us, but just in case the usages need to be adjusted as follows:
```python
# old code:
os_version = negotiate_message.get_os_version()

# new code:
v = negotiate_message['os_version']
os_version = (v['ProductMajorVersion'], v['ProductMinorVersion'], v['ProductBuild']) if v else None
```