### PR TITLE
Convert b64encode from bytes to str to fix NTLM content in HTTP header

### DIFF
--- a/impacket/examples/ntlmrelayx/clients/httprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/httprelayclient.py
@@ -65,7 +65,7 @@ class HTTPRelayClient(ProtocolClient):
             return False
 
         #Negotiate auth
-        negotiate = base64.b64encode(negotiateMessage)
+        negotiate = base64.b64encode(negotiateMessage).decode("ascii")
         headers = {'Authorization':'NTLM %s' % negotiate}
         self.session.request('GET', self.path ,headers=headers)
         res = self.session.getresponse()
@@ -85,7 +85,7 @@ class HTTPRelayClient(ProtocolClient):
             token = respToken2['ResponseToken']
         else:
             token = authenticateMessageBlob
-        auth = base64.b64encode(token)
+        auth = base64.b64encode(token).decode("ascii")
         headers = {'Authorization':'NTLM %s' % auth}
         self.session.request('GET', self.path,headers=headers)
         res = self.session.getresponse()


### PR DESCRIPTION
Otherwise we get nasty stuff like this which make everything fail!
![image](https://user-images.githubusercontent.com/550823/92130161-b4463000-ee04-11ea-82c8-a4f0eb05f7db.png)

Similar correct code is already present in many other locations, ex.
https://github.com/SecureAuthCorp/impacket/blob/b5fa089b058b097037efd79760d71bae39524948/impacket/http.py#L146