### PR TITLE
ntlmrelayx: "isinstance" needs a tuple of types, not a list

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -186,7 +186,7 @@ def start_servers(options, threads):
 def stop_servers(threads):
     todelete = []
     for thread in threads:
-        if isinstance(thread, RELAY_SERVERS):
+        if isinstance(thread, tuple(RELAY_SERVERS)):
             thread.server.shutdown()
             todelete.append(thread)
     # Now remove threads from the set


### PR DESCRIPTION
Fixes this error:
```
  File ".../impacket/examples/ntlmrelayx.py", line 125, in do_stopservers
    stop_servers(self.relayThreads)
  File ".../impacket/examples/ntlmrelayx.py", line 191, in stop_servers
    if isinstance(thread, RELAY_SERVERS):
TypeError: isinstance() arg 2 must be a type or tuple of types
```

Not tested with Python2 though...