### PR TITLE
Tests: Removed some deprecation warnings

### DIFF
--- a/tests/ImpactPacket/test_ICMP6.py
+++ b/tests/ImpactPacket/test_ICMP6.py
@@ -79,7 +79,7 @@ class TestICMP6(unittest.TestCase):
         icmp6_payload_buffer = icmp6_packet.child().get_bytes().tolist()
         generated_buffer = icmp6_header_buffer + icmp6_payload_buffer
         
-        self.assertEquals(generated_buffer, reference_buffer, test_fail_message)
+        self.assertEqual(generated_buffer, reference_buffer, test_fail_message)
         
     def generate_icmp6_constructed_packets(self):
         packet_list = []
@@ -157,19 +157,19 @@ class TestICMP6(unittest.TestCase):
         
         for i in range (0, len(self.reference_data_list)):
             p = d.decode(self.reference_data_list[i])
-            self.assertEquals(p.get_type(), msg_types[i], self.message_description_list[i] + " - Msg type mismatch")
-            self.assertEquals(p.get_code(), msg_codes[i], self.message_description_list[i] + " - Msg code mismatch")
+            self.assertEqual(p.get_type(), msg_types[i], self.message_description_list[i] + " - Msg type mismatch")
+            self.assertEqual(p.get_code(), msg_codes[i], self.message_description_list[i] + " - Msg code mismatch")
             
             if i in range(0, 2):
-                self.assertEquals(p.get_echo_id(), 1, self.message_description_list[i] + " - ID mismatch")
-                self.assertEquals(p.get_echo_sequence_number(), 2, self.message_description_list[i] + " - Sequence number mismatch")
-                self.assertEquals(p.get_echo_arbitrary_data().tolist(), [0xFE, 0x56, 0x88], self.message_description_list[i] + " - Arbitrary data mismatch")
+                self.assertEqual(p.get_echo_id(), 1, self.message_description_list[i] + " - ID mismatch")
+                self.assertEqual(p.get_echo_sequence_number(), 2, self.message_description_list[i] + " - Sequence number mismatch")
+                self.assertEqual(p.get_echo_arbitrary_data().tolist(), [0xFE, 0x56, 0x88], self.message_description_list[i] + " - Arbitrary data mismatch")
             if i in range(2, 5):
-                self.assertEquals(p.get_parm_problem_pointer(), 2, self.message_description_list[i] + " - Pointer mismatch")
+                self.assertEqual(p.get_parm_problem_pointer(), 2, self.message_description_list[i] + " - Pointer mismatch")
             if i in range(5, 15):
-                self.assertEquals(p.get_originating_packet_data().tolist(), [0xFE, 0x56, 0x88], self.message_description_list[i] + " - Originating packet data mismatch")
+                self.assertEqual(p.get_originating_packet_data().tolist(), [0xFE, 0x56, 0x88], self.message_description_list[i] + " - Originating packet data mismatch")
             if i in range(14, 15):
-                self.assertEquals(p.get_mtu(), 1300, self.message_description_list[i] + " - MTU mismatch")
+                self.assertEqual(p.get_mtu(), 1300, self.message_description_list[i] + " - MTU mismatch")
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestICMP6)

--- a/tests/ImpactPacket/test_IP6.py
+++ b/tests/ImpactPacket/test_IP6.py
@@ -51,14 +51,14 @@ class TestIP6(unittest.TestCase):
         source_address = parsed_packet.get_ip_src()
         destination_address = parsed_packet.get_ip_dst()
         
-        self.assertEquals(protocol_version, 6, "IP6 parsing - Incorrect protocol version")
-        self.assertEquals(traffic_class, 72, "IP6 parsing - Incorrect traffic class")
-        self.assertEquals(flow_label, 148997, "IP6 parsing - Incorrect flow label")
-        self.assertEquals(payload_length, 1500, "IP6 parsing - Incorrect payload length")
-        self.assertEquals(next_header, 17, "IP6 parsing - Incorrect next header")
-        self.assertEquals(hop_limit, 1, "IP6 parsing - Incorrect hop limit")
-        self.assertEquals(source_address.as_string(), "FE80::78F8:89D1:30FF:256B", "IP6 parsing - Incorrect source address")
-        self.assertEquals(destination_address.as_string(), "FF02::1:3", "IP6 parsing - Incorrect destination address")
+        self.assertEqual(protocol_version, 6, "IP6 parsing - Incorrect protocol version")
+        self.assertEqual(traffic_class, 72, "IP6 parsing - Incorrect traffic class")
+        self.assertEqual(flow_label, 148997, "IP6 parsing - Incorrect flow label")
+        self.assertEqual(payload_length, 1500, "IP6 parsing - Incorrect payload length")
+        self.assertEqual(next_header, 17, "IP6 parsing - Incorrect next header")
+        self.assertEqual(hop_limit, 1, "IP6 parsing - Incorrect hop limit")
+        self.assertEqual(source_address.as_string(), "FE80::78F8:89D1:30FF:256B", "IP6 parsing - Incorrect source address")
+        self.assertEqual(destination_address.as_string(), "FF02::1:3", "IP6 parsing - Incorrect destination address")
         
     def test_creation(self):
         '''Test IP6 Packet creation.'''
@@ -72,7 +72,7 @@ class TestIP6(unittest.TestCase):
         crafted_packet.set_ip_src("FE80::78F8:89D1:30FF:256B")
         crafted_packet.set_ip_dst("FF02::1:3")
         crafted_buffer = crafted_packet.get_bytes().tolist()
-        self.assertEquals(crafted_buffer, self.binary_packet, "IP6 creation - Buffer mismatch")
+        self.assertEqual(crafted_buffer, self.binary_packet, "IP6 creation - Buffer mismatch")
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestIP6)

--- a/tests/ImpactPacket/test_IP6_Address.py
+++ b/tests/ImpactPacket/test_IP6_Address.py
@@ -1,93 +1,110 @@
 #!/usr/bin/env python
 
-#Impact test version
+# Impact test version
 try:
     from impacket import IP6_Address
 except:
     pass
- 
-#Standalone test version
+
+# Standalone test version
 try:
     import sys
-    sys.path.insert(0,"../..")
+
+    sys.path.insert(0, "../..")
     import IP6_Address
 except:
     pass
 
 import unittest
 
+
 class TestIP6_Address(unittest.TestCase):
-        
+
     def runTest(self):
         pass
-  
+
     def test_construction(self):
-        '''Test IP6 Address construction'''
+        """Test IP6 Address construction"""
         normal_text_address = "FE80:1234:5678:ABCD:EF01:2345:6789:ABCD"
         normal_binary_address = [0xFE, 0x80, 0x12, 0x34,
-                          0x56, 0x78, 0xAB, 0xCD, 
-                          0xEF, 0x01, 0x23, 0x45,
-                          0x67, 0x89, 0xAB, 0xCD]
-        
+                                 0x56, 0x78, 0xAB, 0xCD,
+                                 0xEF, 0x01, 0x23, 0x45,
+                                 0x67, 0x89, 0xAB, 0xCD]
+
         oversized_text_address = "FE80:1234:5678:ABCD:EF01:2345:6789:ABCD:1234"
         oversized_binary_address = [0xFE, 0x80, 0x12, 0x34,
-                          0x56, 0x78, 0xAB, 0xCD, 
-                          0xEF, 0x01, 0x23, 0x45,
-                          0x67, 0x89, 0xAB, 0xCD, 0x00]
-        
+                                    0x56, 0x78, 0xAB, 0xCD,
+                                    0xEF, 0x01, 0x23, 0x45,
+                                    0x67, 0x89, 0xAB, 0xCD, 0x00]
+
         subsized_text_address = "FE80:1234:5678:ABCD:EF01:2345:6789"
         subsized_binary_address = [0xFE, 0x80, 0x12, 0x34,
-                          0x56, 0x78, 0xAB, 0xCD, 
-                          0xEF, 0x01, 0x23, 0x45,
-                          0x67, 0x89, 0xAB]
-        
+                                   0x56, 0x78, 0xAB, 0xCD,
+                                   0xEF, 0x01, 0x23, 0x45,
+                                   0x67, 0x89, 0xAB]
+
         malformed_text_address_1 = "FE80:123456788:ABCD:EF01:2345:6789:ABCD"
         malformed_text_address_2 = "ZXYW:1234:5678:ABCD:EF01:2345:6789:ABCD"
         malformed_text_address_3 = "FFFFFF:1234:5678:ABCD:EF01:2345:67:ABCD"
         empty_text_address = ""
         empty_binary_address = []
 
-        self.assert_(IP6_Address.IP6_Address(normal_text_address), "IP6 address construction with normal text address failed")
-        self.assert_(IP6_Address.IP6_Address(normal_binary_address), "IP6 address construction with normal binary address failed")
-        
-        self.assertRaises(Exception, IP6_Address.IP6_Address, oversized_text_address)#, "IP6 address construction with oversized text address incorrectly succeeded")
-        self.assertRaises(Exception, IP6_Address.IP6_Address, oversized_binary_address)#, "IP6 address construction with oversized binary address incorrectly succeeded")
-        self.assertRaises(Exception, IP6_Address.IP6_Address, subsized_text_address)#, "IP6 address construction with subsized text address incorrectly succeeded")
-        self.assertRaises(Exception, IP6_Address.IP6_Address, subsized_binary_address)#, "IP6 address construction with subsized binary address incorrectly succeeded")
-        self.assertRaises(Exception, IP6_Address.IP6_Address, malformed_text_address_1)#, "IP6 address construction with malformed text address (#1) incorrectly succeeded")
-        self.assertRaises(Exception, IP6_Address.IP6_Address, malformed_text_address_2)#, "IP6 address construction with malformed text address (#2) incorrectly succeeded")
-        self.assertRaises(Exception, IP6_Address.IP6_Address, malformed_text_address_3)#, "IP6 address construction with malformed text address (#3) incorrectly succeeded")
-        self.assertRaises(Exception, IP6_Address.IP6_Address, empty_text_address)#, "IP6 address construction with empty text address incorrectly succeeded")
-        self.assertRaises(Exception, IP6_Address.IP6_Address, empty_binary_address)#, "IP6 address construction with empty binary address incorrectly succeeded")
-        
+        self.assertTrue(IP6_Address.IP6_Address(normal_text_address),
+                        "IP6 address construction with normal text address failed")
+        self.assertTrue(IP6_Address.IP6_Address(normal_binary_address),
+                        "IP6 address construction with normal binary address failed")
+
+        self.assertRaises(Exception, IP6_Address.IP6_Address,
+                          oversized_text_address)  # , "IP6 address construction with oversized text address incorrectly succeeded")
+        self.assertRaises(Exception, IP6_Address.IP6_Address,
+                          oversized_binary_address)  # , "IP6 address construction with oversized binary address incorrectly succeeded")
+        self.assertRaises(Exception, IP6_Address.IP6_Address,
+                          subsized_text_address)  # , "IP6 address construction with subsized text address incorrectly succeeded")
+        self.assertRaises(Exception, IP6_Address.IP6_Address,
+                          subsized_binary_address)  # , "IP6 address construction with subsized binary address incorrectly succeeded")
+        self.assertRaises(Exception, IP6_Address.IP6_Address,
+                          malformed_text_address_1)  # , "IP6 address construction with malformed text address (#1) incorrectly succeeded")
+        self.assertRaises(Exception, IP6_Address.IP6_Address,
+                          malformed_text_address_2)  # , "IP6 address construction with malformed text address (#2) incorrectly succeeded")
+        self.assertRaises(Exception, IP6_Address.IP6_Address,
+                          malformed_text_address_3)  # , "IP6 address construction with malformed text address (#3) incorrectly succeeded")
+        self.assertRaises(Exception, IP6_Address.IP6_Address,
+                          empty_text_address)  # , "IP6 address construction with empty text address incorrectly succeeded")
+        self.assertRaises(Exception, IP6_Address.IP6_Address,
+                          empty_binary_address)  # , "IP6 address construction with empty binary address incorrectly succeeded")
+
     def test_unicode_representation(self):
-        '''Test IP6 Unicode text representations'''
+        """Test IP6 Unicode text representations"""
         unicode_normal_text_address = u'FE80:1234:5678:ABCD:EF01:2345:6789:ABCD'
 
-        self.assert_(IP6_Address.IP6_Address(unicode_normal_text_address), "IP6 address construction with UNICODE normal text address failed")
+        self.assertTrue(IP6_Address.IP6_Address(unicode_normal_text_address),
+                        "IP6 address construction with UNICODE normal text address failed")
 
-        
     def test_conversions(self):
-        '''Test IP6 Address conversions.'''
+        """Test IP6 Address conversions."""
         text_address = "FE80:1234:5678:ABCD:EF01:2345:6789:ABCD"
         binary_address = [0xFE, 0x80, 0x12, 0x34,
-                          0x56, 0x78, 0xAB, 0xCD, 
+                          0x56, 0x78, 0xAB, 0xCD,
                           0xEF, 0x01, 0x23, 0x45,
                           0x67, 0x89, 0xAB, 0xCD]
-        self.assert_(IP6_Address.IP6_Address(text_address).as_string() == text_address, "IP6 address conversion text -> text failed")
-        self.assert_(IP6_Address.IP6_Address(binary_address).as_bytes() == binary_address, "IP6 address conversion binary -> binary failed")
-        self.assert_(IP6_Address.IP6_Address(binary_address).as_string() == text_address, "IP6 address conversion binary -> text failed")
-        self.assert_(IP6_Address.IP6_Address(text_address).as_bytes().tolist() == binary_address, "IP6 address conversion text -> binary failed")
-        
+        self.assertTrue(IP6_Address.IP6_Address(text_address).as_string() == text_address,
+                        "IP6 address conversion text -> text failed")
+        self.assertTrue(IP6_Address.IP6_Address(binary_address).as_bytes() == binary_address,
+                        "IP6 address conversion binary -> binary failed")
+        self.assertTrue(IP6_Address.IP6_Address(binary_address).as_string() == text_address,
+                        "IP6 address conversion binary -> text failed")
+        self.assertTrue(IP6_Address.IP6_Address(text_address).as_bytes().tolist() == binary_address,
+                        "IP6 address conversion text -> binary failed")
+
     def test_compressions(self):
-        '''Test IP6 Address compressions.'''
-        compressed_addresses = [ "::",
-                          "1::",
-                          "::1",
-                          "1::2",
-                          "1::1:2:3",
-                          "FE80:234:567:4::1"
-                          ]
+        """Test IP6 Address compressions."""
+        compressed_addresses = ["::",
+                                "1::",
+                                "::1",
+                                "1::2",
+                                "1::1:2:3",
+                                "FE80:234:567:4::1"
+                                ]
         full_addresses = ["0000:0000:0000:0000:0000:0000:0000:0000",
                           "0001:0000:0000:0000:0000:0000:0000:0000",
                           "0000:0000:0000:0000:0000:0000:0000:0001",
@@ -95,29 +112,39 @@ class TestIP6_Address(unittest.TestCase):
                           "0001:0000:0000:0000:0000:0001:0002:0003",
                           "FE80:0234:0567:0004:0000:0000:0000:0001"
                           ]
-        
-        for f, c in zip(full_addresses, compressed_addresses):
-            self.assert_(IP6_Address.IP6_Address(f).as_string() == c, "IP6 address compression failed with full address: " + f)
-            self.assert_(IP6_Address.IP6_Address(c).as_string(False) == f, "IP6 address compression failed with compressed address:" + c)
 
+        for f, c in zip(full_addresses, compressed_addresses):
+            self.assertTrue(IP6_Address.IP6_Address(f).as_string() == c,
+                            "IP6 address compression failed with full address: " + f)
+            self.assertTrue(IP6_Address.IP6_Address(c).as_string(False) == f,
+                            "IP6 address compression failed with compressed address:" + c)
 
     def test_scoped_addresses(self):
-        '''Test scoped addresses.'''
+        """Test scoped addresses."""
         numeric_scoped_address = "FE80::1234:1%12"
-        self.assert_(IP6_Address.IP6_Address(numeric_scoped_address).as_string() == numeric_scoped_address, "Numeric scoped address conversion failed on address: " + numeric_scoped_address)
-        self.assert_(IP6_Address.IP6_Address(numeric_scoped_address).get_scope_id() == "12", "Numeric scope ID fetch failed on address: " + numeric_scoped_address)
-        self.assert_(IP6_Address.IP6_Address(numeric_scoped_address).get_unscoped_address() == "FE80::1234:1", "Get unscoped address failed on address: " + numeric_scoped_address)
-        
+        self.assertTrue(IP6_Address.IP6_Address(numeric_scoped_address).as_string() == numeric_scoped_address,
+                        "Numeric scoped address conversion failed on address: " + numeric_scoped_address)
+        self.assertTrue(IP6_Address.IP6_Address(numeric_scoped_address).get_scope_id() == "12",
+                        "Numeric scope ID fetch failed on address: " + numeric_scoped_address)
+        self.assertTrue(IP6_Address.IP6_Address(numeric_scoped_address).get_unscoped_address() == "FE80::1234:1",
+                        "Get unscoped address failed on address: " + numeric_scoped_address)
+
         unscoped_address = "1::4:1"
-        self.assert_(IP6_Address.IP6_Address(unscoped_address).as_string() == unscoped_address, "Unscoped address conversion failed on address: " + unscoped_address)
-        self.assert_(IP6_Address.IP6_Address(unscoped_address).get_scope_id() == "", "Unscoped address scope ID fetch failed on address: " + unscoped_address)
-        self.assert_(IP6_Address.IP6_Address(unscoped_address).get_unscoped_address() == unscoped_address, "Get unscoped address failed on address: " + unscoped_address)
-        
-        text_scoped_address = "FE80::1234:1%BLAH"        
-        self.assert_(IP6_Address.IP6_Address(text_scoped_address).as_string() == text_scoped_address, "Text scoped address conversion failed on address: " + text_scoped_address)
-        self.assert_(IP6_Address.IP6_Address(text_scoped_address).get_scope_id() == "BLAH", "Text scope ID fetch failed on address: " + text_scoped_address)
-        self.assert_(IP6_Address.IP6_Address(text_scoped_address).get_unscoped_address() == "FE80::1234:1", "Get unscoped address failed on address: " + text_scoped_address)
-        
+        self.assertTrue(IP6_Address.IP6_Address(unscoped_address).as_string() == unscoped_address,
+                        "Unscoped address conversion failed on address: " + unscoped_address)
+        self.assertTrue(IP6_Address.IP6_Address(unscoped_address).get_scope_id() == "",
+                        "Unscoped address scope ID fetch failed on address: " + unscoped_address)
+        self.assertTrue(IP6_Address.IP6_Address(unscoped_address).get_unscoped_address() == unscoped_address,
+                        "Get unscoped address failed on address: " + unscoped_address)
+
+        text_scoped_address = "FE80::1234:1%BLAH"
+        self.assertTrue(IP6_Address.IP6_Address(text_scoped_address).as_string() == text_scoped_address,
+                        "Text scoped address conversion failed on address: " + text_scoped_address)
+        self.assertTrue(IP6_Address.IP6_Address(text_scoped_address).get_scope_id() == "BLAH",
+                        "Text scope ID fetch failed on address: " + text_scoped_address)
+        self.assertTrue(IP6_Address.IP6_Address(text_scoped_address).get_unscoped_address() == "FE80::1234:1",
+                        "Get unscoped address failed on address: " + text_scoped_address)
+
         empty_scoped_address = "FE80::1234:1%"
         self.assertRaises(Exception, IP6_Address.IP6_Address, empty_scoped_address)
 

--- a/tests/dot11/test_wps.py
+++ b/tests/dot11/test_wps.py
@@ -50,7 +50,8 @@ class TestTLVContainer(unittest.TestCase):
             self.assertEqual(v, tlvc2.first(k))
         
         self.assertEqual(tlvc.to_ary(), tlvc2.to_ary())
-        self.assertEquals(b"Sarlanga", tlvc.first(1))
+        self.assertEqual(b"Sarlanga", tlvc.first(1))
+
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestTLVContainer)
 unittest.TextTestRunner(verbosity=1).run(suite)


### PR DESCRIPTION
Replaced some test alias that were deprecated long time ago and were showing some warnings in our tests:

- `assert_` with `assertTrue`
- `assertEquals` with `assertEqual`