### PR TITLE
Add PowerShell option for semi-interactive shells in *exec.py

### DIFF
--- a/examples/dcomexec.py
+++ b/examples/dcomexec.py
@@ -39,6 +39,7 @@ import ntpath
 import os
 import sys
 import time
+from base64 import b64encode
 
 from six import PY2, PY3
 from impacket import version
@@ -58,7 +59,7 @@ CODEC = sys.stdout.encoding
 
 class DCOMEXEC:
     def __init__(self, command='', username='', password='', domain='', hashes=None, aesKey=None, share=None,
-                 noOutput=False, doKerberos=False, kdcHost=None, dcomObject=None):
+                 noOutput=False, doKerberos=False, kdcHost=None, dcomObject=None, shell_type=None):
         self.__command = command
         self.__username = username
         self.__password = password
@@ -71,6 +72,7 @@ class DCOMEXEC:
         self.__doKerberos = doKerberos
         self.__kdcHost = kdcHost
         self.__dcomObject = dcomObject
+        self.__shell_type = shell_type
         self.shell = None
         if hashes is not None:
             self.__lmhash, self.__nthash = hashes.split(':')
@@ -160,14 +162,14 @@ class DCOMEXEC:
 
                 iActiveView = IDispatch(self.getInterface(iMMC, resp['pVarResult']['_varUnion']['pdispVal']['abData']))
                 pExecuteShellCommand = iActiveView.GetIDsOfNames(('ExecuteShellCommand',))[0]
-                self.shell = RemoteShellMMC20(self.__share, (iMMC, pQuit), (iActiveView, pExecuteShellCommand), smbConnection)
+                self.shell = RemoteShellMMC20(self.__share, (iMMC, pQuit), (iActiveView, pExecuteShellCommand), smbConnection, self.__shell_type)
             else:
                 resp = iDocument.GetIDsOfNames(('Application',))
                 resp = iDocument.Invoke(resp[0], 0x409, DISPATCH_PROPERTYGET, dispParams, 0, [], [])
 
                 iActiveView = IDispatch(self.getInterface(iMMC, resp['pVarResult']['_varUnion']['pdispVal']['abData']))
                 pExecuteShellCommand = iActiveView.GetIDsOfNames(('ShellExecute',))[0]
-                self.shell = RemoteShell(self.__share, (iMMC, pQuit), (iActiveView, pExecuteShellCommand), smbConnection)
+                self.shell = RemoteShell(self.__share, (iMMC, pQuit), (iActiveView, pExecuteShellCommand), smbConnection, self.__shell_type)
 
             if self.__command != ' ':
                 self.shell.onecmd(self.__command)
@@ -193,12 +195,14 @@ class DCOMEXEC:
         dcom.disconnect()
 
 class RemoteShell(cmd.Cmd):
-    def __init__(self, share, quit, executeShellCommand, smbConnection):
+    def __init__(self, share, quit, executeShellCommand, smbConnection, shell_type):
         cmd.Cmd.__init__(self)
         self._share = share
         self._output = '\\' + OUTPUT_FILENAME
         self.__outputBuffer = ''
         self._shell = 'cmd.exe'
+        self.__shell_type = shell_type
+        self.__pwsh = 'powershell.exe -NoP -NoL -sta -NonI -W Hidden -Exec Bypass -Enc '
         self.__quit = quit
         self._executeShellCommand = executeShellCommand
         self.__transferClient = smbConnection
@@ -220,8 +224,8 @@ class RemoteShell(cmd.Cmd):
         print("""
  lcd {path}                 - changes the current local directory to {path}
  exit                       - terminates the server process (and this session)
- put {src_file, dst_path}   - uploads a local file to the dst_path (dst_path = default current directory)
- get {file}                 - downloads pathname to the current local dir
+ lput {src_file, dst_path}   - uploads a local file to the dst_path (dst_path = default current directory)
+ lget {file}                 - downloads pathname to the current local dir
  ! {cmd}                    - executes a local shell cmd
 """)
 
@@ -234,7 +238,7 @@ class RemoteShell(cmd.Cmd):
             except Exception as e:
                 logging.error(str(e))
 
-    def do_get(self, src_path):
+    def do_lget(self, src_path):
         try:
             import ntpath
             newPath = ntpath.normpath(ntpath.join(self._pwd, src_path))
@@ -249,7 +253,7 @@ class RemoteShell(cmd.Cmd):
             os.remove(filename)
             pass
 
-    def do_put(self, s):
+    def do_lput(self, s):
         try:
             params = s.split(' ')
             if len(params) > 1:
@@ -283,6 +287,10 @@ class RemoteShell(cmd.Cmd):
                                              0, [], [])
         return True
 
+    def do_EOF(self, s):
+        print()
+        return self.do_exit(s)
+
     def emptyline(self):
         return False
 
@@ -299,6 +307,8 @@ class RemoteShell(cmd.Cmd):
             self.execute_remote('cd ')
             self._pwd = self.__outputBuffer.strip('\r\n')
             self.prompt = (self._pwd + '>')
+            if self.__shell_type == 'powershell':
+                    self.prompt = 'PS ' + self.prompt + ' '
             self.__outputBuffer = ''
 
     def default(self, line):
@@ -315,7 +325,9 @@ class RemoteShell(cmd.Cmd):
                 self._pwd = line
                 self.execute_remote('cd ')
                 self._pwd = self.__outputBuffer.strip('\r\n')
-                self.prompt = self._pwd + '>'
+                self.prompt = (self._pwd + '>')
+                if self.__shell_type == 'powershell':
+                    self.prompt = 'PS ' + self.prompt + ' '
                 self.__outputBuffer = ''
         else:
             if line != '':
@@ -351,7 +363,11 @@ class RemoteShell(cmd.Cmd):
                     return self.get_output()
         self.__transferClient.deleteFile(self._share, self._output)
 
-    def execute_remote(self, data):
+    def execute_remote(self, data, shell_type='cmd'):
+        if shell_type == 'powershell':
+            data = '$ProgressPreference="SilentlyContinue";' + data
+            data = self.__pwsh + b64encode(data.encode('utf-16le')).decode()
+
         command = '/Q /c ' + data
         if self._noOutput is False:
             command += ' 1> ' + '\\\\127.0.0.1\\%s' % self._share + self._output + ' 2>&1'
@@ -407,12 +423,16 @@ class RemoteShell(cmd.Cmd):
         self.get_output()
 
     def send_data(self, data):
-        self.execute_remote(data)
+        self.execute_remote(data, self.__shell_type)
         print(self.__outputBuffer)
         self.__outputBuffer = ''
 
 class RemoteShellMMC20(RemoteShell):
-    def execute_remote(self, data):
+    def execute_remote(self, data, shell_type='cmd'):
+        if shell_type == 'powershell':
+            data = '$ProgressPreference="SilentlyContinue";' + data
+            data = self.__pwsh + b64encode(data.encode('utf-16le')).decode()
+
         command = '/Q /c ' + data
         if self._noOutput is False:
             command += ' 1> ' + '\\\\127.0.0.1\\%s' % self._share + self._output  + ' 2>&1'
@@ -526,6 +546,9 @@ if __name__ == '__main__':
     parser.add_argument('-object', choices=['ShellWindows', 'ShellBrowserWindow', 'MMC20'], nargs='?', default='ShellWindows',
                         help='DCOM object to be used to execute the shell command (default=ShellWindows)')
 
+    parser.add_argument('-shell-type', action='store', default = 'cmd', choices = ['cmd', 'powershell'], help='choose '
+                        'a command processor for the semi-interactive shell')
+
     parser.add_argument('command', nargs='*', default = ' ', help='command to execute at the target. If empty it will '
                                                                   'launch a semi-interactive shell')
 
@@ -600,7 +623,7 @@ if __name__ == '__main__':
             options.k = True
 
         executer = DCOMEXEC(' '.join(options.command), username, password, domain, options.hashes, options.aesKey,
-                            options.share, options.nooutput, options.k, options.dc_ip, options.object)
+                            options.share, options.nooutput, options.k, options.dc_ip, options.object, options.shell_type)
         executer.run(address)
     except (Exception, KeyboardInterrupt) as e:
         if logging.getLogger().level == logging.DEBUG:

--- a/examples/dcomexec.py
+++ b/examples/dcomexec.py
@@ -431,7 +431,7 @@ class RemoteShellMMC20(RemoteShell):
     def execute_remote(self, data, shell_type='cmd'):
         if shell_type == 'powershell':
             data = '$ProgressPreference="SilentlyContinue";' + data
-            data = self.__pwsh + b64encode(data.encode('utf-16le')).decode()
+            data = self._RemoteShell__pwsh + b64encode(data.encode('utf-16le')).decode()
 
         command = '/Q /c ' + data
         if self._noOutput is False:

--- a/examples/psexec.py
+++ b/examples/psexec.py
@@ -329,8 +329,8 @@ class RemoteShell(cmd.Cmd):
         print("""
  lcd {path}                 - changes the current local directory to {path}
  exit                       - terminates the server process (and this session)
- put {src_file, dst_path}   - uploads a local file to the dst_path RELATIVE to the connected share (%s)
- get {file}                 - downloads pathname RELATIVE to the connected share (%s) to the current local dir
+ lput {src_file, dst_path}   - uploads a local file to the dst_path RELATIVE to the connected share (%s)
+ lget {file}                 - downloads pathname RELATIVE to the connected share (%s) to the current local dir
  ! {cmd}                    - executes a local shell cmd
 """ % (self.share, self.share))
         self.send_data('\r\n', False)
@@ -339,7 +339,7 @@ class RemoteShell(cmd.Cmd):
         os.system(s)
         self.send_data('\r\n')
 
-    def do_get(self, src_path):
+    def do_lget(self, src_path):
         try:
             if self.transferClient is None:
                 self.connect_transferClient()
@@ -356,7 +356,7 @@ class RemoteShell(cmd.Cmd):
 
         self.send_data('\r\n')
 
-    def do_put(self, s):
+    def do_lput(self, s):
         try:
             if self.transferClient is None:
                 self.connect_transferClient()

--- a/examples/smbexec.py
+++ b/examples/smbexec.py
@@ -39,6 +39,7 @@ except ImportError:
     import configparser as ConfigParser
 import logging
 from threading import Thread
+from base64 import b64encode
 
 from impacket.examples import logger
 from impacket import version, smbserver
@@ -111,8 +112,8 @@ class SMBServer(Thread):
         self._Thread__stop()
 
 class CMDEXEC:
-    def __init__(self, username='', password='', domain='', hashes=None, aesKey=None,
-                 doKerberos=None, kdcHost=None, mode=None, share=None, port=445, serviceName=SERVICE_NAME):
+    def __init__(self, username='', password='', domain='', hashes=None, aesKey=None, doKerberos=None,
+                 kdcHost=None, mode=None, share=None, port=445, serviceName=SERVICE_NAME, shell_type=None):
 
         self.__username = username
         self.__password = password
@@ -126,6 +127,7 @@ class CMDEXEC:
         self.__kdcHost = kdcHost
         self.__share = share
         self.__mode  = mode
+        self.__shell_type = shell_type
         self.shell = None
         if hashes is not None:
             self.__lmhash, self.__nthash = hashes.split(':')
@@ -148,7 +150,7 @@ class CMDEXEC:
                 serverThread = SMBServer()
                 serverThread.daemon = True
                 serverThread.start()
-            self.shell = RemoteShell(self.__share, rpctransport, self.__mode, self.__serviceName)
+            self.shell = RemoteShell(self.__share, rpctransport, self.__mode, self.__serviceName, self.__shell_type)
             self.shell.cmdloop()
             if self.__mode == 'SERVER':
                 serverThread.stop()
@@ -163,7 +165,7 @@ class CMDEXEC:
             sys.exit(1)
 
 class RemoteShell(cmd.Cmd):
-    def __init__(self, share, rpc, mode, serviceName):
+    def __init__(self, share, rpc, mode, serviceName, shell_type):
         cmd.Cmd.__init__(self)
         self.__share = share
         self.__mode = mode
@@ -172,6 +174,8 @@ class RemoteShell(cmd.Cmd):
         self.__outputBuffer = b''
         self.__command = ''
         self.__shell = '%COMSPEC% /Q /c '
+        self.__shell_type = shell_type
+        self.__pwsh = 'powershell.exe -NoP -NoL -sta -NonI -W Hidden -Exec Bypass -Enc '
         self.__serviceName = serviceName
         self.__rpc = rpc
         self.intro = '[!] Launching semi-interactive shell - Careful what you execute'
@@ -219,6 +223,10 @@ class RemoteShell(cmd.Cmd):
     def do_exit(self, s):
         return True
 
+    def do_EOF(self, s):
+        print()
+        return self.do_exit(s)
+
     def emptyline(self):
         return False
 
@@ -231,6 +239,8 @@ class RemoteShell(cmd.Cmd):
         if len(self.__outputBuffer) > 0:
             # Stripping CR/LF
             self.prompt = self.__outputBuffer.decode().replace('\r\n','') + '>'
+            if self.__shell_type == 'powershell':
+                self.prompt = 'PS ' + self.prompt + ' '
             self.__outputBuffer = b''
 
     def do_CD(self, s):
@@ -253,9 +263,14 @@ class RemoteShell(cmd.Cmd):
             fd.close()
             os.unlink(SMBSERVER_DIR + '/' + OUTPUT_FILENAME)
 
-    def execute_remote(self, data):
+    def execute_remote(self, data, shell_type='cmd'):
+        if shell_type == 'powershell':
+            data = '$ProgressPreference="SilentlyContinue";' + data
+            data = self.__pwsh + b64encode(data.encode('utf-16le')).decode()
+
         command = self.__shell + 'echo ' + data + ' ^> ' + self.__output + ' 2^>^&1 > ' + self.__batchFile + ' & ' + \
                   self.__shell + self.__batchFile
+
         if self.__mode == 'SERVER':
             command += ' & ' + self.__copyBack
         command += ' & ' + 'del ' + self.__batchFile
@@ -274,7 +289,7 @@ class RemoteShell(cmd.Cmd):
         self.get_output()
 
     def send_data(self, data):
-        self.execute_remote(data)
+        self.execute_remote(data, self.__shell_type)
         try:
             print(self.__outputBuffer.decode(CODEC))
         except UnicodeDecodeError:
@@ -303,6 +318,8 @@ if __name__ == '__main__':
                                                        'map the result with '
                           'https://docs.python.org/3/library/codecs.html#standard-encodings and then execute smbexec.py '
                           'again with -codec and the corresponding codec ' % CODEC)
+    parser.add_argument('-shell-type', action='store', default = 'cmd', choices = ['cmd', 'powershell'], help='choose '
+                        'a command processor for the semi-interactive shell')
 
     group = parser.add_argument_group('connection')
 
@@ -376,8 +393,8 @@ if __name__ == '__main__':
         options.k = True
 
     try:
-        executer = CMDEXEC(username, password, domain, options.hashes, options.aesKey, options.k,
-                           options.dc_ip, options.mode, options.share, int(options.port), options.service_name)
+        executer = CMDEXEC(username, password, domain, options.hashes, options.aesKey, options.k, options.dc_ip,
+                           options.mode, options.share, int(options.port), options.service_name, options.shell_type)
         executer.run(remoteName, options.target_ip)
     except Exception as e:
         if logging.getLogger().level == logging.DEBUG:


### PR DESCRIPTION
To continue PR #1035, I've added the same `-shell-type` option to execute PowerShell commands within semi-interactive shells in some other **\*exec.py** example scripts. Now this option is available for **dcomexec.py**, **smbexec.py** and **wmiexec.py**.

I did not touch **psexec.py** due to different nature of the script. From my understanding, PowerShell can be used out-of-the-box with psexec.py by providing `powershell.exe` as the positional `command` option.