### PR TITLE
KRB5: Fix crash when KerberosTime contains NoValue

### DIFF
--- a/impacket/krb5/types.py
+++ b/impacket/krb5/types.py
@@ -28,6 +28,7 @@ import datetime
 import socket
 import re
 import struct
+import pyasn1
 
 from pyasn1.codec.der import decoder
 
@@ -247,6 +248,8 @@ class KerberosTime(object):
 
     @staticmethod
     def from_asn1(data):
+        if isinstance(data._value, pyasn1.type.base.NoValue):
+            return KerberosTime.INDEFINITE
         data = str(data)
         year = int(data[0:4])
         month = int(data[4:6])


### PR DESCRIPTION
The KerberosTime from parsed kerberos responses can contain a `pyasn1.type.base.NoValue`. When it does, calls to `str()` on it (such as the one in `from_asn1`) fail.
An example of such a crash is this stack trace from getST.py:

```
[*] Saving ticket in Administrator.ccache
Traceback (most recent call last):
  File "examples/getST.py", line 451, in <module>
    executer.run()
  File "examples/getST.py", line 385, in run
    self.saveTicket(tgs,oldSessionKey)
  File "examples/getST.py", line 82, in saveTicket
    ccache.fromTGS(ticket, sessionKey, sessionKey)
  File "/home/kali/impacket/lib/python3.8/site-packages/impacket/krb5/ccache.py", line 501, in fromTGS
    credential['time']['renew_till'] = self.toTimeStamp(types.KerberosTime.from_asn1(encTGSRepPart['renew-till']))
  File "/home/kali/impacket/lib/python3.8/site-packages/impacket/krb5/types.py", line 250, in from_asn1
    data = str(data)
  File "/home/kali/impacket/lib/python3.8/site-packages/pyasn1/type/char.py", line 102, in __str__
    return str(self._value)
  File "/home/kali/impacket/lib/python3.8/site-packages/pyasn1/type/base.py", line 214, in plug
    raise error.PyAsn1Error('Attempted "%s" operation on ASN.1 schema object' % name)
pyasn1.error.PyAsn1Error: Attempted "__str__" operation on ASN.1 schema object
Attempted "__str__" operation on ASN.1 schema object
```

I know it doesn't look good to check pyasn1's underscored (private) variables from impacket, but I don't know of any other way to check for the NoValue.