### PR TITLE
docs: fix simple typo, gettting -> getting

### DIFF
--- a/impacket/examples/ntlmrelayx/servers/socksserver.py
+++ b/impacket/examples/ntlmrelayx/servers/socksserver.py
@@ -224,7 +224,7 @@ def activeConnectionsWatcher(server):
             # Let's store the protocol scheme, needed be used later when trying to find the right socks relay server to use
             server.activeRelays[target][port]['scheme'] = scheme
 
-            # Default values in case somebody asks while we're gettting the data
+            # Default values in case somebody asks while we're getting the data
             server.activeRelays[target][port][userName]['isAdmin'] = 'N/A'
             # Do we have admin access in this connection?
             try:


### PR DESCRIPTION
There is a small typo in impacket/examples/ntlmrelayx/servers/socksserver.py.

Should read `getting` rather than `gettting`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md