### PR TITLE
Fix "exception is not subscriptable" error

### DIFF
--- a/impacket/examples/ntlmrelayx/clients/smbrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/smbrelayclient.py
@@ -276,14 +276,11 @@ class SMBRelayClient(ProtocolClient):
             packet = self.session.negotiateSessionWildcard(None, self.targetHost, self.targetHost, self.targetPort, 60, self.extendedSecurity,
                                                   flags1=SMB.FLAGS1_PATHCASELESS | SMB.FLAGS1_CANONICALIZED_PATHS,
                              flags2=flags2, data=data)
-        except socketerror as e:
-            if 'reset by peer' in str(e):
-                if not self.serverConfig.smb2support:
-                    LOG.error('SMBCLient error: Connection was reset. Possibly the target has SMBv1 disabled. Try running ntlmrelayx with -smb2support')
-                else:
-                    LOG.error('SMBCLient error: Connection was reset')
+        except Exception as e:
+            if not self.serverConfig.smb2support:
+                LOG.error('SMBClient error: Connection was reset. Possibly the target has SMBv1 disabled. Try running ntlmrelayx with -smb2support')
             else:
-                LOG.error('SMBCLient error: %s' % str(e))
+                LOG.error('SMBClient error: Connection was reset')
             return False
         if packet[0:1] == b'\xfe':
             preferredDialect = None

--- a/impacket/nmb.py
+++ b/impacket/nmb.py
@@ -556,8 +556,8 @@ class NetBIOS:
                             raise NetBIOSError('Negative response', ERRCLASS_QUERY, res['FLAGS'] & 0xf)
                         return res
             except select.error as ex:
-                if ex[0] != errno.EINTR and ex[0] != errno.EAGAIN:
-                    raise NetBIOSError('Error occurs while waiting for response', ERRCLASS_OS, ex[0])
+                if ex.errno != errno.EINTR and ex.errno != errno.EAGAIN:
+                    raise NetBIOSError('Error occurs while waiting for response', ERRCLASS_OS, ex.errno)
             except socket.error as ex:
                 raise NetBIOSError('Connection error: %s' % str(ex))
 
@@ -960,8 +960,8 @@ class NetBIOSTCPSession(NetBIOSSession):
                 data = data + received
                 bytes_left = read_length - len(data)
             except select.error as ex:
-                if ex[0] != errno.EINTR and ex[0] != errno.EAGAIN:
-                    raise NetBIOSError('Error occurs while reading from remote', ERRCLASS_OS, ex[0])
+                if ex.errno != errno.EINTR and ex.errno != errno.EAGAIN:
+                    raise NetBIOSError('Error occurs while reading from remote', ERRCLASS_OS, ex.errno)
 
         return bytes(data)
 
@@ -980,7 +980,7 @@ class NetBIOSTCPSession(NetBIOSSession):
             except socket.timeout:
                 raise NetBIOSTimeout
             except Exception as ex:
-                raise NetBIOSError('Error occurs while reading from remote', ERRCLASS_OS, ex[0])
+                raise NetBIOSError('Error occurs while reading from remote', ERRCLASS_OS, ex.errno)
 
             if (time.time() - start_time) > timeout:
                 raise NetBIOSTimeout

--- a/tests/SMB_RPC/test_smb.py
+++ b/tests/SMB_RPC/test_smb.py
@@ -269,7 +269,7 @@ class SMBTests(unittest.TestCase):
         try:
             select.select([s], [], [], 0)
         except socket.error as e:
-            if e[0] == errno.EBADF:
+            if e.errno == errno.EBADF:
                 is_socket_opened = False
         except ValueError:
             is_socket_opened = False


### PR DESCRIPTION
ex.errno is the way to get the exception "errno" in Python 2 and 3
Fixes #934

Inspired by: https://opendev.org/zuul/nodepool/commit/d1fb0d402ea88b29d481ff384ef6a6da0a03dc9d