### PR TITLE
Add pyreadline requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyOpenSSL>=0.16.2
 ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6
 ldapdomaindump>=0.9.0
 flask>=1.0
+pyreadline


### PR DESCRIPTION
It's necessary on Windows.
It's already covered in setup.py:
https://github.com/SecureAuthCorp/impacket/blob/7e50589280b07ce6814adf97a0492917dc5a6620/setup.py#L63
But that doesn't apply if we install dependencies via pip and requirements.txt

It led to some issues #688 #640 #472
Hence this small suggestion :) Except if you already thought about it!