### PR TITLE
Update comments

### DIFF
--- a/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
@@ -60,14 +60,12 @@ class LDAPRelayClient(ProtocolClient):
         return True
 
     def sendNegotiate(self, negotiateMessage):
-        # Remove the message signing flag
-        # For SMB->LDAP this is required otherwise it triggers LDAP signing
-
-        # Note that this code is commented out because changing flags breaks the signature
-        # unless the client uses a non-standard implementation of NTLM
         negoMessage = NTLMAuthNegotiate()
         negoMessage.fromString(negotiateMessage)
-        # When exploiting CVE-2019-1040, remove flags
+
+        # When exploiting CVE-2019-1040, remove message signing flag
+        # For SMB->LDAP this is required otherwise it triggers LDAP signing
+        # Changing flags breaks the signature unless the client uses a non-standard implementation of NTLM
         if self.serverConfig.remove_mic:
             if negoMessage['flags'] & NTLMSSP_NEGOTIATE_SIGN == NTLMSSP_NEGOTIATE_SIGN:
                 negoMessage['flags'] ^= NTLMSSP_NEGOTIATE_SIGN


### PR DESCRIPTION
The code was previously commented:
https://github.com/SecureAuthCorp/impacket/commit/5f5d3ea25509e96e51c6afb12fbf3bcc7335b1df#diff-28a09571e4ddba87c1fb925596f1d744L67

But it isn't anymore as it's controlled by the "--remove-mic" option

I re-organized the messages too, I hope I didn't get the meaning wrong :)