### PR TITLE
Moved docker container to Python 3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM python:2-alpine as compile
+FROM python:3.8-alpine as compile
 WORKDIR /opt
-RUN apk add --no-cache git gcc openssl-dev libffi-dev musl-dev
+RUN apk add --no-cache git gcc musl-dev python3-dev libffi-dev openssl-dev cargo
 RUN pip install virtualenv
 RUN virtualenv -p python venv
 ENV PATH="/opt/venv/bin:$PATH"
 RUN git clone --depth 1 https://github.com/SecureAuthCorp/impacket.git
 RUN pip install impacket/
 
-FROM python:2-alpine
+FROM python:3.8-alpine
 COPY --from=compile /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 ENTRYPOINT ["/bin/sh"]


### PR DESCRIPTION
Using Python 3.8 Alpine-based as our base image for the default Docker build, as we're slowly trying to move away from Python 2.7. This increases the image size a little bit due to a new Rust dependency needed to have `cryptography` running in Alpine (see https://cryptography.io/en/latest/installation/#alpine).

This PR:
- Changes the base image to `python:3.8-alpine`.
- Adds dependencies needed to have `cryptography` running in Alpine.