### PR TITLE
Travis CI: Add Python 3.8 to the testing (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,18 @@ jobs:
       env: NO_REMOTE=true, TOXENV=py36
     - python: 3.7
       env: NO_REMOTE=true, TOXENV=py37
+    - python: 3.8
+      env: NO_REMOTE=true, TOXENV=py38
+    - python: 3.9-dev
+      env: NO_REMOTE=true, TOXENV=py39
+  allow_failures:
+    - python: 3.9-dev
 
 install: pip install flake8 tox -r requirements.txt
   
 before_script:
   # stop the build if there are Python syntax errors or undefined names
-  - flake8 . --count --select=E9,F72,F82 --show-source --statistics
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
   - flake8 . --count --ignore=E1,E2,E3,E501,W291,W293 --exit-zero --max-complexity=65 --max-line-length=127 --statistics
 

--- a/setup.py
+++ b/setup.py
@@ -61,11 +61,11 @@ setup(name = PACKAGE_NAME,
       install_requires=['pyasn1>=0.2.3', 'pycryptodomex', 'pyOpenSSL>=0.13.1', 'six', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6', 'ldapdomaindump>=0.9.0', 'flask>=1.0'],
       extras_require={
                       'pyreadline:sys_platform=="win32"': [],
-                      'python_version<"2.7"': [ 'argparse' ],
                     },
       classifiers = [
+          "Programming Language :: Python :: 3.8",
+          "Programming Language :: Python :: 3.7",
           "Programming Language :: Python :: 3.6",
           "Programming Language :: Python :: 2.7",
-          "Programming Language :: Python :: 2.6",
       ]
       )

--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,15 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-#envlist = py26#, py27,py36,py37
-envlist = py27,py36,py37
+envlist = py27,py36,py37,py38,py39
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
     py36: python3.6
     py37: python3.7
+    py38: python3.8
+    py39: python3.9
 changedir = {toxinidir}/tests
 deps=-rrequirements.txt
-    coverage
-    py26: wheel==0.29.0
     coverage
 passenv = NO_REMOTE
 commands_pre = {envpython} -m pip check


### PR DESCRIPTION
A second attempt at #732 now that #931 has landed.

We leave `Python 3.9 release candidate 1` in allow_failures mode because of
https://docs.python.org/3.9/whatsnew/3.9.html#removed which should be fixed in a follow-up pull request.