### PR TITLE
Kerberos: try to connect to every KDC with a timeout

### DIFF
--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -55,9 +55,7 @@ def sendReceive(data, host, kdcHost):
 
     LOG.debug('Trying to connect to KDC at %s' % targetHost)
     try:
-        af, socktype, proto, canonname, sa = socket.getaddrinfo(targetHost, 88, 0, socket.SOCK_STREAM)[0]
-        s = socket.socket(af, socktype, proto)
-        s.connect(sa)
+        s = socket.create_connection((targetHost, 88), 2.0)
     except socket.error as e:
         raise socket.error("Connection error (%s:%s)" % (targetHost, 88), e)
 


### PR DESCRIPTION
Currently, impacket implementation of Kerberos retrieves KDCs of a Kerberos realm using DNS. However, it only tries to connect to the first address returned (`[0]`) and fails in case of error. The problem is that the first address returned by the DNS server might be down whereas others are up. Moreover, no timeout is configured so `socket.connect` hangs for a while (something like 1 minute) before throwing a `TimeoutError`.

I propose to replace `socket.connect` by `socket.create_connection`: it tries to connect to all possible addresses in turn until a connection succeeds and it supports a timeout option.