### PR TITLE
Change duration measurement from days to hours

### DIFF
--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -400,7 +400,7 @@ class TICKETER:
         encTicketPart['authtime'] = KerberosTime.to_asn1(datetime.datetime.utcnow())
         encTicketPart['starttime'] = KerberosTime.to_asn1(datetime.datetime.utcnow())
         # Let's extend the ticket's validity a lil bit
-        ticketDuration = datetime.datetime.utcnow() + datetime.timedelta(days=int(self.__options.duration))
+        ticketDuration = datetime.datetime.utcnow() + datetime.timedelta(hours=float(self.__options.duration))
         encTicketPart['endtime'] = KerberosTime.to_asn1(ticketDuration)
         encTicketPart['renew-till'] = KerberosTime.to_asn1(ticketDuration)
         encTicketPart['authorization-data'] = noValue
@@ -742,8 +742,8 @@ if __name__ == '__main__':
     parser.add_argument('-user-id', action="store", default = '500', help='user id for the user the ticket will be '
                                                                           'created for (default = 500)')
     parser.add_argument('-extra-sid', action="store", help='Comma separated list of ExtraSids to be included inside the ticket\'s PAC')
-    parser.add_argument('-duration', action="store", default = '3650', help='Amount of days till the ticket expires '
-                                                                            '(default = 365*10)')
+    parser.add_argument('-duration', action="store", default = '87600', help='Amount of hours till the ticket expires '
+                                                                            '(default = 24*365*10)')
     parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
 


### PR DESCRIPTION
The default value for the lifetime of a legit ticket is 10h, so a longer one could be [suspicious](https://github.com/MicrosoftDocs/ATADocs/blob/54991bf39311683f66b6d2a10a6318c127f290be/ATPDocs/domain-dominance-alerts.md#suspected-golden-ticket-usage-time-anomaly-external-id-2022).
It is not possible to set a lifetime shorter than 1 day due to the fact that the data type of the duration parameter is int and it is measured in days.

The measurement is changed from days to hours because the value considered opsec is 10h. The default value for the duration parameter is still 10 years for anyone who doesn't care about opsec. Now the data type is float in case someone wants to set a decimal value.