### PR TITLE
Fix reading binary file error while using custom exe file

### DIFF
--- a/examples/goldenPac.py
+++ b/examples/goldenPac.py
@@ -121,7 +121,7 @@ class PSEXEC:
                 installService = serviceinstall.ServiceInstall(rpctransport.get_smb_connection(), remcomsvc.RemComSvc())
             else:
                 try:
-                    f = open(self.__exeFile)
+                    f = open(self.__exeFile, 'rb')
                 except Exception as e:
                     logging.critical(str(e))
                     sys.exit(1)

--- a/examples/psexec.py
+++ b/examples/psexec.py
@@ -137,7 +137,7 @@ class PSEXEC:
                 installService = serviceinstall.ServiceInstall(rpctransport.get_smb_connection(), remcomsvc.RemComSvc(), self.__serviceName, self.__remoteBinaryName)
             else:
                 try:
-                    f = open(self.__exeFile)
+                    f = open(self.__exeFile, 'rb')
                 except Exception as e:
                     logging.critical(str(e))
                     sys.exit(1)

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -162,7 +162,7 @@ class PSEXEC:
                 installService = serviceinstall.ServiceInstall(rpctransport.get_smb_connection(), remcomsvc.RemComSvc())
             else:
                 try:
-                    f = open(self.__exeFile)
+                    f = open(self.__exeFile, 'rb')
                 except Exception as e:
                     logging.critical(str(e))
                     sys.exit(1)

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -108,6 +108,9 @@ class SMBConnection:
             else:
                 self._remoteName = res
 
+        if self._sess_port == nmb.NETBIOS_SESSION_PORT:
+            negoData = '\x02NT LM 0.12\x00\x02SMB 2.002\x00'
+
         hostType = nmb.TYPE_SERVER
         if preferredDialect is None:
             # If no preferredDialect sent, we try the highest available one.


### PR DESCRIPTION
When using psexec.py `-file` option, I encounter an error. 

```
psexec.py -file /tmp/artifact.exe Administrator@dc
Impacket v0.9.21 - Copyright 2020 SecureAuth Corporation

Password:
[*] Requesting shares on dc.....
[*] Found writable share ADMIN$
[*] Uploading file vruNKNIG.exe
[-] Error uploading file vruNKNIG.exe, aborting.....
[-] Error performing the installation, cleaning up: 'utf-8' codec can't decode byte 0x90 in position 2: invalid start byte
```

Using `open` with `rb` flags would fix this issue. So I replaced all the `open(self.__exeFile)` to `open(self.__exeFile, 'rb')`.