### PR TITLE
User can select comversion #1031

### DIFF
--- a/examples/dcomexec.py
+++ b/examples/dcomexec.py
@@ -45,7 +45,7 @@ from six import PY2, PY3
 from impacket import version
 from impacket.dcerpc.v5.dcom.oaut import IID_IDispatch, string_to_bin, IDispatch, DISPPARAMS, DISPATCH_PROPERTYGET, \
     VARIANT, VARENUM, DISPATCH_METHOD
-from impacket.dcerpc.v5.dcomrt import DCOMConnection
+from impacket.dcerpc.v5.dcomrt import DCOMConnection, COMVERSION
 from impacket.dcerpc.v5.dcomrt import OBJREF, FLAGS_OBJREF_CUSTOM, OBJREF_CUSTOM, OBJREF_HANDLER, \
     OBJREF_EXTENDED, OBJREF_STANDARD, FLAGS_OBJREF_HANDLER, FLAGS_OBJREF_STANDARD, FLAGS_OBJREF_EXTENDED, \
     IRemUnknown2, INTERFACE
@@ -545,6 +545,8 @@ if __name__ == '__main__':
                           'again with -codec and the corresponding codec ' % CODEC)
     parser.add_argument('-object', choices=['ShellWindows', 'ShellBrowserWindow', 'MMC20'], nargs='?', default='ShellWindows',
                         help='DCOM object to be used to execute the shell command (default=ShellWindows)')
+    parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSOIN:MINOR_VERSION", help='DCOM versoin, '
+                        'format is MAJOR_VERSOIN:MINOR_VERSION e.g. 5.7')
 
     parser.add_argument('-shell-type', action='store', default = 'cmd', choices = ['cmd', 'powershell'], help='choose '
                         'a command processor for the semi-interactive shell')
@@ -592,6 +594,14 @@ if __name__ == '__main__':
         logging.debug(version.getInstallationPath())
     else:
         logging.getLogger().setLevel(logging.INFO)
+
+    if options.com_version is not None:
+        try:
+            major_version, minor_version = options.com_version.split('.')
+            COMVERSION.set_default_version(int(major_version), int(minor_version))
+        except Exception:
+            logging.error("Wrong COMVERSION format, use dot separated integers e.g. \"5.7\"")
+            sys.exit(1)
 
     import re
 

--- a/examples/dcomexec.py
+++ b/examples/dcomexec.py
@@ -546,7 +546,7 @@ if __name__ == '__main__':
     parser.add_argument('-object', choices=['ShellWindows', 'ShellBrowserWindow', 'MMC20'], nargs='?', default='ShellWindows',
                         help='DCOM object to be used to execute the shell command (default=ShellWindows)')
     parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSION:MINOR_VERSION", help='DCOM version, '
-                        'format is MAJOR_VERSOIN:MINOR_VERSION e.g. 5.7')
+                        'format is MAJOR_VERSION:MINOR_VERSION e.g. 5.7')
 
     parser.add_argument('-shell-type', action='store', default = 'cmd', choices = ['cmd', 'powershell'], help='choose '
                         'a command processor for the semi-interactive shell')

--- a/examples/dcomexec.py
+++ b/examples/dcomexec.py
@@ -545,7 +545,7 @@ if __name__ == '__main__':
                           'again with -codec and the corresponding codec ' % CODEC)
     parser.add_argument('-object', choices=['ShellWindows', 'ShellBrowserWindow', 'MMC20'], nargs='?', default='ShellWindows',
                         help='DCOM object to be used to execute the shell command (default=ShellWindows)')
-    parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSOIN:MINOR_VERSION", help='DCOM versoin, '
+    parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSION:MINOR_VERSION", help='DCOM version, '
                         'format is MAJOR_VERSOIN:MINOR_VERSION e.g. 5.7')
 
     parser.add_argument('-shell-type', action='store', default = 'cmd', choices = ['cmd', 'powershell'], help='choose '

--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -32,7 +32,7 @@ from base64 import b64encode
 from impacket.examples import logger
 from impacket import version
 from impacket.smbconnection import SMBConnection, SMB_DIALECT, SMB2_DIALECT_002, SMB2_DIALECT_21
-from impacket.dcerpc.v5.dcomrt import DCOMConnection
+from impacket.dcerpc.v5.dcomrt import DCOMConnection, COMVERSION
 from impacket.dcerpc.v5.dcom import wmi
 from impacket.dcerpc.v5.dtypes import NULL
 from impacket.krb5.keytab import Keytab
@@ -363,6 +363,8 @@ if __name__ == '__main__':
                           'again with -codec and the corresponding codec ' % CODEC)
     parser.add_argument('-shell-type', action='store', default = 'cmd', choices = ['cmd', 'powershell'], help='choose '
                         'a command processor for the semi-interactive shell')
+    parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSOIN:MINOR_VERSION", help='DCOM versoin, '
+                        'format is MAJOR_VERSOIN:MINOR_VERSION e.g. 5.7')
 
     parser.add_argument('command', nargs='*', default = ' ', help='command to execute at the target. If empty it will '
                                                                   'launch a semi-interactive shell')
@@ -407,6 +409,14 @@ if __name__ == '__main__':
         logging.debug(version.getInstallationPath())
     else:
         logging.getLogger().setLevel(logging.INFO)
+
+    if options.com_version is not None:
+        try:
+            major_version, minor_version = options.com_version.split('.')
+            COMVERSION.set_default_version(int(major_version), int(minor_version))
+        except Exception:
+            logging.error("Wrong COMVERSION format, use dot separated integers e.g. \"5.7\"")
+            sys.exit(1)
 
     import re
 

--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -363,7 +363,7 @@ if __name__ == '__main__':
                           'again with -codec and the corresponding codec ' % CODEC)
     parser.add_argument('-shell-type', action='store', default = 'cmd', choices = ['cmd', 'powershell'], help='choose '
                         'a command processor for the semi-interactive shell')
-    parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSOIN:MINOR_VERSION", help='DCOM versoin, '
+    parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSION:MINOR_VERSION", help='DCOM version, '
                         'format is MAJOR_VERSOIN:MINOR_VERSION e.g. 5.7')
 
     parser.add_argument('command', nargs='*', default = ' ', help='command to execute at the target. If empty it will '

--- a/examples/wmiexec.py
+++ b/examples/wmiexec.py
@@ -364,7 +364,7 @@ if __name__ == '__main__':
     parser.add_argument('-shell-type', action='store', default = 'cmd', choices = ['cmd', 'powershell'], help='choose '
                         'a command processor for the semi-interactive shell')
     parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSION:MINOR_VERSION", help='DCOM version, '
-                        'format is MAJOR_VERSOIN:MINOR_VERSION e.g. 5.7')
+                        'format is MAJOR_VERSION:MINOR_VERSION e.g. 5.7')
 
     parser.add_argument('command', nargs='*', default = ' ', help='command to execute at the target. If empty it will '
                                                                   'launch a semi-interactive shell')

--- a/examples/wmipersist.py
+++ b/examples/wmipersist.py
@@ -51,7 +51,7 @@ import logging
 
 from impacket.examples import logger
 from impacket import version
-from impacket.dcerpc.v5.dcomrt import DCOMConnection
+from impacket.dcerpc.v5.dcomrt import DCOMConnection, COMVERSION
 from impacket.dcerpc.v5.dcom import wmi
 from impacket.dcerpc.v5.dtypes import NULL
 
@@ -161,6 +161,8 @@ if __name__ == '__main__':
 
     parser.add_argument('target', action='store', help='[domain/][username[:password]@]<address>')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSOIN:MINOR_VERSION", help='DCOM versoin, '
+                        'format is MAJOR_VERSOIN:MINOR_VERSION e.g. 5.7')
     subparsers = parser.add_subparsers(help='actions', dest='action')
 
     # A start command
@@ -202,6 +204,15 @@ if __name__ == '__main__':
         logging.debug(version.getInstallationPath())
     else:
         logging.getLogger().setLevel(logging.INFO)
+
+    
+    if options.com_version is not None:
+        try:
+            major_version, minor_version = options.com_version.split('.')
+            COMVERSION.set_default_version(int(major_version), int(minor_version))
+        except Exception:
+            logging.error("Wrong COMVERSION format, use dot separated integers e.g. \"5.7\"")
+            sys.exit(1)
 
 
     if options.action.upper() == 'INSTALL':

--- a/examples/wmipersist.py
+++ b/examples/wmipersist.py
@@ -161,7 +161,7 @@ if __name__ == '__main__':
 
     parser.add_argument('target', action='store', help='[domain/][username[:password]@]<address>')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
-    parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSOIN:MINOR_VERSION", help='DCOM versoin, '
+    parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSION:MINOR_VERSION", help='DCOM version, '
                         'format is MAJOR_VERSOIN:MINOR_VERSION e.g. 5.7')
     subparsers = parser.add_subparsers(help='actions', dest='action')
 

--- a/examples/wmipersist.py
+++ b/examples/wmipersist.py
@@ -162,7 +162,7 @@ if __name__ == '__main__':
     parser.add_argument('target', action='store', help='[domain/][username[:password]@]<address>')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
     parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSION:MINOR_VERSION", help='DCOM version, '
-                        'format is MAJOR_VERSOIN:MINOR_VERSION e.g. 5.7')
+                        'format is MAJOR_VERSION:MINOR_VERSION e.g. 5.7')
     subparsers = parser.add_subparsers(help='actions', dest='action')
 
     # A start command

--- a/examples/wmiquery.py
+++ b/examples/wmiquery.py
@@ -131,7 +131,7 @@ if __name__ == '__main__':
     parser.add_argument('-file', type=argparse.FileType('r'), help='input file with commands to execute in the WQL shell')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
     parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSION:MINOR_VERSION", help='DCOM version, '
-                        'format is MAJOR_VERSOIN:MINOR_VERSION e.g. 5.7')
+                        'format is MAJOR_VERSION:MINOR_VERSION e.g. 5.7')
 
     group = parser.add_argument_group('authentication')
 

--- a/examples/wmiquery.py
+++ b/examples/wmiquery.py
@@ -28,7 +28,7 @@ from impacket.examples import logger
 from impacket import version
 from impacket.dcerpc.v5.dtypes import NULL
 from impacket.dcerpc.v5.dcom import wmi
-from impacket.dcerpc.v5.dcomrt import DCOMConnection
+from impacket.dcerpc.v5.dcomrt import DCOMConnection, COMVERSION
 from impacket.dcerpc.v5.rpcrt import RPC_C_AUTHN_LEVEL_PKT_PRIVACY, RPC_C_AUTHN_LEVEL_PKT_INTEGRITY
 
 if __name__ == '__main__':
@@ -130,6 +130,8 @@ if __name__ == '__main__':
     parser.add_argument('-namespace', action='store', default='//./root/cimv2', help='namespace name (default //./root/cimv2)')
     parser.add_argument('-file', type=argparse.FileType('r'), help='input file with commands to execute in the WQL shell')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSOIN:MINOR_VERSION", help='DCOM versoin, '
+                        'format is MAJOR_VERSOIN:MINOR_VERSION e.g. 5.7')
 
     group = parser.add_argument_group('authentication')
 
@@ -159,6 +161,14 @@ if __name__ == '__main__':
         logging.debug(version.getInstallationPath())
     else:
         logging.getLogger().setLevel(logging.INFO)
+
+    if options.com_version is not None:
+        try:
+            major_version, minor_version = options.com_version.split('.')
+            COMVERSION.set_default_version(int(major_version), int(minor_version))
+        except Exception:
+            logging.error("Wrong COMVERSION format, use dot separated integers e.g. \"5.7\"")
+            sys.exit(1)
 
     import re
 

--- a/examples/wmiquery.py
+++ b/examples/wmiquery.py
@@ -130,7 +130,7 @@ if __name__ == '__main__':
     parser.add_argument('-namespace', action='store', default='//./root/cimv2', help='namespace name (default //./root/cimv2)')
     parser.add_argument('-file', type=argparse.FileType('r'), help='input file with commands to execute in the WQL shell')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
-    parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSOIN:MINOR_VERSION", help='DCOM versoin, '
+    parser.add_argument('-com-version', action='store', metavar = "MAJOR_VERSION:MINOR_VERSION", help='DCOM version, '
                         'format is MAJOR_VERSOIN:MINOR_VERSION e.g. 5.7')
 
     group = parser.add_argument_group('authentication')

--- a/impacket/dcerpc/v5/dcomrt.py
+++ b/impacket/dcerpc/v5/dcomrt.py
@@ -164,15 +164,28 @@ class handle_t(NDRSTRUCT):
 
 # 2.2.11 COMVERSION
 class COMVERSION(NDRSTRUCT):
+
+    default_major_version = 5
+    default_minor_version = 7
+
     structure = (
         ('MajorVersion',USHORT),
         ('MinorVersion',USHORT),
     )
+
+    @classmethod
+    def set_default_version(cls, major_version=None, minor_version=None):
+        # Set default dcom version for all new COMVERSION objects.
+        if major_version is not None:
+            cls.default_major_version = major_version
+        if minor_version is not None:
+            cls.default_minor_version = minor_version
+
     def __init__(self, data = None,isNDR64 = False):
         NDRSTRUCT.__init__(self, data, isNDR64)
         if data is None:
-            self['MajorVersion'] = 5
-            self['MinorVersion'] = 7
+            self['MajorVersion'] = self.default_major_version
+            self['MinorVersion'] = self.default_minor_version
 
 class PCOMVERSION(NDRPOINTER):
     referent = (

--- a/impacket/dcerpc/v5/dcomrt.py
+++ b/impacket/dcerpc/v5/dcomrt.py
@@ -164,7 +164,6 @@ class handle_t(NDRSTRUCT):
 
 # 2.2.11 COMVERSION
 class COMVERSION(NDRSTRUCT):
-
     default_major_version = 5
     default_minor_version = 7
 


### PR DESCRIPTION
Fixed #1031.

Server want 5.6 DCOM version, but client version is 5.7.

```bash
$ python3 wmiquery.py user:pass@10.50.240.10 -debug
Impacket v0.9.23.dev1+20210315.121412.a16198c3 - Copyright 2020 SecureAuth Corporation

[+] Impacket Library Installation Path: /root/impacket/impacket
[+] Target system is 10.50.240.10 and isFDQN is False
[+] StringBinding: corp-6jl4yybmxr[1025]
[+] StringBinding: 10.50.240.10[1025]
[+] StringBinding chosen: ncacn_ip_tcp:10.50.240.10[1025]
[-] RPC_E_VERSION_MISMATCH - The version of OLE on the client and server machines does not match.
```

Now we cat define (globally) client DCOM version (e.g. 5.6).

```bash
$ python3 wmiquery.py user:pass@10.50.240.10 -debug -com-version 5.6 -debug
Impacket v0.9.23.dev1+20210315.121412.a16198c3 - Copyright 2020 SecureAuth Corporation

[+] Impacket Library Installation Path: /root/impacket/impacket
[+] Target system is 10.50.240.10 and isFDQN is False
[+] StringBinding: corp-6jl4yybmxr[1025]
[+] StringBinding: 10.50.240.10[1025]
[+] StringBinding chosen: ncacn_ip_tcp:10.50.240.10[1025]
[!] Press help for extra shell commands
WQL>
```