### PR TITLE
Added cat command to smbclient

### DIFF
--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -114,6 +114,7 @@ class MiniImpacketShell(cmd.Cmd):
  rmdir {dirname} - removes the directory under the current path
  put {filename} - uploads the filename into the current path
  get {filename} - downloads the filename from the current path
+ cat {filename} - reads the filename from the current path
  mount {target,path} - creates a mount point from {path} to {target} (admin required)
  umount {path} - removes the mount point at {path} without deleting the directory (admin required)
  list_snapshots {path} - lists the vss snapshots for the specified path

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 future
 six
+chardet
 pyasn1>=0.2.3
 pycryptodomex
 pyOpenSSL>=0.16.2


### PR DESCRIPTION
Instead of always get file then change location then cat file, we can instead just read the file directly from the smbclient 😊
I took the do_get function and edited it to write the output into a BytesIO object, then auto-detecting the charset to print it directly in the MiniImpacketShell.