### PR TITLE
Getting targeted users with secretsdump

### DIFF
--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -299,8 +299,10 @@ if __name__ == '__main__':
                         'method to use at target (only when using -use-vss). Default: smbexec')
     group = parser.add_argument_group('display options')
     group.add_argument('-just-dc-user', action='store', metavar='USERNAME',
-                       help='Extract only NTDS.DIT data for the user specified. Only available for DRSUAPI approach. '
-                            'Implies also -just-dc switch')
+                       help='Extract only NTDS.DIT data for the specified user. Multiple users can be specified by command'
+                       ' line separated by commas, or by using a file with one username per line. '
+                       'It is recommended to use NetBIOS domain name instead of FQDN. ' 
+                       'Only available for DRSUAPI approach. Implies also -just-dc switch')
     group.add_argument('-just-dc', action='store_true', default=False,
                         help='Extract only NTDS.DIT data (NTLM hashes and Kerberos keys)')
     group.add_argument('-just-dc-ntlm', action='store_true', default=False,

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -2436,41 +2436,49 @@ class NTDSHashes:
                     # That's because we don't specify the domain for the user (and there might be duplicates)
                     # Always remember that if you specify a domain, you should specify the NetBIOS domain name,
                     # not the FQDN. Just for this time. It's confusing I know, but that's how this API works.
-                    if self.__justUser.find('\\') >=0 or self.__justUser.find('/') >= 0:
-                        self.__justUser = self.__justUser.replace('/','\\')
-                        formatOffered = drsuapi.DS_NAME_FORMAT.DS_NT4_ACCOUNT_NAME
+                    if os.path.isfile(self.__justUser):
+                        with open(self.__justUser) as fi:
+                            usernames = [line.strip() for line in fi]
                     else:
-                        formatOffered = drsuapi.DS_NT4_ACCOUNT_NAME_SANS_DOMAIN
+                        usernames = [x.strip() for x in self.__justUser.split(',')]
+                    for username in usernames:
+                        self.__justUser = username
+                        if self.__justUser.find('\\') >=0 or self.__justUser.find('/') >= 0:
+                            self.__justUser = self.__justUser.replace('/','\\')
+                            formatOffered = drsuapi.DS_NAME_FORMAT.DS_NT4_ACCOUNT_NAME
+                        else:
+                            formatOffered = drsuapi.DS_NT4_ACCOUNT_NAME_SANS_DOMAIN
 
-                    crackedName = self.__remoteOps.DRSCrackNames(formatOffered,
-                                                                 drsuapi.DS_NAME_FORMAT.DS_UNIQUE_ID_NAME,
-                                                                 name=self.__justUser)
+                        crackedName = self.__remoteOps.DRSCrackNames(formatOffered,
+                                                                     drsuapi.DS_NAME_FORMAT.DS_UNIQUE_ID_NAME,
+                                                                     name=self.__justUser)
 
-                    if crackedName['pmsgOut']['V1']['pResult']['cItems'] == 1:
-                        if crackedName['pmsgOut']['V1']['pResult']['rItems'][0]['status'] != 0:
-                            raise Exception("%s: %s" % system_errors.ERROR_MESSAGES[
-                                0x2114 + crackedName['pmsgOut']['V1']['pResult']['rItems'][0]['status']])
+                        if crackedName['pmsgOut']['V1']['pResult']['cItems'] == 1:
+                            if crackedName['pmsgOut']['V1']['pResult']['rItems'][0]['status'] != 0:
+                                LOG.error('DRSCrackNames returned error for user %s, skipping' % self.__justUser)
+                                LOG.warning('Check username or filename.')
+                                continue
 
-                        userRecord = self.__remoteOps.DRSGetNCChanges(crackedName['pmsgOut']['V1']['pResult']['rItems'][0]['pName'][:-1])
-                        #userRecord.dump()
-                        replyVersion = 'V%d' % userRecord['pdwOutVersion']
-                        if userRecord['pmsgOut'][replyVersion]['cNumObjects'] == 0:
-                            raise Exception('DRSGetNCChanges didn\'t return any object!')
-                    else:
-                        LOG.warning('DRSCrackNames returned %d items for user %s, skipping' % (
-                        crackedName['pmsgOut']['V1']['pResult']['cItems'], self.__justUser))
-                    try:
-                        self.__decryptHash(userRecord,
-                                           userRecord['pmsgOut'][replyVersion]['PrefixTableSrc']['pPrefixEntry'],
-                                           hashesOutputFile)
-                        if self.__justNTLM is False:
-                            self.__decryptSupplementalInfo(userRecord, userRecord['pmsgOut'][replyVersion]['PrefixTableSrc'][
-                                'pPrefixEntry'], keysOutputFile, clearTextOutputFile)
+                            userRecord = self.__remoteOps.DRSGetNCChanges(crackedName['pmsgOut']['V1']['pResult']['rItems'][0]['pName'][:-1])
+                            #userRecord.dump()
+                            replyVersion = 'V%d' % userRecord['pdwOutVersion']
+                            if userRecord['pmsgOut'][replyVersion]['cNumObjects'] == 0:
+                                raise Exception('DRSGetNCChanges didn\'t return any object!')
+                        else:
+                            LOG.warning('DRSCrackNames returned %d items for user %s, skipping' % (
+                            crackedName['pmsgOut']['V1']['pResult']['cItems'], self.__justUser))
+                        try:
+                            self.__decryptHash(userRecord,
+                                               userRecord['pmsgOut'][replyVersion]['PrefixTableSrc']['pPrefixEntry'],
+                                               hashesOutputFile)
+                            if self.__justNTLM is False:
+                                self.__decryptSupplementalInfo(userRecord, userRecord['pmsgOut'][replyVersion]['PrefixTableSrc'][
+                                    'pPrefixEntry'], keysOutputFile, clearTextOutputFile)
 
-                    except Exception as e:
-                        LOG.error("Error while processing user!")
-                        LOG.debug("Exception", exc_info=True)
-                        LOG.error(str(e))
+                        except Exception as e:
+                            LOG.error("Error while processing user!")
+                            LOG.debug("Exception", exc_info=True)
+                            LOG.error(str(e))
                 else:
                     while status == STATUS_MORE_ENTRIES:
                         resp = self.__remoteOps.getDomainUsers(enumerationContext)


### PR DESCRIPTION
Up to now there are two options for dcsync, dump all users or just one user. Sometimes dumping all users takes too much time depending on the size of NTDS and the connection.

This PR allows to reuse the authentication to request specific users, avoiding dumping machine accounts or disabled users for example.

Usernames can be specified by command line separated by commas or by using a file with one username per line. It's recommended to use NetBIOS domain name instead of FQDN.

I reuse the `-just-dc-user` argument to modify the code as less as possible.