### PR TITLE
Added basic GitHub Actions workflow

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,28 +12,28 @@ env:
 jobs:
   test:
     name: Run unit tests and build wheel
-    runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        tox-env: [py27, py36, py37, py38, py39]
         experimental: [false]
         include:
-          - python-version: 2.7
-            tox-env: py27
-          - python-version: 3.6
-            tox-env: py36
-          - python-version: 3.7
-            tox-env: py37
-          - python-version: 3.8
-            tox-env: py38
-          - python-version: 3.9
-            tox-env: py39
+          - tox-env: py27
+            python-version: 2.7
+          - tox-env: py36
+            python-version: 3.6
+          - tox-env: py37
+            python-version: 3.7
+          - tox-env: py38
+            python-version: 3.8
+          - tox-env: py39
+            python-version: 3.9
             experimental: true
     env:
       TOXENV: ${{ matrix.tox-env }}
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
 
     steps:
       - name: Checkout Impacket

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tox-env: [py27, py36, py37, py38, py39]
+        tox-env: [py27, py36, py37, py38]
         experimental: [false]
         include:
           - tox-env: py27

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -73,4 +73,5 @@ jobs:
         uses: action/checkout@v2
 
       - name: Build docker image
-        docker build -t ${{ DOCKER_TAG }} .
+        run: |
+          docker build -t ${{ DOCKER_TAG }} .

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -74,4 +74,4 @@ jobs:
 
       - name: Build docker image
         run: |
-          docker build -t ${{ DOCKER_TAG }} .
+          docker build -t ${{ env.DOCKER_TAG }} .

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout Impacket
-        uses: action/checkout@v2
+        uses: actions/checkout@v2
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -68,9 +68,10 @@ jobs:
   docker:
     name: Build docker image
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Checkout Impacket
-        uses: action/checkout@v2
+        uses: actions/checkout@v2
 
       - name: Build docker image
         run: |

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,76 @@
+# GitHub Action workflow to build and run Impacket's tests
+#
+
+name: Build and test Impacket
+
+on: [push, pull_request]
+
+env:
+  NO_REMOTE: true
+  DOCKER_TAG: impacket:latests
+
+jobs:
+  test:
+    name: Run unit tests and build wheel
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [2.7, 3.6, 3.7, 3.8, 3.9]
+        experimental: [false]
+        include:
+          - python-version: 2.7
+            tox-env: py27
+          - python-version: 3.6
+            tox-env: py36
+          - python-version: 3.7
+            tox-env: py37
+          - python-version: 3.8
+            tox-env: py38
+          - python-version: 3.9
+            tox-env: py39
+            experimental: true
+    env:
+      TOXENV: ${{ matrix.tox-env }}
+
+    steps:
+      - name: Checkout Impacket
+        uses: action/checkout@v2
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          pip install flake8 tox -r requirements.txt
+
+      - name: Check syntax errors
+        run: |
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+
+      - name: Check PEP8 warnings
+        run: |
+          flake8 . --count --ignore=E1,E2,E3,E501,W291,W293 --exit-zero --max-complexity=65 --max-line-length=127 --statistics
+
+      - name: Run unit tests
+        run: |
+          tox
+
+      - name: Build wheel artifact
+        run: |
+          python setup.py bdist_wheel
+
+  docker:
+    name: Build docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Impacket
+        uses: action/checkout@v2
+
+      - name: Build docker image
+        docker build -t ${{ DOCKER_TAG }} .

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -12,10 +12,10 @@ env:
 jobs:
   test:
     name: Run unit tests and build wheel
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         tox-env: [py27, py36, py37, py38, py39]
         experimental: [false]
         include:
@@ -32,7 +32,6 @@ jobs:
             experimental: true
     env:
       TOXENV: ${{ matrix.tox-env }}
-    runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
 
     steps:


### PR DESCRIPTION
As we were running with some issues with Travis (e.g. limited run minutes), we're adding GitHub Actions as a separate CI unit tests runner. Tests are executed via Tox in virtual environments so we should expect the same results as in Travis, although we're not yet replacing it at this point.

This PR:
- Adds a basic workflow that:
  - Runs flake8 for syntax errors and then runs non-remote unit tests using Tox.
  - Runs on Python 2.7, 3.6, 3.7, 3.8 and allows failures on 3.9 as we do in Travis.
- Adds a job that just builds the contributed docker image to check it's not failing.