### PR TITLE
Add Pass-the-Hash option for smbpasswd.py

### DIFF
--- a/examples/smbpasswd.py
+++ b/examples/smbpasswd.py
@@ -32,12 +32,12 @@ from impacket import version
 
 class SMBPasswd():
 
-	def __init__(self, userName, oldPwd, oldPwdHashLM, oldPwdHashNT, newPwd, target):
+	def __init__(self, userName, oldPwd, newPwd, oldPwdHashLM, oldPwdHashNT, target):
 		self.userName = userName
 		self.oldPwd = oldPwd
+		self.newPwd = newPwd
 		self.oldPwdHashLM = oldPwdHashLM
 		self.oldPwdHashNT = oldPwdHashNT
-		self.newPwd = newPwd
 		self.target = target
 		self.dce = None
 		self.connect()
@@ -72,20 +72,20 @@ class SMBPasswd():
 
 def normalize_args(args):
 	try:
-		if args.hashes is not None:
-			oldPwdHashLM, oldPwdHashNT = args.hashes.split(':')
-		else:
-			oldPwdHashLM = ''
-			oldPwdHashNT = ''
-	except ValueError:
-		print('Wrong hashes string format. For more information run with --help option.')
-		sys.exit(1)
-
-	try:
 		credentials, target = args.target.rsplit('@', 1)
 	except ValueError:
 		print('Wrong target string format. For more information run with --help option.')
 		sys.exit(1)
+
+	if args.hashes is not None:
+		try:
+			oldPwdHashLM, oldPwdHashNT = args.hashes.split(':')
+		except ValueError:
+			print('Wrong hashes string format. For more information run with --help option.')
+			sys.exit(1)
+	else:
+		oldPwdHashLM = ''
+		oldPwdHashNT = ''
 
 	try:
 		userName, oldPwd = credentials.split(':', 1)
@@ -104,7 +104,7 @@ def normalize_args(args):
 	else:
 		newPwd = args.newpass
 
-	return (userName, oldPwd, oldPwdHashLM, oldPwdHashNT, newPwd, target)
+	return (userName, oldPwd, newPwd, oldPwdHashLM, oldPwdHashNT, target)
 
 
 if __name__ == '__main__':
@@ -116,10 +116,10 @@ if __name__ == '__main__':
 	parser.add_argument('-newpass', action='store', default=None, help='new SMB password')
 	args = parser.parse_args()
 
-	userName, oldPwd, oldPwdHashLM, oldPwdHashNT, newPwd, target = normalize_args(args)
+	userName, oldPwd, newPwd, oldPwdHashLM, oldPwdHashNT, target = normalize_args(args)
 
 	try:
-		smbpasswd = SMBPasswd(userName, oldPwd, oldPwdHashLM, oldPwdHashNT, newPwd, target)
+		smbpasswd = SMBPasswd(userName, oldPwd, newPwd, oldPwdHashLM, oldPwdHashNT, target)
 	except Exception as e:
 		if 'STATUS_ACCESS_DENIED' in str(e):
 			print('[-] Access was denied when attempting to initialize a null session. Try changing the password with smbclient.py.')

--- a/examples/smbpasswd.py
+++ b/examples/smbpasswd.py
@@ -7,16 +7,16 @@
 # for more information.
 #
 # Description:
-#  This script is an alternative to smbpasswd tool for changing Windows
-#  passwords over SMB (MSRPC-SAMR) remotely from Linux with a single shot to
-#  SamrUnicodeChangePasswordUser2 function (Opnum 55).
+#  This script is an alternative to smbpasswd tool for changing passwords
+#  remotely over SMB (MSRPC-SAMR). Supports changing expired passwords.
 #
 # Author:
 #  Sam Freeside (@snovvcrash)
 #
 # Example:
-#  python smbpasswd.py 'j.doe'@pc1.megacorp.local
-#  python smbpasswd.py 'j.doe:Passw0rd!'@10.10.13.37 -newpass 'N3wPassw0rd!'
+#  smbpasswd.py j.doe@PC01.megacorp.local
+#  smbpasswd.py j.doe:'Passw0rd!'@10.10.13.37 -newpass 'N3wPassw0rd!'
+#  smbpasswd.py -hashes :fc525c9683e8fe067095ba2ddc971889 j.doe@10.10.13.37 -newpass 'N3wPassw0rd!'
 #
 # References:
 #  https://github.com/samba-team/samba/blob/master/source3/utils/smbpasswd.c
@@ -30,69 +30,100 @@ from impacket.dcerpc.v5 import transport, samr
 from impacket import version
 
 
-def connect(host_name_or_ip):
-	rpctransport = transport.SMBTransport(host_name_or_ip, filename=r'\samr')
-	if hasattr(rpctransport, 'set_credentials'):
-		rpctransport.set_credentials(username='', password='', domain='', lmhash='', nthash='', aesKey='') # null session
+class SMBPasswd():
 
-	dce = rpctransport.get_dce_rpc()
-	dce.connect()
-	dce.bind(samr.MSRPC_UUID_SAMR)
+	def __init__(self, userName, oldPwd, oldPwdHashLM, oldPwdHashNT, newPwd, target):
+		self.userName = userName
+		self.oldPwd = oldPwd
+		self.oldPwdHashLM = oldPwdHashLM
+		self.oldPwdHashNT = oldPwdHashNT
+		self.newPwd = newPwd
+		self.target = target
+		self.dce = None
+		self.connect()
 
-	return dce
+	def connect(self):
+		rpctransport = transport.SMBTransport(self.target, filename=r'\samr')
+		if hasattr(rpctransport, 'set_credentials'):
+			# Initializing a null sessions to be able to change an expired password
+			rpctransport.set_credentials(username='', password='', domain='', lmhash='', nthash='', aesKey='')
+
+		self.dce = rpctransport.get_dce_rpc()
+		self.dce.connect()
+		self.dce.bind(samr.MSRPC_UUID_SAMR)
+
+	def hSamrUnicodeChangePasswordUser2(self):
+		try:
+			resp = samr.hSamrUnicodeChangePasswordUser2(self.dce, '\x00', self.userName, self.oldPwd, self.newPwd, self.oldPwdHashLM, self.oldPwdHashNT)
+		except Exception as e:
+			if 'STATUS_WRONG_PASSWORD' in str(e):
+				print('[-] Current SMB password is not correct.')
+			elif 'STATUS_PASSWORD_RESTRICTION' in str(e):
+				print('[-] Some password update rule has been violated. For example, the password may not meet length criteria.')
+			else:
+				raise e
+		else:
+			if resp['ErrorCode'] == 0:
+				print('[+] Password was changed successfully.')
+			else:
+				print('[?] Non-zero return code, something weird happened.')
+				resp.dump()
 
 
-def hSamrUnicodeChangePasswordUser2(username, currpass, newpass, target):
-	dce = connect(target)
+def normalize_args(args):
+	try:
+		if args.hashes is not None:
+			oldPwdHashLM, oldPwdHashNT = args.hashes.split(':')
+		else:
+			oldPwdHashLM = ''
+			oldPwdHashNT = ''
+	except ValueError:
+		print('Wrong hashes string format. For more information run with --help option.')
+		sys.exit(1)
 
 	try:
-		resp = samr.hSamrUnicodeChangePasswordUser2(dce, '\x00', username, currpass, newpass)
-	except Exception as e:
-		if 'STATUS_WRONG_PASSWORD' in str(e):
-			print('[-] Current SMB password is not correct.')
-		elif 'STATUS_PASSWORD_RESTRICTION' in str(e):
-			print('[-] Some password update rule has been violated. For example, the password may not meet length criteria.')
-		else:
-			raise e
-	else:
-		if resp['ErrorCode'] == 0:
-			print('[+] Password was changed successfully.')
-		else:
-			print('[?] Non-zero return code, something weird happened.')
-			resp.dump()
-
-
-def parse_target(target):
-	try:
-		userpass, hostname_or_ip = target.rsplit('@', 1)
+		credentials, target = args.target.rsplit('@', 1)
 	except ValueError:
 		print('Wrong target string format. For more information run with --help option.')
 		sys.exit(1)
 
 	try:
-		username, currpass = userpass.split(':', 1)
+		userName, oldPwd = credentials.split(':', 1)
 	except ValueError:
-		username = userpass
-		currpass = getpass('Current SMB password: ')
+		userName = credentials
+		if oldPwdHashNT == '':
+			oldPwd = getpass('Current SMB password: ')
+		else:
+			oldPwd = ''
 
-	return (username, currpass, hostname_or_ip)
+	if args.newpass is None:
+		newPwd = getpass('New SMB password: ')
+		if newPwd != getpass('Retype new SMB password: '):
+			print('Password does not match, try again.')
+			sys.exit(1)
+	else:
+		newPwd = args.newpass
+
+	return (userName, oldPwd, oldPwdHashLM, oldPwdHashNT, newPwd, target)
 
 
 if __name__ == '__main__':
 	print (version.BANNER)
-	parser = ArgumentParser()
-	parser.add_argument('target', help='<username[:currpass]>@<target_hostname_or_IP_address>')
-	parser.add_argument('-newpass', default=None, help='new SMB password')
+
+	parser = ArgumentParser(description='Change password over SMB.')
+	parser.add_argument('target', action='store', help='<username[:password]>@<target_hostname_or_IP_address>')
+	parser.add_argument('-hashes', action='store', default=None, metavar='LMHASH:NTHASH', help='current NTLM hashes, format is LMHASH:NTHASH')
+	parser.add_argument('-newpass', action='store', default=None, help='new SMB password')
 	args = parser.parse_args()
 
-	username, currpass, hostname_or_ip = parse_target(args.target)
+	userName, oldPwd, oldPwdHashLM, oldPwdHashNT, newPwd, target = normalize_args(args)
 
-	if args.newpass is None:
-		newpass = getpass('New SMB password: ')
-		if newpass != getpass('Retype new SMB password: '):
-			print('Password does not match, try again.')
-			sys.exit(2)
+	try:
+		smbpasswd = SMBPasswd(userName, oldPwd, oldPwdHashLM, oldPwdHashNT, newPwd, target)
+	except Exception as e:
+		if 'STATUS_ACCESS_DENIED' in str(e):
+			print('[-] Access was denied when attempting to initialize a null session. Try changing the password with smbclient.py.')
+		else:
+			raise e
 	else:
-		newpass = args.newpass
-
-	hSamrUnicodeChangePasswordUser2(username, currpass, newpass, hostname_or_ip)
+		smbpasswd.hSamrUnicodeChangePasswordUser2()

--- a/examples/smbpasswd.py
+++ b/examples/smbpasswd.py
@@ -31,7 +31,7 @@ from impacket.dcerpc.v5 import transport, samr
 from impacket import version
 
 
-class SMBPasswd():
+class SMBPasswd:
 
 	def __init__(self, userName, oldPwd, newPwd, oldPwdHashLM, oldPwdHashNT, target):
 		self.userName = userName
@@ -120,8 +120,9 @@ if __name__ == '__main__':
 
 	parser = ArgumentParser(description='Change password over SMB.')
 	parser.add_argument('target', action='store', help='<username[:password]>@<target_hostname_or_IP_address>')
-	parser.add_argument('-hashes', action='store', default=None, metavar='LMHASH:NTHASH', help='current NTLM hashes, format is LMHASH:NTHASH')
 	parser.add_argument('-newpass', action='store', default=None, help='new SMB password')
+	group = parser.add_argument_group('authentication')
+	group.add_argument('-hashes', action='store', default=None, metavar='LMHASH:NTHASH', help='current NTLM hashes, format is LMHASH:NTHASH')
 	args = parser.parse_args()
 
 	userName, oldPwd, newPwd, oldPwdHashLM, oldPwdHashNT, target = normalize_args(args)


### PR DESCRIPTION
Hello @asolino!

I'd like to add the `-hashes` option for smbpasswd.py script in order to be able to change expired passwords via Pass-the-Hash. There's also some code refactoring in this PR.