### PR TITLE
Fixed raw exception handlers to allow Ctrl+C

### DIFF
--- a/impacket/ImpactDecoder.py
+++ b/impacket/ImpactDecoder.py
@@ -362,7 +362,7 @@ class BaseDot11Decoder(Decoder):
     def find_key(self, bssid):
         try:
             key = self.key_manager.get_key(bssid)
-        except:
+        except Exception:
             return False
         return key
 

--- a/impacket/ImpactPacket.py
+++ b/impacket/ImpactPacket.py
@@ -627,7 +627,7 @@ class Ethernet(Header):
         if self.child():
             try:
                 self.set_ether_type(self.child().ethertype)
-            except:
+            except Exception:
                 " an Ethernet packet may have a Data() "
                 pass
         return Header.get_packet(self)

--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -52,10 +52,10 @@ def format_structure(d, level=0):
     return x
 try:
     from collections import OrderedDict
-except:
+except Exception:
     try:
         from ordereddict.ordereddict import OrderedDict
-    except:
+    except Exception:
         from ordereddict import OrderedDict
 
 class DCERPCSessionError(DCERPCException):
@@ -71,7 +71,7 @@ class DCERPCSessionError(DCERPCException):
             # Let's see if we have it as WBEMSTATUS
             try:
                 return 'WMI Session Error: code: 0x%x - %s' % (self.error_code, WBEMSTATUS.enumItems(self.error_code).name)
-            except:
+            except Exception:
                 return 'WMI SessionError: unknown error code: 0x%x' % self.error_code
 
 ################################################################################
@@ -560,7 +560,7 @@ class CLASS_PART(Structure):
             dataSize = calcsize(unpackStr)
             try:
                 itemValue = unpack(unpackStr, valueTable[:dataSize])[0]
-            except: 
+            except Exception: 
                 LOG.error("getProperties: Error unpacking!!")
                 itemValue = 0xffffffff
 
@@ -805,7 +805,7 @@ class INSTANCE_TYPE(Structure):
             dataSize = calcsize(unpackStr)
             try:
                 itemValue = unpack(unpackStr, valueTable[:dataSize])[0]
-            except:
+            except Exception:
                 LOG.error("getValues: Error Unpacking!")
                 itemValue = 0xffffffff
 

--- a/impacket/dcerpc/v5/dcomrt.py
+++ b/impacket/dcerpc/v5/dcomrt.py
@@ -1207,11 +1207,11 @@ class INTERFACE:
         # Is it isn't both, then it is a FDQN
         try:
             socket.inet_aton(self.__target)
-        except:
+        except Exception:
             # Not an IPv4
             try:
                 self.__target.index(':')
-            except:
+            except Exception:
                 # Not an IPv6, it's a FDQN
                 return True
         return False

--- a/impacket/dcerpc/v5/ndr.py
+++ b/impacket/dcerpc/v5/ndr.py
@@ -63,7 +63,7 @@ class NDR(object):
             elif len(fieldTypeOrClass.split('=')) == 2: 
                try:
                    self.fields[fieldName] = eval(fieldTypeOrClass.split('=')[1])
-               except:
+               except Exception:
                    self.fields[fieldName] = None
             else:
                self.fields[fieldName] = []
@@ -200,7 +200,7 @@ class NDR(object):
         if isinstance(fieldType, str):
             try:
                 alignment = calcsize(fieldType.split('=')[0])
-            except:
+            except Exception:
                 alignment = 0
         else:
             alignment = 0
@@ -277,7 +277,7 @@ class NDR(object):
         if len(two) >= 2:
             try:
                 return self.pack(fieldName, two[0], soFar)
-            except:
+            except Exception:
                 self.fields[fieldName] = eval(two[1], {}, self.fields)
                 return self.pack(fieldName, two[0], soFar)
 
@@ -1238,7 +1238,7 @@ class NDRUNION(NDRCONSTRUCTEDTYPE):
             elif len(fieldTypeOrClass.split('=')) == 2: 
                try:
                    self.fields[fieldName] = eval(fieldTypeOrClass.split('=')[1])
-               except:
+               except Exception:
                    self.fields[fieldName] = None
             else:
                self.fields[fieldName] = 0
@@ -1618,7 +1618,7 @@ class NDRCALL(NDRCONSTRUCTEDTYPE):
             elif len(fieldTypeOrClass.split('=')) == 2:
                try:
                    self.fields[fieldName] = eval(fieldTypeOrClass.split('=')[1])
-               except:
+               except Exception:
                    self.fields[fieldName] = None
             else:
                self.fields[fieldName] = 0

--- a/impacket/dcerpc/v5/rpch.py
+++ b/impacket/dcerpc/v5/rpch.py
@@ -34,7 +34,7 @@ class RPCProxyClientException(DCERPCException):
             try:
                 search = self.parser.search(proxy_error)
                 rpc_error_code = int(search.group(1), 16)
-            except:
+            except Exception:
                 error_string += ': ' + proxy_error
 
         DCERPCException.__init__(self, error_string, rpc_error_code)

--- a/impacket/dcerpc/v5/rpcrt.py
+++ b/impacket/dcerpc/v5/rpcrt.py
@@ -560,7 +560,7 @@ class DCERPCException(Exception):
         if packet is not None:
             try:
                 self.error_code = packet['ErrorCode']
-            except:
+            except Exception:
                 self.error_code = error_code
         else:
             self.error_code = error_code
@@ -870,7 +870,7 @@ class DCERPC:
                 try:
                     # Try to unpack the answer, even if it is an error, it works most of the times
                     response =  respClass(answer, isNDR64 = isNDR64)
-                except:
+                except Exception:
                     # No luck :(
                     exception = sessionErrorClass(error_code = error_code)
                 else:
@@ -956,7 +956,7 @@ class DCERPC_v5(DCERPC):
             try: # just in case they were converted already
                 self.__lmhash = unhexlify(lmhash)
                 self.__nthash = unhexlify(nthash)
-            except:
+            except Exception:
                 self.__lmhash = lmhash
                 self.__nthash = nthash
                 pass
@@ -1242,7 +1242,7 @@ class DCERPC_v5(DCERPC):
         try:
             if data['uuid'] != b'':
                 data['flags'] |= PFC_OBJECT_UUID
-        except:
+        except Exception:
             # Structure doesn't have uuid
             pass
         data['ctx_id'] = self._ctx

--- a/impacket/dcerpc/v5/samr.py
+++ b/impacket/dcerpc/v5/samr.py
@@ -2777,11 +2777,11 @@ def hSamrUnicodeChangePasswordUser2(dce, serverName='\x00', userName='', oldPass
         # Let's convert the hashes to binary form, if not yet
         try:
             oldPwdHashLM = unhexlify(oldPwdHashLM)
-        except:
+        except Exception:
             pass
         try:
             oldPwdHashNT = unhexlify(oldPwdHashNT)
-        except:
+        except Exception:
             pass
 
     newPwdHashNT = ntlm.NTOWFv1(newPassword)

--- a/impacket/dcerpc/v5/transport.py
+++ b/impacket/dcerpc/v5/transport.py
@@ -46,7 +46,7 @@ class DCERPCStringBinding:
             try:
                 self.__endpoint.index('endpoint=')
                 self.__endpoint = self.__endpoint[len('endpoint='):]
-            except:
+            except Exception:
                 pass
 
             self.__options = {}
@@ -275,7 +275,7 @@ class DCERPCTransport:
             try: # just in case they were converted already
                self._lmhash = binascii.unhexlify(lmhash)
                self._nthash = binascii.unhexlify(nthash)
-            except:
+            except Exception:
                self._lmhash = lmhash
                self._nthash = nthash
                pass

--- a/impacket/ese.py
+++ b/impacket/ese.py
@@ -25,10 +25,10 @@ from __future__ import print_function
 from impacket import LOG
 try:
     from collections import OrderedDict
-except:
+except Exception:
     try:
         from ordereddict.ordereddict import OrderedDict
-    except:
+    except Exception:
         from ordereddict import OrderedDict
 from impacket.structure import Structure, hexdump
 from struct import unpack

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -660,7 +660,7 @@ class LDAPAttack(ProtocolAttack):
                         fd.write(passwd)
                         fd.write("\n")
 
-                    except:
+                    except Exception:
                         continue
 
                 if fd is None:
@@ -693,7 +693,7 @@ class LDAPAttack(ProtocolAttack):
                             fd = open(filename, "a+")
                         fd.write(userpass)
                         fd.write("\n")
-                    except:
+                    except Exception:
                         continue
                 if fd is None:
                     LOG.info("The relayed user %s does not have permissions to read any gMSA passwords" % self.username)

--- a/impacket/examples/ntlmrelayx/clients/dcsyncclient.py
+++ b/impacket/examples/ntlmrelayx/clients/dcsyncclient.py
@@ -321,7 +321,7 @@ class DCSYNCRelayClient(ProtocolClient):
             av_pairs = AV_PAIRS(av_pairs)
 
             serverName = av_pairs[NTLMSSP_AV_HOSTNAME][1].decode('utf-16le')
-        except:
+        except Exception:
             LOG.debug("Exception:", exc_info=True)
             # We're in NTLMv1, not supported
             return STATUS_ACCESS_DENIED

--- a/impacket/examples/ntlmrelayx/clients/smbrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/smbrelayclient.py
@@ -153,7 +153,7 @@ class SMBRelayClient(ProtocolClient):
 
         try:
             serverName = machineAccount[:len(machineAccount)-1]
-        except:
+        except Exception:
             # We're in NTLMv1, not supported
             return STATUS_ACCESS_DENIED
 
@@ -455,7 +455,7 @@ class SMBRelayClient(ProtocolClient):
             smb = v1client.recvSMB()
             try:
                 smb.isValidAnswer(SMB.SMB_COM_SESSION_SETUP_ANDX)
-            except:
+            except Exception:
                 return None, STATUS_LOGON_FAILURE
             else:
                 v1client.set_uid(smb['Uid'])
@@ -608,7 +608,7 @@ class SMBRelayClient(ProtocolClient):
         dce = rpctransport.get_dce_rpc()
         try:
             dce.connect()
-        except:
+        except Exception:
             pass
         else:
             dce.bind(scmr.MSRPC_UUID_SCMR)

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -152,7 +152,7 @@ class HTTPRelayServer(Thread):
                 try:
                     _, blob = typeX.split('NTLM')
                     token = base64.b64decode(blob.strip())
-                except:
+                except Exception:
                     self.do_AUTHHEAD()
                 messageType = struct.unpack('<L', token[len('NTLMSSP\x00'):len('NTLMSSP\x00') + 4])[0]
 

--- a/impacket/examples/ntlmrelayx/servers/socksplugins/mssql.py
+++ b/impacket/examples/ntlmrelayx/servers/socksplugins/mssql.py
@@ -25,7 +25,7 @@ from impacket.tds import TDSPacket, TDS_STATUS_NORMAL, TDS_STATUS_EOM, TDS_PRE_L
 from impacket.ntlm import NTLMAuthChallengeResponse
 try:
     from OpenSSL import SSL
-except:
+except Exception:
     LOG.critical("pyOpenSSL is not installed, can't continue")
     raise
 

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -626,7 +626,7 @@ class RemoteOperations:
                 return '%s\\%s' % (domain,username)
             else:
                 return username
-        except:
+        except Exception:
             return None
 
     def getServiceAccount(self, serviceName):
@@ -770,7 +770,7 @@ class RemoteOperations:
         keyHandle = ans['phkResult']
         try:
             dataType, noLMHash = rrp.hBaseRegQueryValue(self.__rrp, keyHandle, 'NoLmHash')
-        except:
+        except Exception:
             noLMHash = 0
 
         if noLMHash != 1:
@@ -786,7 +786,7 @@ class RemoteOperations:
         regHandle = ans['phKey']
         try:
             ans = rrp.hBaseRegCreateKey(self.__rrp, regHandle, hiveName)
-        except:
+        except Exception:
             raise Exception("Can't open %s hive" % hiveName)
         keyHandle = ans['phkResult']
         rrp.hBaseRegSaveKey(self.__rrp, keyHandle, tmpFileName)
@@ -811,7 +811,7 @@ class RemoteOperations:
         service = resp['lpServiceHandle']
         try:
             scmr.hRStartServiceW(self.__scmr, service)
-        except:
+        except Exception:
             pass
         scmr.hRDeleteService(self.__scmr, service)
         self.__serviceDeleted = True
@@ -1000,7 +1000,7 @@ class RemoteOperations:
         try:
             ans = rrp.hBaseRegOpenKey(self.__rrp, self.__regHandle, 'SYSTEM\\CurrentControlSet\\Services\\NTDS\\Parameters')
             keyHandle = ans['phkResult']
-        except:
+        except Exception:
             # Can't open the registry path, assuming no NTDS on the other end
             return None
 
@@ -1008,7 +1008,7 @@ class RemoteOperations:
             dataType, dataValue = rrp.hBaseRegQueryValue(self.__rrp, keyHandle, 'DSA Database file')
             ntdsLocation = dataValue[:-1]
             ntdsDrive = ntdsLocation[:2]
-        except:
+        except Exception:
             # Can't open the registry path, assuming no NTDS on the other end
             return None
 
@@ -1223,7 +1223,7 @@ class SAMHashes(OfflineRegistry):
         # Remove the Names item
         try:
             rids.remove('Names')
-        except:
+        except Exception:
             pass
 
         for rid in rids:
@@ -1417,7 +1417,7 @@ class LSASecrets(OfflineRegistry):
         try:
             # Remove unnecessary value
             values.remove(b'NL$Control')
-        except:
+        except Exception:
             pass
 
         iterationCount = 10240
@@ -1488,7 +1488,7 @@ class LSASecrets(OfflineRegistry):
             # Let's first try to decode the secret
             try:
                 strDecoded = secretItem.decode('utf-16le')
-            except:
+            except Exception:
                 pass
             else:
                 # We have to get the account the service
@@ -1508,7 +1508,7 @@ class LSASecrets(OfflineRegistry):
             # Let's first try to decode the secret
             try:
                 strDecoded = secretItem.decode('utf-16le')
-            except:
+            except Exception:
                 pass
             else:
                 # We have to get the account this password is for
@@ -1525,7 +1525,7 @@ class LSASecrets(OfflineRegistry):
         elif upperName.startswith('ASPNET_WP_PASSWORD'):
             try:
                 strDecoded = secretItem.decode('utf-16le')
-            except:
+            except Exception:
                 pass
             else:
                 secret = 'ASPNET: %s' % strDecoded
@@ -1616,7 +1616,7 @@ class LSASecrets(OfflineRegistry):
         try:
             # Remove unnecessary value
             keys.remove(b'NL$Control')
-        except:
+        except Exception:
             pass
 
         if self.__LSAKey == b'':
@@ -1872,7 +1872,7 @@ class NTDSHashes:
         while True:
             try:
                 record = self.__ESEDB.getNextRow(self.__cursor)
-            except:
+            except Exception:
                 LOG.error('Error while calling getNextRow(), trying the next one')
                 continue
 
@@ -2005,7 +2005,7 @@ class NTDSHashes:
                     if attr['AttrVal']['valCount'] > 0:
                         try:
                             domain = b''.join(attr['AttrVal']['pAVal'][0]['pVal']).decode('utf-16le').split('@')[-1]
-                        except:
+                        except Exception:
                             domain = None
                     else:
                         domain = None
@@ -2013,7 +2013,7 @@ class NTDSHashes:
                     if attr['AttrVal']['valCount'] > 0:
                         try:
                             userName = b''.join(attr['AttrVal']['pAVal'][0]['pVal']).decode('utf-16le')
-                        except:
+                        except Exception:
                             LOG.error(
                                 'Cannot get sAMAccountName for %s' % record['pmsgOut'][replyVersion]['pNC']['StringName'][:-1])
                             userName = 'unknown'
@@ -2032,7 +2032,7 @@ class NTDSHashes:
         if haveInfo is True:
             try:
                 userProperties = samr.USER_PROPERTIES(plainText)
-            except:
+            except Exception:
                 # On some old w2k3 there might be user properties that don't
                 # match [MS-SAMR] structure, discarding them
                 return
@@ -2229,7 +2229,7 @@ class NTDSHashes:
                     if attr['AttrVal']['valCount'] > 0:
                         try:
                             domain = b''.join(attr['AttrVal']['pAVal'][0]['pVal']).decode('utf-16le').split('@')[-1]
-                        except:
+                        except Exception:
                             domain = None
                     else:
                         domain = None
@@ -2237,7 +2237,7 @@ class NTDSHashes:
                     if attr['AttrVal']['valCount'] > 0:
                         try:
                             userName = b''.join(attr['AttrVal']['pAVal'][0]['pVal']).decode('utf-16le')
-                        except:
+                        except Exception:
                             LOG.error('Cannot get sAMAccountName for %s' % record['pmsgOut'][replyVersion]['pNC']['StringName'][:-1])
                             userName = 'unknown'
                     else:
@@ -2253,7 +2253,7 @@ class NTDSHashes:
                     if attr['AttrVal']['valCount'] > 0:
                         try:
                             pwdLastSet = self.__fileTimeToDateTime(unpack('<Q', b''.join(attr['AttrVal']['pAVal'][0]['pVal']))[0])
-                        except:
+                        except Exception:
                             LOG.error('Cannot get pwdLastSet for %s' % record['pmsgOut'][replyVersion]['pNC']['StringName'][:-1])
                             pwdLastSet = 'N/A'
                 elif self.__printUserStatus and attId == LOOKUP_TABLE['userAccountControl']:
@@ -2333,7 +2333,7 @@ class NTDSHashes:
                     if self.__remoteOps is not None:
                         try:
                             self.__remoteOps.connectSamr(self.__remoteOps.getMachineNameAndDomain()[1])
-                        except:
+                        except Exception:
                             if os.getenv('KRB5CCNAME') is not None and self.__justUser is not None:
                                 # RemoteOperations failed. That might be because there was no way to log into the
                                 # target system. We just have a last resort. Hope we have tickets cached and that they
@@ -2383,7 +2383,7 @@ class NTDSHashes:
                                     "Error while processing row for user %s" % record[self.NAME_TO_INTERNAL['name']])
                                 LOG.error(str(e))
                                 pass
-                            except:
+                            except Exception:
                                 LOG.error("Error while processing row!")
                                 LOG.error(str(e))
                                 pass
@@ -2392,7 +2392,7 @@ class NTDSHashes:
                     while True:
                         try:
                             record = self.__ESEDB.getNextRow(self.__cursor)
-                        except:
+                        except Exception:
                             LOG.error('Error while calling getNextRow(), trying the next one')
                             continue
 
@@ -2410,7 +2410,7 @@ class NTDSHashes:
                                     "Error while processing row for user %s" % record[self.NAME_TO_INTERNAL['name']])
                                 LOG.error(str(e))
                                 pass
-                            except:
+                            except Exception:
                                 LOG.error("Error while processing row!")
                                 LOG.error(str(e))
                                 pass

--- a/impacket/examples/serviceinstall.py
+++ b/impacket/examples/serviceinstall.py
@@ -59,7 +59,7 @@ class ServiceInstall:
             dce_srvs.bind(srvs.MSRPC_UUID_SRVS)
             resp = srvs.hNetrShareEnum(dce_srvs, 1)
             return resp['InfoStruct']['ShareInfo']['Level1']
-        except:
+        except Exception:
             LOG.critical("Error requesting shares on %s, aborting....." % (self.connection.getRemoteHost()))
             raise
 
@@ -86,7 +86,7 @@ class ServiceInstall:
         try:
             resp = scmr.hRCreateServiceW(self.rpcsvc, handle,self.__service_name + '\x00', self.__service_name + '\x00',
                                          lpBinaryPathName=command + '\x00', dwStartType=scmr.SERVICE_DEMAND_START)
-        except:
+        except Exception:
             LOG.critical("Error creating service %s on %s" % (self.__service_name, self.connection.getRemoteHost()))
             raise
         else:
@@ -102,7 +102,7 @@ class ServiceInstall:
         self.rpcsvc.bind(scmr.MSRPC_UUID_SCMR)
         try:
             resp = scmr.hROpenSCManagerW(self.rpcsvc)
-        except:
+        except Exception:
             LOG.critical("Error opening SVCManager on %s....." % self.connection.getRemoteHost())
             raise Exception('Unable to open SVCManager')
         else:
@@ -120,7 +120,7 @@ class ServiceInstall:
         pathname = f.replace('/','\\')
         try:
             self.connection.putFile(tree, pathname, fh.read)
-        except:
+        except Exception:
             LOG.critical("Error uploading file %s, aborting....." % dst)
             raise
         fh.close()
@@ -135,7 +135,7 @@ class ServiceInstall:
                try:
                    tid = self.connection.connectTree(share)
                    self.connection.openFile(tid, '\\', FILE_WRITE_DATA, creationOption=FILE_DIRECTORY_FILE)
-               except:
+               except Exception:
                    LOG.debug('Exception', exc_info=True)
                    LOG.critical("share '%s' is not writable." % share)
                    pass
@@ -182,7 +182,7 @@ class ServiceInstall:
                         LOG.info('Starting service %s.....' % self.__service_name)
                         try:
                             scmr.hRStartServiceW(self.rpcsvc, service)
-                        except:
+                        except Exception:
                             pass
                         scmr.hRCloseServiceHandle(self.rpcsvc, service)
                     scmr.hRCloseServiceHandle(self.rpcsvc, svcManager)
@@ -192,17 +192,17 @@ class ServiceInstall:
                 LOG.debug("Exception", exc_info=True)
                 try:
                     scmr.hRControlService(self.rpcsvc, service, scmr.SERVICE_CONTROL_STOP)
-                except:
+                except Exception:
                     pass
                 if fileCopied is True:
                     try:
                         self.connection.deleteFile(self.share, self.__binary_service_name)
-                    except:
+                    except Exception:
                         pass
                 if serviceCreated is True:
                     try:
                         scmr.hRDeleteService(self.rpcsvc, service)
-                    except:
+                    except Exception:
                         pass
             return False
 
@@ -219,7 +219,7 @@ class ServiceInstall:
                 LOG.info('Stopping service %s.....' % self.__service_name)
                 try:
                     scmr.hRControlService(self.rpcsvc, service, scmr.SERVICE_CONTROL_STOP)
-                except:
+                except Exception:
                     pass
                 LOG.info('Removing service %s.....' % self.__service_name)
                 scmr.hRDeleteService(self.rpcsvc, service)
@@ -231,19 +231,19 @@ class ServiceInstall:
             LOG.critical("Error performing the uninstallation, cleaning up" )
             try:
                 scmr.hRControlService(self.rpcsvc, service, scmr.SERVICE_CONTROL_STOP)
-            except:
+            except Exception:
                 pass
             if fileCopied is True:
                 try:
                     self.connection.deleteFile(self.share, self.__binary_service_name)
-                except:
+                except Exception:
                     try:
                         self.connection.deleteFile(self.share, self.__binary_service_name)
-                    except:
+                    except Exception:
                         pass
                     pass
             if serviceCreated is True:
                 try:
                     scmr.hRDeleteService(self.rpcsvc, service)
-                except:
+                except Exception:
                     pass

--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -454,7 +454,7 @@ class MiniImpacketShell(cmd.Cmd):
         pathname = ntpath.join(self.pwd,filename)
         try:
             self.smb.getFile(self.share, pathname, fh.write)
-        except:
+        except Exception:
             fh.close()
             os.remove(filename)
             raise

--- a/impacket/http.py
+++ b/impacket/http.py
@@ -78,7 +78,7 @@ class HTTPClientSecurityProvider:
             try: # just in case they were converted already
                 self.__lmhash = binascii.unhexlify(lmhash)
                 self.__nthash = binascii.unhexlify(nthash)
-            except:
+            except Exception:
                 self.__lmhash = lmhash
                 self.__nthash = nthash
                 pass

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -71,7 +71,7 @@ def sendReceive(data, host, kdcHost):
 
     try:
         krbError = KerberosError(packet = decoder.decode(r, asn1Spec = KRB_ERROR())[0])
-    except:
+    except Exception:
         return r
 
     if krbError.getErrorCode() != constants.ErrorCodes.KDC_ERR_PREAUTH_REQUIRED.value:
@@ -181,7 +181,7 @@ def getKerberosTGT(clientName, password, domain, lmhash, nthash, aesKey='', kdcH
     preAuth = True
     try:
         asRep = decoder.decode(r, asn1Spec = KRB_ERROR())[0]
-    except:
+    except Exception:
         # Most of the times we shouldn't be here, is this a TGT?
         asRep = decoder.decode(r, asn1Spec=AS_REP())[0]
         # Yes
@@ -343,7 +343,7 @@ def getKerberosTGS(serverName, domain, kdcHost, tgt, cipher, sessionKey):
     # Decode the TGT
     try:
         decodedTGT = decoder.decode(tgt, asn1Spec = AS_REP())[0]
-    except:
+    except Exception:
         decodedTGT = decoder.decode(tgt, asn1Spec = TGS_REP())[0]
 
     domain = domain.upper()
@@ -727,7 +727,7 @@ class KerberosError(SessionError):
                 eData = decoder.decode(self.packet['e-data'], asn1Spec = KERB_ERROR_DATA())[0]
                 nt_error = struct.unpack('<L', eData['data-value'].asOctets()[:4])[0]
                 retString += '\nNT ERROR: %s(%s)' % (nt_errors.ERROR_MESSAGES[nt_error])
-        except:
+        except Exception:
             pass
 
         return retString

--- a/impacket/krb5/keytab.py
+++ b/impacket/krb5/keytab.py
@@ -30,7 +30,7 @@ class Enctype(Enum):
 
 class CountedOctetString(Structure):
     """
-    Note: This is very similar to the CountedOctetString structure in ccache, except:
+    Note: This is very similar to the CountedOctetString structure in ccache, except Exception:
       * `length` is uint16 instead of uint32
     """
     structure = (
@@ -52,7 +52,7 @@ class KeyBlock(Structure):
     def prettyKeytype(self):
         try:
             return Enctype(self['keytype']).name
-        except:
+        except Exception:
             return "UNKNOWN:0x%x" % (self['keytype'])
 
     def hexlifiedValue(self):
@@ -64,7 +64,7 @@ class KeyBlock(Structure):
 
 class KeytabPrincipal:
     """
-    Note: This is very similar to the principal structure in ccache, except:
+    Note: This is very similar to the principal structure in ccache, except Exception:
       * `num_components` is just uint16
       * using other size type for CountedOctetString
       * `name_type` field follows the other fields behind.

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -38,7 +38,7 @@ from impacket.spnego import SPNEGO_NegTokenInit, TypesMech
 try:
     import OpenSSL
     from OpenSSL import SSL, crypto
-except:
+except Exception:
     LOG.critical("pyOpenSSL is not installed, can't continue")
     raise
 
@@ -163,7 +163,7 @@ class LDAPConnection:
         if useCache:
             try:
                 ccache = CCache.loadFile(os.getenv('KRB5CCNAME'))
-            except:
+            except Exception:
                 # No cache present
                 pass
             else:

--- a/impacket/nmb.py
+++ b/impacket/nmb.py
@@ -673,7 +673,7 @@ class NetBIOSSessionPacket:
                     self.length = unpack('!H', data[2:4])[0]
 
                 self._trailer = data[4:]
-            except:
+            except Exception:
                 raise NetBIOSError('Wrong packet format ')
 
     def set_type(self, type):
@@ -731,7 +731,7 @@ class NetBIOSSession:
             nb = NetBIOS()
             try:
                 res = nb.getnetbiosname(remote_host)
-            except:
+            except Exception:
                 res = None
                 pass
 

--- a/impacket/ntlm.py
+++ b/impacket/ntlm.py
@@ -566,11 +566,11 @@ def getNTLMSSPType1(workstation='', domain='', signingRequired = False, use_ntlm
     if encoding is not None:
         try:
             workstation.encode('utf-16le')
-        except:
+        except Exception:
             workstation = workstation.decode(encoding)
         try:
             domain.encode('utf-16le')
-        except:
+        except Exception:
             domain = domain.decode(encoding)
 
     # Let's prepare a Type 1 NTLMSSP Message
@@ -603,15 +603,15 @@ def getNTLMSSPType3(type1, type2, user, password, domain, lmhash = '', nthash = 
     if encoding is not None:
         try:
             user.encode('utf-16le')
-        except:
+        except Exception:
             user = user.decode(encoding)
         try:
             password.encode('utf-16le')
-        except:
+        except Exception:
             password = password.decode(encoding)
         try:
             domain.encode('utf-16le')
-        except:
+        except Exception:
             domain = user.decode(encoding)
 
     ntlmChallenge = NTLMAuthChallenge(type2)

--- a/impacket/pcapfile.py
+++ b/impacket/pcapfile.py
@@ -100,7 +100,7 @@ class PcapFile:
           pkt = PCapFilePacket.fromFile(self.file)
           pkt['data'] = self.file.read(pkt['savedLength'])
           return pkt
-       except:
+       except Exception:
           return None
 
     def write(self, pkt):

--- a/impacket/smb.py
+++ b/impacket/smb.py
@@ -3092,7 +3092,7 @@ class SMB(object):
             try: # just in case they were converted already
                 lmhash = a2b_hex(lmhash)
                 nthash = a2b_hex(nthash)
-            except:
+            except Exception:
                 pass
 
         self.__userName = user
@@ -3406,7 +3406,7 @@ class SMB(object):
             try: # just in case they were converted already
                 lmhash = a2b_hex(lmhash)
                 nthash = a2b_hex(nthash)
-            except:
+            except Exception:
                 pass
 
         self.__userName = user
@@ -3421,7 +3421,7 @@ class SMB(object):
         if self._dialects_parameters['Capabilities'] & SMB.CAP_EXTENDED_SECURITY:
             try:
                 self.login_extended(user, password, domain, lmhash, nthash, use_ntlmv2 = True)
-            except:
+            except Exception:
                 # If the target OS is Windows 5.0 or Samba, let's try using NTLMv1
                 if ntlm_fallback and ((self.get_server_lanman().find('Windows 2000') != -1) or (self.get_server_lanman().find('Samba') != -1)):
                     self.login_extended(user, password, domain, lmhash, nthash, use_ntlmv2 = False)
@@ -3633,7 +3633,7 @@ class SMB(object):
                     return ans
                 else:
                     return None
-            except:
+            except Exception:
                 return ans
 
         return None

--- a/impacket/smb3.py
+++ b/impacket/smb3.py
@@ -616,7 +616,7 @@ class SMB3:
             try: # just in case they were converted already
                 lmhash = a2b_hex(lmhash)
                 nthash = a2b_hex(nthash)
-            except:
+            except Exception:
                 pass
 
         self.__userName = user
@@ -865,7 +865,7 @@ class SMB3:
             try: # just in case they were converted already
                 lmhash = a2b_hex(lmhash)
                 nthash = a2b_hex(nthash)
-            except:
+            except Exception:
                 pass
 
         self.__userName = user
@@ -931,27 +931,27 @@ class SMB3:
                 if av_pairs[ntlm.NTLMSSP_AV_HOSTNAME] is not None:
                    try:
                        self._Session['ServerName'] = av_pairs[ntlm.NTLMSSP_AV_HOSTNAME][1].decode('utf-16le')
-                   except:
+                   except Exception:
                        # For some reason, we couldn't decode Unicode here.. silently discard the operation
                        pass
                 if av_pairs[ntlm.NTLMSSP_AV_DOMAINNAME] is not None:
                    try:
                        if self._Session['ServerName'] != av_pairs[ntlm.NTLMSSP_AV_DOMAINNAME][1].decode('utf-16le'):
                            self._Session['ServerDomain'] = av_pairs[ntlm.NTLMSSP_AV_DOMAINNAME][1].decode('utf-16le')
-                   except:
+                   except Exception:
                        # For some reason, we couldn't decode Unicode here.. silently discard the operation
                        pass
                 if av_pairs[ntlm.NTLMSSP_AV_DNS_DOMAINNAME] is not None:
                    try:
                        self._Session['ServerDNSDomainName'] = av_pairs[ntlm.NTLMSSP_AV_DNS_DOMAINNAME][1].decode('utf-16le')
-                   except:
+                   except Exception:
                        # For some reason, we couldn't decode Unicode here.. silently discard the operation
                        pass
 
                 if av_pairs[ntlm.NTLMSSP_AV_DNS_HOSTNAME] is not None:
                    try:
                        self._Session['ServerDNSHostName'] = av_pairs[ntlm.NTLMSSP_AV_DNS_HOSTNAME][1].decode('utf-16le')
-                   except:
+                   except Exception:
                        # For some reason, we couldn't decode Unicode here.. silently discard the operation
                        pass
 
@@ -1044,7 +1044,7 @@ class SMB3:
                                                                                      b"ServerOut\x00", 128)
                     self._Session['CalculatePreAuthHash'] = False
                     return True
-            except:
+            except Exception:
                 # We clean the stuff we used in case we want to authenticate again
                 # within the same connection
                 self._Session['UserCredentials']   = ''
@@ -1076,7 +1076,7 @@ class SMB3:
         try:
             _, _, _, _, sockaddr = socket.getaddrinfo(self._Connection['ServerIP'], 80, 0, 0, socket.IPPROTO_TCP)[0]
             remoteHost = sockaddr[0]
-        except:
+        except Exception:
             remoteHost = self._Connection['ServerIP']
         path = '\\\\' + remoteHost + '\\' +share
 

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -103,7 +103,7 @@ class SMBConnection:
             nb = nmb.NetBIOS()
             try:
                 res = nb.getnetbiosname(self._remoteHost)
-            except:
+            except Exception:
                 pass
             else:
                 self._remoteName = res
@@ -307,7 +307,7 @@ class SMBConnection:
         if useCache is True:
             try:
                 ccache = CCache.loadFile(os.getenv('KRB5CCNAME'))
-            except:
+            except Exception:
                 # No cache present
                 pass
             else:
@@ -985,7 +985,7 @@ class SMBConnection:
         """
         try:
             self.logoff()
-        except:
+        except Exception:
             pass
         self._SMBConnection.close_session()
 

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -144,7 +144,7 @@ def outputToJohnFormat(challenge, username, domain, lmresponse, ntresponse):
                 username.decode('utf-16le'), domain.decode('utf-16le'), hexlify(lmresponse).decode('latin-1'),
                 hexlify(ntresponse).decode('latin-1'),
             hexlify(challenge).decode()), 'hash_version': 'ntlm'}
-    except:
+    except Exception:
         # Let's try w/o decoding Unicode
         try:
             if len(ntresponse) > 24:
@@ -2463,7 +2463,7 @@ class SMBCommands:
                         smbServer.log(ntlm_hash_data['hash_string'])
                         if jtr_dump_path != '':
                             writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'], jtr_dump_path)
-                    except:
+                    except Exception:
                         smbServer.log("Could not write NTLM Hashes to the specified JTR_Dump_Path %s" % jtr_dump_path)
                 else:
                     respToken = SPNEGO_NegTokenResp()
@@ -2499,7 +2499,7 @@ class SMBCommands:
                 smbServer.log(ntlm_hash_data['hash_string'])
                 if jtr_dump_path != '':
                     writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'], jtr_dump_path)
-            except:
+            except Exception:
                 smbServer.log("Could not write NTLM Hashes to the specified JTR_Dump_Path %s" % jtr_dump_path)
 
         respData['NativeOS']     = encodeSMBString(recvPacket['Flags2'], smbServer.getServerOS())
@@ -2842,7 +2842,7 @@ class SMB2Commands:
                     if jtr_dump_path != '':
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'],
                                               jtr_dump_path)
-                except:
+                except Exception:
                     smbServer.log("Could not write NTLM Hashes to the specified JTR_Dump_Path %s" % jtr_dump_path)
 
                 if isGuest:
@@ -3880,7 +3880,7 @@ smb.SMB.TRANS_TRANSACT_NMPIPE          :self.__smbTransHandler.transactNamedPipe
     def removeConnection(self, name):
         try:
            del(self.__activeConnections[name])
-        except:
+        except Exception:
            pass
         self.log("Remaining connections %s" % list(self.__activeConnections.keys()))
 
@@ -4145,7 +4145,7 @@ smb.SMB.TRANS_TRANSACT_NMPIPE          :self.__smbTransHandler.transactNamedPipe
         try:
             packet = smb.NewSMBPacket(data = data)
             SMBCommand  = smb.SMBCommand(packet['Data'][0])
-        except:
+        except Exception:
             # Maybe a SMB2 packet?
             packet = smb2.SMB2Packet(data = data)
             connData = self.getConnectionData(connId, False)
@@ -4433,7 +4433,7 @@ smb.SMB.TRANS_TRANSACT_NMPIPE          :self.__smbTransHandler.transactNamedPipe
             try: # just in case they were converted already
                 lmhash = a2b_hex(lmhash)
                 nthash = a2b_hex(nthash)
-            except:
+            except Exception:
                 pass
         self.__credentials[name.lower()] = (uid, lmhash, nthash)
 

--- a/impacket/structure.py
+++ b/impacket/structure.py
@@ -197,7 +197,7 @@ class Structure:
         if len(two) >= 2:
             try:
                 return self.pack(two[0], data)
-            except:
+            except Exception:
                 fields = {'self':self}
                 fields.update(self.fields)
                 return self.pack(two[0], eval(two[1], {}, fields))
@@ -207,7 +207,7 @@ class Structure:
         if len(two) == 2:
             try:
                 return self.pack(two[0], data)
-            except:
+            except Exception:
                 if (two[1] in self.fields) and (self[two[1]] is not None):
                     return self.pack(two[0], id(self[two[1]]) & ((1<<(calcsize(two[0])*8))-1) )
                 else:
@@ -218,7 +218,7 @@ class Structure:
         if len(two) == 2:
             try:
                 return self.pack(two[0],data)
-            except:
+            except Exception:
                 return self.pack(two[0], self.calcPackFieldSize(two[1]))
 
         # array specifier

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -33,7 +33,7 @@ from impacket.structure import Structure
 
 try:
     from OpenSSL import SSL
-except:
+except Exception:
     LOG.critical("pyOpenSSL is not installed, can't continue")
     raise
 
@@ -708,7 +708,7 @@ class MSSQL:
         if useCache is True:
             try:
                 ccache = CCache.loadFile(os.getenv('KRB5CCNAME'))
-            except:
+            except Exception:
                 # No cache present
                 pass
             else:
@@ -733,7 +733,7 @@ class MSSQL:
                         try:
                             if int(i['tcp']) == self.port:
                                 instanceName = i['InstanceName']
-                        except:
+                        except Exception:
                             pass
 
                     if instanceName:

--- a/impacket/winregistry.py
+++ b/impacket/winregistry.py
@@ -400,7 +400,7 @@ class Registry:
                     hexdump(valueData, self.indent)
                 else:
                     print(" NULL")
-            except:
+            except Exception:
                 print(" NULL")
         elif valueType == REG_MULTISZ:
             print("%s" % (valueData.decode('utf-16le')))


### PR DESCRIPTION
A ton of exception handlers (i.e. `except`-Statements) in impacket are 'raw', i.e. they just catch **any** exception.
This makes it impossible to cancel script execution using Ctrl+C, because those raw handlers also catch the `KeyboardInterrupt`.

This patchset just narrows all raw handlers down to `Exception`-based exceptions.
I generated it using the following command:

`find impacket/ -type f -name '*.py' -exec sed -i 's/except:/except Exception:/' {} \;`

Before merging, it should be verified, that there is indeed no `except`-Statement that _should_ catch _all_ possible Exceptions.
This should be true for all backend code.

For frontend code, it might need review, so please comment.