### PR TITLE
Attempt to fix Python 3.9 compatibility issue with Thread.is_alive

### DIFF
--- a/tests/ImpactPacket/test_TCP_bug_issue7.py
+++ b/tests/ImpactPacket/test_TCP_bug_issue7.py
@@ -7,6 +7,7 @@ from impacket.ImpactPacket import TCP, ImpactPacketException
 import unittest
 from threading import Thread
 
+
 class TestTCP(unittest.TestCase):
 
     def setUp(self):
@@ -33,9 +34,8 @@ class TestTCP(unittest.TestCase):
         thread_hangs.setDaemon(True)
         thread_hangs.start()
 
-        thread_hangs.join(1.0) # 1 seconds timeout
-        self.assertEqual(thread_hangs.isAlive(), False)
-        #if thread_hang.isAlive():
+        thread_hangs.join(1.0)  # 1 seconds timeout
+        self.assertEqual(thread_hangs.is_alive(), False)
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestTCP)


### PR DESCRIPTION
As mentioned in #946 and #1054, one unit test of the ImpactPacket suite was using the isAlive method which was already depracated in Python 3.8, and removed in Python 3.9. This changes its use to is_alive, introduced back in Python 2.6!