### PR TITLE
Small fix in secretsdump cleanup

### DIFF
--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -684,7 +684,7 @@ class RemoteOperations:
         if self.__disabled is True:
             LOG.info('Restoring the disabled state for service %s' % self.__serviceName)
             scmr.hRChangeServiceConfigW(self.__scmr, self.__serviceHandle, dwStartType = 0x4)
-        if self.__serviceDeleted is False:
+        if self.__serviceDeleted is False and self.__tmpServiceName is not None:
             # Check again the service we created does not exist, starting a new connection
             # Why?.. Hitting CTRL+C might break the whole existing DCE connection
             try:


### PR DESCRIPTION
The cleanup part initiates a new connection to the target, even if no cleanup is needed because no service was actually created/modified. Added an extra check to skip this in cases such as dcsync where this doesn't apply