### PR TITLE
array.array: to- and fromstring() methods removed.

### DIFF
--- a/impacket/ICMP6.py
+++ b/impacket/ICMP6.py
@@ -10,6 +10,7 @@ import struct
 
 from impacket.ImpactPacket import Header, Data
 from impacket.IP6_Address import IP6_Address
+from impacket.compat import tobytes
 
 
 class ICMP6(Header):    
@@ -234,7 +235,7 @@ class ICMP6(Header):
         icmp_bytes = struct.pack('>H', id)
         icmp_bytes += struct.pack('>H', sequence_number)
         if (arbitrary_data is not None):
-            icmp_bytes += array.array('B', arbitrary_data).tostring()
+            icmp_bytes += tobytes(array.array('B', arbitrary_data))
         icmp_payload = Data()
         icmp_payload.set_data(icmp_bytes)
         
@@ -273,9 +274,9 @@ class ICMP6(Header):
         icmp_packet.set_code(code)
         
         #Pack ICMP payload
-        icmp_bytes = array.array('B', data).tostring()
+        icmp_bytes = tobytes(array.array('B', data))
         if (originating_packet_data is not None):
-            icmp_bytes += array.array('B', originating_packet_data).tostring()
+            icmp_bytes += tobytes(array.array('B', originating_packet_data))
         icmp_payload = Data()
         icmp_payload.set_data(icmp_bytes)
         
@@ -302,11 +303,11 @@ class ICMP6(Header):
         icmp_packet.set_code(0)
         
         # Flags + Reserved
-        icmp_bytes = array.array('B', [0x00] * 4).tostring()       
+        icmp_bytes = tobytes(array.array('B', [0x00] * 4))
         
         # Target Address: The IP address of the target of the solicitation.
         # It MUST NOT be a multicast address.
-        icmp_bytes += array.array('B', IP6_Address(target_address).as_bytes()).tostring()
+        icmp_bytes += tobytes(array.array('B', IP6_Address(target_address).as_bytes()))
         
         icmp_payload = Data()
         icmp_payload.set_data(icmp_bytes)
@@ -394,10 +395,10 @@ class ICMP6(Header):
         
         icmp_bytes = struct.pack('>H', qtype)
         icmp_bytes += struct.pack('>H', flags)
-        icmp_bytes += array.array('B', nonce).tostring()
+        icmp_bytes += tobytes(array.array('B', nonce))
         
         if payload is not None:
-            icmp_bytes += array.array('B', payload).tostring()
+            icmp_bytes += tobytes(array.array('B', payload))
         
         icmp_payload = Data()
         icmp_payload.set_data(icmp_bytes)

--- a/impacket/IP6.py
+++ b/impacket/IP6.py
@@ -11,6 +11,7 @@ import array
 from impacket.ImpactPacket import Header
 from impacket.IP6_Address import IP6_Address
 from impacket.IP6_Extension_Headers import IP6_Extension_Header
+from impacket.compat import frombytes
 
 from impacket import LOG
 
@@ -78,9 +79,9 @@ class IP6(Header):
         pseudo_header = array.array('B')        
         pseudo_header.extend(source_address)
         pseudo_header.extend(destination_address)
-        pseudo_header.fromstring(struct.pack('!L', upper_layer_packet_length))
+        frombytes(pseudo_header, struct.pack('!L', upper_layer_packet_length))
         pseudo_header.fromlist(reserved_bytes)
-        pseudo_header.fromstring(struct.pack('B', upper_layer_protocol_number))
+        frombytes(pseudo_header, struct.pack('B', upper_layer_protocol_number))
         return pseudo_header
     
 ############################################################################

--- a/impacket/NDP.py
+++ b/impacket/NDP.py
@@ -10,6 +10,7 @@ import struct
 
 from impacket import ImpactPacket
 from impacket.ICMP6 import ICMP6
+from impacket.compat import tobytes
 
 
 class NDP(ICMP6):
@@ -51,7 +52,7 @@ class NDP(ICMP6):
     @classmethod
     def Neighbor_Solicitation(class_object, target_address):        
         message_data = struct.pack('>L', 0) #Reserved bytes
-        message_data += target_address.as_bytes().tostring()
+        message_data += tobytes(target_address.as_bytes())
         return class_object.__build_message(NDP.NEIGHBOR_SOLICITATION, message_data)
 
 
@@ -66,15 +67,15 @@ class NDP(ICMP6):
             flag_byte |= 0x20
             
         message_data = struct.pack('>BBBB', flag_byte, 0x00, 0x00, 0x00) #Flag byte and three reserved bytes
-        message_data += target_address.as_bytes().tostring()
+        message_data += tobytes(target_address.as_bytes())
         return class_object.__build_message(NDP.NEIGHBOR_ADVERTISEMENT, message_data)
 
 
     @classmethod
     def Redirect(class_object, target_address, destination_address):        
         message_data = struct.pack('>L', 0)# Reserved bytes
-        message_data += target_address.as_bytes().tostring()
-        message_data += destination_address.as_bytes().tostring()
+        message_data += tobytes(target_address.as_bytes())
+        message_data += tobytes(destination_address.as_bytes())
         return class_object.__build_message(NDP.REDIRECT, message_data)
 
     
@@ -118,7 +119,7 @@ class NDP_Option():
     #link_layer_address must have a size that is a multiple of 8 octets
     def __Link_Layer_Address(class_object, option_type, link_layer_address):
         option_length = (len(link_layer_address) / 8) + 1
-        option_data = array.array("B", link_layer_address).tostring()
+        option_data = tobytes(array.array("B", link_layer_address))
         return class_object.__build_option(option_type, option_length, option_data)
 
     @classmethod
@@ -134,7 +135,7 @@ class NDP_Option():
         
         option_data = struct.pack('>BBLL', prefix_length, flag_byte, valid_lifetime, preferred_lifetime)
         option_data += struct.pack('>L', 0) #Reserved bytes
-        option_data += array.array("B", prefix).tostring()
+        option_data += tobytes(array.array("B", prefix))
         option_length = 4        
         return class_object.__build_option(NDP_Option.PREFIX_INFORMATION, option_length, option_data)
         
@@ -142,7 +143,7 @@ class NDP_Option():
     @classmethod    
     def Redirected_Header(class_object, original_packet):
         option_data = struct.pack('>BBBBBB', 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)# Reserved bytes
-        option_data += array.array("B", original_packet).tostring()
+        option_data += tobytes(array.array("B", original_packet))
         option_length = (len(option_data) + 4) / 8  
         return class_object.__build_option(NDP_Option.REDIRECTED_HEADER, option_length, option_data)
     

--- a/impacket/cdp.py
+++ b/impacket/cdp.py
@@ -16,6 +16,7 @@ import socket
 
 from impacket.ImpactPacket import Header
 from impacket import LOG
+from impacket.compat import tobytes
 
 IP_ADDRESS_LENGTH = 4
 
@@ -124,11 +125,11 @@ class CDPElement(Header):
         return self.get_word(2)
                 
     def get_data(self):        
-        return self.get_bytes().tostring()[4:self.get_length()]
+        return tobytes(self.get_bytes())[4:self.get_length()]
 
     def get_ip_address(self, offset = 0, ip = None):
         if not ip:
-            ip = self.get_bytes().tostring()[offset : offset + IP_ADDRESS_LENGTH]
+            ip = tobytes(self.get_bytes())[offset : offset + IP_ADDRESS_LENGTH]
         return socket.inet_ntoa( ip )
         
 class CDPDevice(CDPElement):
@@ -149,7 +150,7 @@ class Address(CDPElement):
     def __init__(self, aBuffer = None):
         CDPElement.__init__(self, aBuffer)
         if aBuffer:
-            data = self.get_bytes().tostring()[8:]
+            data = tobytes(self.get_bytes())[8:]
             self._generateAddressDetails(data)
 
     def _generateAddressDetails(self, buff):
@@ -353,10 +354,10 @@ class ProtocolHello(CDPElement):
         return self.get_byte(19)
 
     def get_cluster_command_mac(self):
-        return self.get_bytes().tostring()[20:20+6]
+        return tobytes(self.get_bytes())[20:20+6]
             
     def get_switch_mac(self):
-        return self.get_bytes().tostring()[28:28+6]
+        return tobytes(self.get_bytes())[28:28+6]
             
     def get_management_vlan(self):
         return self.get_word(36)

--- a/impacket/compat.py
+++ b/impacket/compat.py
@@ -1,0 +1,17 @@
+"""
+Compatibility module
+"""
+import array
+if hasattr(array.array, 'frombytes'):
+    def frombytes(a, b):
+        return a.frombytes(b)
+else:
+    def frombytes(a, b):
+         return a.fromstring(b)
+
+if hasattr(array.array, 'tobytes'):
+    def tobytes(a):
+        return a.tobytes()
+else:
+    def tobytes(a):
+         return a.tostring()

--- a/impacket/dot11.py
+++ b/impacket/dot11.py
@@ -15,6 +15,7 @@ from binascii import crc32
 
 from impacket.ImpactPacket import ProtocolPacket
 from impacket.Dot11Crypto import RC4
+from impacket.compat import tobytes
 frequency = {
     2412: 1,    2417: 2,    2422: 3,    2427: 4,    2432: 5,    2437: 6,    2442: 7,    2447: 8,    2452: 9,
     2457: 10,   2462: 11,   2467: 12,   2472: 13,   2484: 14,   5170: 34,   5180: 36,   5190: 38,   5200: 40,
@@ -997,7 +998,7 @@ class SNAP(ProtocolPacket):
 
     def get_OUI(self):
         "Get the three-octet Organizationally Unique Identifier (OUI) SNAP frame"
-        b=self.header.get_bytes()[0:3].tostring()
+        b=tobytes(self.header.get_bytes()[0:3])
         #unpack requires a string argument of length 4 and b is 3 bytes long
         (oui,)=struct.unpack('!L', b'\x00'+b)
         return oui
@@ -1040,7 +1041,7 @@ class Dot11WEP(ProtocolPacket):
             
     def get_iv(self):
         'Return the \'WEP IV\' field'
-        b=self.header.get_bytes()[0:3].tostring()
+        b=tobytes(self.header.get_bytes()[0:3])
         #unpack requires a string argument of length 4 and b is 3 bytes long
         (iv,)=struct.unpack('!L', b'\x00'+b)
         return iv

--- a/impacket/helper.py
+++ b/impacket/helper.py
@@ -16,6 +16,7 @@ import functools
 from six import add_metaclass
 
 import impacket.ImpactPacket as ip
+from impacket.compat import tobytes
 
 
 def rebind(f):
@@ -100,7 +101,7 @@ class ThreeBytesBigEndian(Field):
         Field.__init__(self, index)
                 
     def getter(self, o):
-        b=o.header.get_bytes()[self.index:self.index+3].tostring()
+        b=tobytes(o.header.get_bytes()[self.index:self.index+3])
         #unpack requires a string argument of length 4 and b is 3 bytes long
         (value,)=struct.unpack('!L', b'\x00'+b)
         return value

--- a/impacket/wps.py
+++ b/impacket/wps.py
@@ -16,6 +16,7 @@ import struct
 
 from impacket.helper import ProtocolPacket, Byte, Bit
 from functools import reduce
+from impacket.compat import tobytes
 
 
 class ArrayBuilder(object):
@@ -36,7 +37,7 @@ class ByteBuilder(object):
     
 class StringBuilder(object):
     def from_ary(self, ary):
-        return ary.tostring()
+        return tobytes(ary)
         
     def to_ary(self, value):
         return array.array('B', value)
@@ -115,7 +116,7 @@ class TLVContainer(object):
 
     
     def get_packet(self):
-        return self.to_ary().tostring()
+        return tobytes(self.to_ary())
     
     def set_parent(self, my_parent):
         self.__parent = my_parent
@@ -127,7 +128,7 @@ class TLVContainer(object):
         return array.array("B", struct.pack(">H",n))
     
     def ary2n(self, ary, i=0):
-        return struct.unpack(">H", ary[i:i+2].tostring())[0]
+        return struct.unpack(">H", tobytes(ary[i:i+2]))[0]
     
     def __repr__(self):
         def desc(kind):


### PR DESCRIPTION
array.array: tostring() and fromstring() methods have been removed [From python 3.9]. They were aliases to tobytes() and frombytes(), deprecated since Python 3.2. (Contributed by Victor Stinner in bpo-38916.)

Changes:
* Introduced compatiblity functions frombytes and tobytes to alias to- and fromstring.
* Changed calls of array.array to- and fromstring methods to tobytes and frombytes compatibility functions.

This is similar to #946 but I hope this will be easier to merge.