### PR TITLE
Catch DistributionNotFound exception when trying to get version number and package not installed

### DIFF
--- a/impacket/version.py
+++ b/impacket/version.py
@@ -12,6 +12,8 @@ try:
     version = pkg_resources.get_distribution('impacket').version
 except pkg_resources.DistributionNotFound:
     version = "?"
+    print("Cannot determine Impacket version. "
+          "If running from source you should at least run \"python setup.py egg_info\"")
 BANNER = "Impacket v{} - Copyright 2020 SecureAuth Corporation\n".format(version)
 
 def getInstallationPath():

--- a/impacket/version.py
+++ b/impacket/version.py
@@ -8,7 +8,11 @@ import pkg_resources
 from impacket import __path__
 
 
-BANNER = "Impacket v{} - Copyright 2020 SecureAuth Corporation\n".format(pkg_resources.get_distribution('impacket').version)
+try:
+    version = pkg_resources.get_distribution('impacket').version
+except pkg_resources.DistributionNotFound:
+    version = "?"
+BANNER = "Impacket v{} - Copyright 2020 SecureAuth Corporation\n".format(version)
 
 def getInstallationPath():
     return 'Impacket Library Installation Path: {}'.format(__path__[0])


### PR DESCRIPTION
For example when running it for development in an IDE

In my case I'm doing some dev with PyCharm on Windows where I never installed the "impacket" package. Just running the examples from the source-code folder. It runs nice except that `pkg_resources` cannot get version number since it isn't installed.
Better to show "v?" instead of crashing!