### PR TITLE
Avoid cipher_list DeprecationWarning on Python3

### DIFF
--- a/examples/rdp_check.py
+++ b/examples/rdp_check.py
@@ -406,7 +406,7 @@ if __name__ == '__main__':
 
        # Switching to TLS now
        ctx = SSL.Context(SSL.TLSv1_2_METHOD)
-       ctx.set_cipher_list('RC4,AES')
+       ctx.set_cipher_list(b'RC4,AES')
        tls = SSL.Connection(ctx,s)
        tls.set_connect_state()
        tls.do_handshake()


### PR DESCRIPTION
there is a DeprecationWarning when using python3 (version 3.8.5) to execute `example/rdp_check.py`

```bash
python3 rdp_check.py offensive/administrator:"password"@dc2019
```

```
Impacket v0.9.21 - Copyright 2020 SecureAuth Corporation

rdp_check.py:409: DeprecationWarning: str for cipher_list is no longer accepted, use bytes
  ctx.set_cipher_list('RC4,AES')
```