### PR TITLE
Impacket takes into CustomHeader garbage #1029

### DIFF
--- a/impacket/dcerpc/v5/dcomrt.py
+++ b/impacket/dcerpc/v5/dcomrt.py
@@ -509,6 +509,14 @@ class CustomHeader(TypeSerialization1):
             TypeSerialization1.getDataReferents(self, soFar))
         self['cIfs'] = len(self['pclsid'])
         return TypeSerialization1.getData(self, soFar)
+    
+    def fromStringReferent(self, data, offset=0):
+        return (
+            TypeSerialization1.fromStringReferent(self, data, offset) +
+            self['headerSize'] -
+            len(TypeSerialization1.getData(self, 0)) -
+            len(TypeSerialization1.getDataReferents(self, 0))
+        )
 
 # 2.2.22 Activation Properties BLOB
 class ACTIVATION_BLOB(NDRTLSTRUCT):


### PR DESCRIPTION
Fixed #1029.

After parsing arrays in structure (`pclsid` and `pSizes` arrays) method `fromStringReferent` returns not only arrays size (in bytes) but garbage size (in bytes) too. Garbage size is calculated by payload size and received `headerSize` field value.