### PR TITLE
Remove superfluous UTF16 encoding

### DIFF
--- a/impacket/examples/ntlmrelayx/utils/enum.py
+++ b/impacket/examples/ntlmrelayx/utils/enum.py
@@ -59,6 +59,6 @@ class EnumLocalAdmins:
         resp = lsat.hLsarLookupSids(dce, policyHandle, sids, lsat.LSAP_LOOKUP_LEVEL.LsapLookupWksta)
         names = []
         for n, item in enumerate(resp['TranslatedNames']['Names']):
-            names.append("{}\\{}".format(resp['ReferencedDomains']['Domains'][item['DomainIndex']]['Name'].encode('utf-16-le'), item['Name']))
+            names.append("{}\\{}".format(resp['ReferencedDomains']['Domains'][item['DomainIndex']]['Name'], item['Name']))
         dce.disconnect()
         return names


### PR DESCRIPTION
It's already a string and it gives an ugly UTF16 output when using --enum-local-admins (and only on the first part which is the domain)