### PR TITLE
Avoid SyntaxWarning on Python >= 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 group: travis_latest
+os: linux
+dist: focal
 language: python
 cache: pip
 
-matrix:
+jobs:
   include:
     - python: 2.7
       env: NO_REMOTE=true, TOXENV=py27
@@ -10,7 +12,6 @@ matrix:
       env: NO_REMOTE=true, TOXENV=py36
     - python: 3.7
       env: NO_REMOTE=true, TOXENV=py37
-      dist: xenial  # required for Python >= 3.7
 
 install: pip install flake8 tox -r requirements.txt
   

--- a/examples/netview.py
+++ b/examples/netview.py
@@ -127,7 +127,7 @@ class USERENUM:
     def getDomainMachines(self):
         if self.__kdcHost is not None:
             domainController = self.__kdcHost
-        elif self.__domain is not '':
+        elif self.__domain != '':
             domainController = self.__domain
         else:
             raise Exception('A domain is needed!')


### PR DESCRIPTION
Avoid [SyntaxWarnings on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8`
```
>>> "" is ""
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```
Also, fix:
<img width="703" alt="Screenshot 2020-09-02 at 15 28 03" src="https://user-images.githubusercontent.com/3709715/91989907-5c8ac480-ed31-11ea-8207-bb8ac6267781.png">
