### PR TITLE
Fix issue when relaying and creating computer in CN=Computers

### DIFF
--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -709,7 +709,15 @@ class LDAPAttack(ProtocolAttack):
         # Add a new computer if that is requested
         # privileges required are not yet enumerated, neither is ms-ds-MachineAccountQuota
         if self.config.addcomputer:
-            self.addComputer('CN=Computers,%s' % domainDumper.root, domainDumper)
+            self.client.search(domainDumper.root, "(ObjectClass=domain)", attributes=['wellKnownObjects'])
+            # Computer well-known GUID
+            # https://social.technet.microsoft.com/Forums/windowsserver/en-US/d028952f-a25a-42e6-99c5-28beae2d3ac3/how-can-i-know-the-default-computer-container?forum=winservergen
+            computerscontainer = [
+                entry.decode('utf-8').split(":")[-1] for entry in self.client.entries[0]["wellKnownObjects"]
+                if b"AA312825768811D1ADED00C04FD8D5CD" in entry
+            ][0]
+            LOG.debug("Computer container is {}".format(computerscontainer))
+            self.addComputer(computerscontainer, domainDumper)
             return
 
         # Last attack, dump the domain if no special privileges are present


### PR DESCRIPTION
Hello,

When using `--add-computer` attack parameter, `ldapattack.py` uses default `CN=Computers,DC=contoso,DC=local` for computer creation.

But admins can use `redicmp` ([doc](https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc770619(v=ws.11))) to change default computer destination.

During my last engagement, users weren't authorized to write to CN=Computers but they were authorized to write to the newly set **Computers Container** location.

This PR fixes this issue and uses the default value stored in `wellKnownObjects` attribute on domain object and extracts the correct location by using the "Default computer location" GUID ([AA312825768811D1ADED00C04FD8D5CD](https://social.technet.microsoft.com/Forums/windowsserver/en-US/d028952f-a25a-42e6-99c5-28beae2d3ac3/how-can-i-know-the-default-computer-container?forum=winservergen)).

**Before**

![image](https://user-images.githubusercontent.com/11051803/97088028-790af500-162e-11eb-9393-334d639164c8.png)

**After**

![image](https://user-images.githubusercontent.com/11051803/97088127-1bc37380-162f-11eb-8d90-31ea3ca7c093.png)

