### PR TITLE
WMI objects minor refactors, fixes, and offline parsing tests

### DIFF
--- a/examples/wmipersist.py
+++ b/examples/wmipersist.py
@@ -70,8 +70,14 @@ class WMIPERSISTENCE:
 
     @staticmethod
     def checkError(banner, resp):
-        if resp.GetCallStatus(0) != 0:
-            logging.error('%s - ERROR (0x%x)' % (banner, resp.GetCallStatus(0)))
+        call_status = resp.GetCallStatus(0) & 0xffffffff  # interpret as unsigned
+        if call_status != 0:
+            from impacket.dcerpc.v5.dcom.wmi import WBEMSTATUS
+            try:
+                error_name = WBEMSTATUS.enumItems(call_status).name
+            except ValueError:
+                error_name = 'Unknown'
+            logging.error('%s - ERROR: %s (0x%08x)' % (banner, error_name, call_status))
         else:
             logging.info('%s - OK' % banner)
 

--- a/examples/wmipersist.py
+++ b/examples/wmipersist.py
@@ -151,9 +151,6 @@ class WMIPERSISTENCE:
             filterBinding.Filter = '__EventFilter.Name="EF_%s"' % self.__options.name
             filterBinding.Consumer = 'ActiveScriptEventConsumer.Name="%s"' % self.__options.name
             filterBinding.CreatorSID = [1, 2, 0, 0, 0, 0, 0, 5, 32, 0, 0, 0, 32, 2, 0, 0]
-            # Even when the default value of DeliveryQoS is 0, we're explicitly assigning it to
-            # avoid the default tag
-            filterBinding.DeliveryQoS = 0  # WMIMSG_FLAG_QOS_SYNCHRONOUS
 
             self.checkError('Adding FilterToConsumerBinding',
                 iWbemServices.PutInstance(filterBinding.marshalMe()))

--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -2382,6 +2382,7 @@ class IWbemClassObject(IRemUnknown):
         for i, propName in enumerate(properties):
             propRecord = properties[propName]
             itemValue = getattr(self, propName)
+            propIsInherited = propRecord['inherited']
             print("PropName %r, Value: %r" % (propName,itemValue))
 
             pType = propRecord['type'] & (~(CIM_ARRAY_FLAG|Inherited)) 
@@ -2393,7 +2394,7 @@ class IWbemClassObject(IRemUnknown):
 
             if propRecord['type'] & CIM_ARRAY_FLAG:
                 if itemValue is None:
-                    ndTable |= self.__ndEntry(i, True, False)
+                    ndTable |= self.__ndEntry(i, True, propIsInherited)
                     valueTable += pack(packStr, 0)
                 else:
                     valueTable += pack('<L', curHeapPtr)
@@ -2407,20 +2408,20 @@ class IWbemClassObject(IRemUnknown):
             elif pType in (CIM_TYPE_ENUM.CIM_TYPE_UINT8.value, CIM_TYPE_ENUM.CIM_TYPE_UINT16.value,
                            CIM_TYPE_ENUM.CIM_TYPE_UINT32.value, CIM_TYPE_ENUM.CIM_TYPE_UINT64.value):
                 if itemValue is None:
-                    ndTable |= self.__ndEntry(i, True, False)
+                    ndTable |= self.__ndEntry(i, True, propIsInherited)
                     valueTable += pack(packStr, 0)
                 else:
                     valueTable += pack(packStr, int(itemValue))
             elif pType in (CIM_TYPE_ENUM.CIM_TYPE_BOOLEAN.value,):
                 if itemValue is None:
-                    ndTable |= self.__ndEntry(i, True, False)
+                    ndTable |= self.__ndEntry(i, True, propIsInherited)
                     valueTable += pack(packStr, False)
                 else:
                     valueTable += pack(packStr, bool(itemValue))
             elif pType not in (CIM_TYPE_ENUM.CIM_TYPE_STRING.value, CIM_TYPE_ENUM.CIM_TYPE_DATETIME.value,
                                CIM_TYPE_ENUM.CIM_TYPE_REFERENCE.value, CIM_TYPE_ENUM.CIM_TYPE_OBJECT.value):
                 if itemValue is None:
-                    ndTable |= self.__ndEntry(i, True, False)
+                    ndTable |= self.__ndEntry(i, True, propIsInherited)
                     valueTable += pack(packStr, -1)
                 else:
                     valueTable += pack(packStr, itemValue)
@@ -2432,7 +2433,7 @@ class IWbemClassObject(IRemUnknown):
                     ndTable |= self.__ndEntry(i, True, True)
             else:
                 if itemValue == '':
-                    ndTable |= self.__ndEntry(i, True, False)
+                    ndTable |= self.__ndEntry(i, True, propIsInherited)
                     valueTable += pack('<L', 0)
                 else:
                     strIn = ENCODED_STRING()

--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -2425,7 +2425,8 @@ class IWbemClassObject(IRemUnknown):
                 else:
                     valueTable += pack(packStr, itemValue)
             elif pType == CIM_TYPE_ENUM.CIM_TYPE_OBJECT.value:
-                # For now we just pack None
+                # For now we just pack None and set the default_value_is_inherited
+                # flag, just in case a parent class defines this for us
                 valueTable += b'\x00'*4
                 if itemValue is None:
                     ndTable |= self.__ndEntry(i, True, True)
@@ -2517,7 +2518,8 @@ class IWbemClassObject(IRemUnknown):
                                    CIM_TYPE_ENUM.CIM_TYPE_REFERENCE.value, CIM_TYPE_ENUM.CIM_TYPE_OBJECT.value):
                     valueTable += pack(packStr, 0)
                 elif pType == CIM_TYPE_ENUM.CIM_TYPE_OBJECT.value:
-                    # For now we just pack None
+                    # For now we just pack None and set the default_value_is_inherited
+                    # flag, just in case a parent class defines this for us
                     valueTable += b'\x00'*4
                     ndTable |= self.__ndEntry(i, True, True)
                 else:
@@ -2709,7 +2711,8 @@ class IWbemClassObject(IRemUnknown):
                         valueTable += pack(packStr, inArg)
                     elif pType == CIM_TYPE_ENUM.CIM_TYPE_OBJECT.value:
                         if inArg is None:
-                            # For now we just pack None
+                            # For now we just pack None and set the default_value_is_inherited
+                            # flag, just in case a parent class defines this for us
                             valueTable += b'\x00' * 4
                             ndTable |= self.__ndEntry(i, True, True)
                         else:

--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -23,6 +23,7 @@ from struct import unpack, calcsize, pack
 from functools import partial
 import collections
 import logging
+import six
 
 from impacket.dcerpc.v5.ndr import NDRSTRUCT, NDRUniConformantArray, NDRPOINTER, NDRUniConformantVaryingArray, NDRUNION, \
     NDRENUM
@@ -794,7 +795,7 @@ class INSTANCE_TYPE(Structure):
     def processNdTable(self, properties):
         octetCount = (len(properties) - 1) // 4 + 1  # see [MS-WMIO]: 2.2.26 NdTable
         packedNdTable = self['NdTable_ValueTable'][:octetCount]
-        unpackedNdTable = [(ord(byte) >> shift) & 0b11 for byte in packedNdTable for shift in (0, 2, 4, 6)]
+        unpackedNdTable = [(byte >> shift) & 0b11 for byte in six.iterbytes(packedNdTable) for shift in (0, 2, 4, 6)]
         for key in properties:
             ndEntry = unpackedNdTable[properties[key]['order']]
             properties[key]['null_default'] = bool(ndEntry & 0b01)

--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -2387,9 +2387,9 @@ class IWbemClassObject(IRemUnknown):
         return self.encodingUnit['ObjectBlock'].ctCurrent['methods']
 
     @staticmethod
-    def __ndEntry(index, default_value_is_null, default_value_is_inherited):
+    def __ndEntry(index, null_default, inherited_default):
         # https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wmio/ed436785-40fc-425e-ad3d-f9200eb1a122
-        return (bool(default_value_is_null) << 1 | bool(default_value_is_inherited)) << (2 * index)
+        return (bool(null_default) << 1 | bool(inherited_default)) << (2 * index)
 
     def marshalMe(self):
         # So, in theory, we have the OBJCUSTOM built, but 
@@ -2451,7 +2451,7 @@ class IWbemClassObject(IRemUnknown):
                 else:
                     valueTable += pack(packStr, itemValue)
             elif pType == CIM_TYPE_ENUM.CIM_TYPE_OBJECT.value:
-                # For now we just pack None and set the default_value_is_inherited
+                # For now we just pack None and set the inherited_default
                 # flag, just in case a parent class defines this for us
                 valueTable += b'\x00'*4
                 if itemValue is None:
@@ -2544,7 +2544,7 @@ class IWbemClassObject(IRemUnknown):
                                    CIM_TYPE_ENUM.CIM_TYPE_REFERENCE.value, CIM_TYPE_ENUM.CIM_TYPE_OBJECT.value):
                     valueTable += pack(packStr, 0)
                 elif pType == CIM_TYPE_ENUM.CIM_TYPE_OBJECT.value:
-                    # For now we just pack None and set the default_value_is_inherited
+                    # For now we just pack None and set the inherited_default
                     # flag, just in case a parent class defines this for us
                     valueTable += b'\x00'*4
                     ndTable |= self.__ndEntry(i, True, True)
@@ -2737,7 +2737,7 @@ class IWbemClassObject(IRemUnknown):
                         valueTable += pack(packStr, inArg)
                     elif pType == CIM_TYPE_ENUM.CIM_TYPE_OBJECT.value:
                         if inArg is None:
-                            # For now we just pack None and set the default_value_is_inherited
+                            # For now we just pack None and set the inherited_default
                             # flag, just in case a parent class defines this for us
                             valueTable += b'\x00' * 4
                             ndTable |= self.__ndEntry(i, True, True)

--- a/impacket/dcerpc/v5/dcom/wmi.py
+++ b/impacket/dcerpc/v5/dcom/wmi.py
@@ -2458,7 +2458,9 @@ class IWbemClassObject(IRemUnknown):
                     ndTable |= self.__ndEntry(i, True, True)
             else:
                 if itemValue == '':
-                    ndTable |= self.__ndEntry(i, True, propIsInherited)
+                    # https://github.com/SecureAuthCorp/impacket/pull/1069#issuecomment-835179409
+                    # Force inherited_default to avoid 'obscure' issue in wmipersist.py
+                    ndTable |= self.__ndEntry(i, True, True)
                     valueTable += pack('<L', 0)
                 else:
                     strIn = ENCODED_STRING()

--- a/tests/ImpactPacket/test_ICMP6.py
+++ b/tests/ImpactPacket/test_ICMP6.py
@@ -173,4 +173,4 @@ class TestICMP6(unittest.TestCase):
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestICMP6)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/ImpactPacket/test_IP6.py
+++ b/tests/ImpactPacket/test_IP6.py
@@ -76,4 +76,4 @@ class TestIP6(unittest.TestCase):
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestIP6)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/ImpactPacket/test_IP6_Address.py
+++ b/tests/ImpactPacket/test_IP6_Address.py
@@ -123,4 +123,4 @@ class TestIP6_Address(unittest.TestCase):
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestIP6_Address)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/ImpactPacket/test_IP6_Extension_Headers.py
+++ b/tests/ImpactPacket/test_IP6_Extension_Headers.py
@@ -617,4 +617,4 @@ class TestIP6(unittest.TestCase):
         self.assertEqual(padn_option_length, 12, "Simple Hop By Hop Parsing - Incorrect option size")
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestIP6)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/ImpactPacket/test_TCP.py
+++ b/tests/ImpactPacket/test_TCP.py
@@ -142,4 +142,4 @@ class TestTCP(unittest.TestCase):
         self.assertEqual(self.tcp.get_th_flags(), 0xAA )
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestTCP)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/ImpactPacket/test_TCP_bug_issue7.py
+++ b/tests/ImpactPacket/test_TCP_bug_issue7.py
@@ -39,4 +39,4 @@ class TestTCP(unittest.TestCase):
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestTCP)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/ImpactPacket/test_ethernet.py
+++ b/tests/ImpactPacket/test_ethernet.py
@@ -106,4 +106,4 @@ class TestEthernet(unittest.TestCase):
 
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestEthernet)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_bkrp.py
+++ b/tests/SMB_RPC/test_bkrp.py
@@ -230,4 +230,4 @@ if __name__ == '__main__':
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(SMBTransport)
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMBTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_dcomrt.py
+++ b/tests/SMB_RPC/test_dcomrt.py
@@ -338,4 +338,4 @@ if __name__ == '__main__':
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(TCPTransport)
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TCPTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_dhcpm.py
+++ b/tests/SMB_RPC/test_dhcpm.py
@@ -208,4 +208,4 @@ if __name__ == '__main__':
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(TCPTransport)
         #suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TCPTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_drsuapi.py
+++ b/tests/SMB_RPC/test_drsuapi.py
@@ -524,4 +524,4 @@ if __name__ == '__main__':
         suite  = unittest.TestLoader().loadTestsFromTestCase(TCPTransport)
         #suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TCPTransport64))
         #suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMBTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_epm.py
+++ b/tests/SMB_RPC/test_epm.py
@@ -180,4 +180,4 @@ if __name__ == '__main__':
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TCPTransport))
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMBTransport64))
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TCPTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_even.py
+++ b/tests/SMB_RPC/test_even.py
@@ -255,4 +255,4 @@ if __name__ == '__main__':
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(SMBTransport)
         #suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMBTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_even6.py
+++ b/tests/SMB_RPC/test_even6.py
@@ -166,4 +166,4 @@ if __name__ == '__main__':
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(TCPTransport)
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TCPTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_fasp.py
+++ b/tests/SMB_RPC/test_fasp.py
@@ -102,4 +102,4 @@ if __name__ == '__main__':
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(TCPTransport)
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TCPTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_ldap.py
+++ b/tests/SMB_RPC/test_ldap.py
@@ -147,4 +147,4 @@ if __name__ == '__main__':
         suite = unittest.TestLoader().loadTestsFromTestCase(globals()[testcase])
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(TCPTransport)
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_lsad.py
+++ b/tests/SMB_RPC/test_lsad.py
@@ -1060,4 +1060,4 @@ if __name__ == '__main__':
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(SMBTransport)
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMBTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_lsat.py
+++ b/tests/SMB_RPC/test_lsat.py
@@ -366,4 +366,4 @@ if __name__ == '__main__':
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(SMBTransport)
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMBTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_mgmt.py
+++ b/tests/SMB_RPC/test_mgmt.py
@@ -185,4 +185,4 @@ if __name__ == '__main__':
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TCPTransport))
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMBTransport64))
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TCPTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_mimilib.py
+++ b/tests/SMB_RPC/test_mimilib.py
@@ -120,4 +120,4 @@ if __name__ == '__main__':
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(TCPTransport)
         #suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMBTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_ndr.py
+++ b/tests/SMB_RPC/test_ndr.py
@@ -388,4 +388,4 @@ if __name__ == '__main__':
         suite = unittest.TestLoader().loadTestsFromTestCase(globals()[testcase])
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(NDRTests)
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_nmb.py
+++ b/tests/SMB_RPC/test_nmb.py
@@ -81,4 +81,4 @@ class NetBIOSTests(NMBTests):
 
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(NetBIOSTests)
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_nrpc.py
+++ b/tests/SMB_RPC/test_nrpc.py
@@ -1086,4 +1086,4 @@ if __name__ == '__main__':
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(SMBTransport)
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TCPTransport))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_ntlm.py
+++ b/tests/SMB_RPC/test_ntlm.py
@@ -339,4 +339,4 @@ if __name__ == '__main__':
         suite = unittest.TestLoader().loadTestsFromTestCase(globals()[testcase])
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(NTLMTests)
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_rpch.py
+++ b/tests/SMB_RPC/test_rpch.py
@@ -296,4 +296,4 @@ if __name__ == '__main__':
         suite = unittest.TestLoader().loadTestsFromTestCase(globals()[testcase])
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(RPCHTransport)
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_rpcrt.py
+++ b/tests/SMB_RPC/test_rpcrt.py
@@ -440,4 +440,4 @@ if __name__ == "__main__":
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(TCPTransport)
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMBTransport))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_rprn.py
+++ b/tests/SMB_RPC/test_rprn.py
@@ -236,4 +236,4 @@ if __name__ == '__main__':
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(SMBTransport)
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMBTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_rrp.py
+++ b/tests/SMB_RPC/test_rrp.py
@@ -787,4 +787,4 @@ if __name__ == '__main__':
         suite = unittest.TestLoader().loadTestsFromTestCase(SMBTransport)
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMBTransport64))
         #suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TCPTransport))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_samr.py
+++ b/tests/SMB_RPC/test_samr.py
@@ -2908,4 +2908,4 @@ if __name__ == '__main__':
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TCPTransport))
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMBTransport64))
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TCPTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_scmr.py
+++ b/tests/SMB_RPC/test_scmr.py
@@ -692,4 +692,4 @@ if __name__ == '__main__':
         suite = unittest.TestLoader().loadTestsFromTestCase(SMBTransport)
         #suite = unittest.TestLoader().loadTestsFromTestCase(TCPTransport)
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TCPTransport))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_secretsdump.py
+++ b/tests/SMB_RPC/test_secretsdump.py
@@ -304,4 +304,4 @@ class Tests(SecretsDumpTests):
 
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(Tests)
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_smb.py
+++ b/tests/SMB_RPC/test_smb.py
@@ -405,4 +405,4 @@ if __name__ == "__main__":
     suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMB002Tests))
     suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMB21Tests))
     suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMB3Tests))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_smbserver.py
+++ b/tests/SMB_RPC/test_smbserver.py
@@ -206,4 +206,4 @@ if __name__ == "__main__":
     suite = unittest.TestSuite()
     suite.addTests(loader.loadTestsFromTestCase(SMBServerUnitTests))
     suite.addTests(loader.loadTestsFromTestCase(SimpleSMBServerFuncTests))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_srvs.py
+++ b/tests/SMB_RPC/test_srvs.py
@@ -1180,4 +1180,4 @@ if __name__ == '__main__':
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(SMBTransport)
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMBTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_tsch.py
+++ b/tests/SMB_RPC/test_tsch.py
@@ -1073,4 +1073,4 @@ if __name__ == '__main__':
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(SMBTransport)
         #suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMBTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_wkst.py
+++ b/tests/SMB_RPC/test_wkst.py
@@ -620,4 +620,4 @@ if __name__ == '__main__':
     else:
         suite = unittest.TestLoader().loadTestsFromTestCase(SMBTransport)
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(SMBTransport64))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_wmi.py
+++ b/tests/SMB_RPC/test_wmi.py
@@ -238,7 +238,7 @@ class TCPTransport64(WMITests):
 class OfflineTests(unittest.TestCase):
     def assertIWbemClassObjectAttr(self, _object, attribute_name, expected_value):
         actual_value = getattr(_object, attribute_name)
-        self.assertEqual(actual_value, expected_value, '{}.{} is {!r}, but was expecting {!r}'.format(
+        self.assertEqual(expected_value, actual_value, '{}.{} is {!r}, but was expecting {!r}'.format(
             _object.getClassName(), attribute_name, actual_value, expected_value
         ))
 
@@ -252,9 +252,9 @@ class OfflineTests(unittest.TestCase):
 
         The following lines were added in the impacket.dcerpc.v5.dcomrt.INTERFACE class constructor:
         https://github.com/SecureAuthCorp/impacket/blob/impacket_0_9_22/impacket/dcerpc/v5/dcomrt.py#L1111-L1112
-        >>> if objRef and b'Win32_CurrentTime' in objRef:
-        >>>     import base64, textwrap, zlib
-        >>>     print('\n'.join(textwrap.wrap(base64.b64encode(zlib.compress(objRef)), 96)))
+        if objRef and b'Win32_CurrentTime' in objRef:
+            import base64, textwrap, zlib
+            print('\n'.join(textwrap.wrap(base64.b64encode(zlib.compress(objRef)), 96)))
 
         Target's time had previously been set to 00:00 UTC
         """

--- a/tests/SMB_RPC/test_wmi.py
+++ b/tests/SMB_RPC/test_wmi.py
@@ -289,4 +289,4 @@ if __name__ == '__main__':
         suite = unittest.TestLoader().loadTestsFromTestCase(TCPTransport)
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(TCPTransport64))
         suite.addTests(unittest.TestLoader().loadTestsFromTestCase(OfflineTests))
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/SMB_RPC/test_wmi.py
+++ b/tests/SMB_RPC/test_wmi.py
@@ -236,6 +236,12 @@ class TCPTransport64(WMITests):
 
 
 class OfflineTests(unittest.TestCase):
+    @staticmethod
+    def createIWbemClassObject(b64_compressed_obj_ref):
+        obj_ref = zlib.decompress(base64.b64decode(b64_compressed_obj_ref))
+        interface = wmi.INTERFACE(objRef=obj_ref, target='')
+        return wmi.IWbemClassObject(interface, interface)  # Use the same interface as a iWbemServices mock
+
     def assertIWbemClassObjectAttr(self, _object, attribute_name, expected_value):
         actual_value = getattr(_object, attribute_name)
         self.assertEqual(expected_value, actual_value, '{}.{} is {!r}, but was expecting {!r}'.format(
@@ -258,15 +264,14 @@ class OfflineTests(unittest.TestCase):
 
         Target's time had previously been set to 00:00 UTC
         """
-        current_time_obj_ref = zlib.decompress(base64.b64decode('''
+        current_time_obj = self.createIWbemClassObject('''
         eJzNks8vA0EUx7/bVutXQotEQkPSJg4Sh1YcnCTVhFC/WopIpKmhGzWbbHeFOCAcSBzEwR/g4ODmJP4CN5x6EiccHcWNN7Ok
         I/bg6CWfnTcvn7d5szup5HjWB2D3PPSwXboLHqRwgZGeaOj9ONkfvg8edjh7UlD2AhszvaFbWv1IJ2eSY7N9vYBpGNZCXl9b
         j6HghRPdRJtIsjqPxxYTtmkybmX0NYYmqnYRAWBHq6Pk48NPKaopbSAiRNyp19KzR2yJeYIRR8QJcU3cEK/EGxHWgCgxQmSI
         LWKPuCCuiEfiSRNv/XOcemgs5wDTmYQc3tkmikZ+dcI01vUlZgJpna8UmWVwYDC3iaYBwCOPIyJI0Dl2IqIwJSq2zq14TLrj
         y1nGVmWHF/VuHftqx5Bhm1L2o9VNvlTllF4s6iWWN/hSSTbVIOrW9PKzidsWk3oA7W56i6bqBrcK0tbgc7MTqj1p50yLOSeo
         QrObX1L9tBxe6tXodNPPVF18ymFeGcmHRreestozx3LOPJX4IXs9ivx/YrSS1j8HxH2AvHAehe+IfK3i/2gN+H2lgU8VG67O
-        '''))
-        current_time_obj = wmi.IWbemClassObject(wmi.INTERFACE(objRef=current_time_obj_ref, target=''))
+        ''')
         self.assertIWbemClassObjectAttr(current_time_obj, 'Year', 2021)
         self.assertIWbemClassObjectAttr(current_time_obj, 'Month', 6)
         self.assertIWbemClassObjectAttr(current_time_obj, 'Day', 8)
@@ -277,6 +282,95 @@ class OfflineTests(unittest.TestCase):
         # According to the Win32_CurrentTime class documentation, the Milliseconds property is not returned / used, the
         # PowerShell "gwmi win32_currenttime" command output shows it empty indicating it is $null, so it should be None
         self.assertIWbemClassObjectAttr(current_time_obj, 'Milliseconds', None)
+
+    def test_wmi_persist_classes_parsing(self):
+        """
+        Parse several objects created thorough SpawnInstance in wmipersist.py
+
+        The data was obtained by running the following command while patching IWbemClassObject.SpawnInstance():
+        wmipersist.py username:password@x.x.x.x -debug install -name ASEC -timer 1000 -vbs toexec.vbs
+
+        The following lines were added in the impacket.dcerpc.v5.dcom.wmi.IWbemClassObject.SpawnInstance():
+        https://github.com/SecureAuthCorp/impacket/blob/impacket_0_9_22/impacket/dcerpc/v5/dcom/wmi.py#L2557
+        import base64, textwrap, zlib
+        print('\n'.join(textwrap.wrap(base64.b64encode(zlib.compress(objRefCustomIn.getData())), 96)))
+        """
+
+        # NOTE: I think these shouldn't be strings, see impacket.dcerpc.v5.dcom.wmi.ENCODED_VALUE.getValue() and
+        # impacket.dcerpc.v5.dcom.wmi.CLASS_PART.getProperties() (links below). I won't change that code since I
+        # don't know the potential splash damage. If you've changed it and found yourself trying to figure out why
+        # does this test fail, just delete this comment, remove string quotes, and inline the following variables
+        # https://github.com/SecureAuthCorp/impacket/blob/impacket_0_9_22/impacket/dcerpc/v5/dcom/wmi.py#L341-L344
+        # https://github.com/SecureAuthCorp/impacket/blob/impacket_0_9_22/impacket/dcerpc/v5/dcom/wmi.py#L568-L569
+        default_creator_sid = '[1, 1, 0, 0, 0, 0, 0, 5, 18, 0, 0, 0]'
+        false = 'False'
+
+        # ActiveScriptEventConsumer - https://docs.microsoft.com/en-us/windows/win32/wmisdk/activescripteventconsumer
+        asec_obj = self.createIWbemClassObject('''
+        eJy1k89r1EAUx7/Z7db6AzS7FpRaq1bpSQuuoHhSdrNLKetis1gKwpqmwzqQTCSZKVsvxpvevIlexIsH8eS/4UHBqxcPIp68
+        6qm+mezWrARvHfgwM2/yvu87L0nH6a5PAXj8pvrlUfLRftLBW6xeOl/99cy5Pv/JfrqQ7ekR/CgDwztXql9pnkaz1W623Lbb
+        bDvAWrfbu5uozcSP+QPJI4FBGdk4Rzh60e8720zIRiQSFbIYdhZcEVvc93TOGgs8ybYwmx24O4lkYSPwkgRHKaKfn9NHWvkg
+        mZ6heZFYJu4RIfGKeEd8Jr4RSxZwkegTEfGaeE/8Jiolis3ujsZV2u3+M3S1lyWkuOlLvs1cc7vJWyCIfC9gQCNmnoxid6UJ
+        m9yUjD3SxCniEJAu6sBG5j+tH4YuB8WFvAas8iDo8ZBFSqJGJwdMVjmXXdbZzwm6eIpcdv0y0PH8+1ywW17IMHNj1HhT3M4X
+        /6CjiYy5GOicIQ9VeFsxxVz+kKFGiZaWN4mn84k2deskUdebM7TYq6wElwmwuSMZTZkB4/xIkf91S5dAWhv5H3vJGtviARNj
+        hWmcKFJ4YU12YFKBlo4YUCeMxBSOjSSW8hLfSeKnvkMmUaQmItkXKgjGuj02lEayguNFrpZLha50DyzLvItKFfsyNv4u53Lh
+        eWKBOIvsF4FpB7m5gP9/zXvjDwGExJk=
+        ''')
+        self.assertIWbemClassObjectAttr(asec_obj, 'CreatorSID', default_creator_sid)  # see comments on variable
+        self.assertIWbemClassObjectAttr(asec_obj, 'KillTimeout', 0)
+        self.assertIWbemClassObjectAttr(asec_obj, 'MachineName', '')
+        self.assertIWbemClassObjectAttr(asec_obj, 'MaximumQueueSize', 0)
+        self.assertIWbemClassObjectAttr(asec_obj, 'Name', '')
+        self.assertIWbemClassObjectAttr(asec_obj, 'ScriptingEngine', '')
+        self.assertIWbemClassObjectAttr(asec_obj, 'ScriptFilename', '')
+        self.assertIWbemClassObjectAttr(asec_obj, 'ScriptText', '')
+
+        # __IntervalTimerInstruction - https://docs.microsoft.com/en-us/windows/win32/wmisdk/--intervaltimerinstruction
+        iti_obj = self.createIWbemClassObject('''
+        eJy9UbFOAkEQfYAxRBINh1aiFtrYWIiVNkY5LsQQDEe0MZLjWM3isUdu91ATEzE22ukX2Fn4EbaW8gF+iLHBWQ6vsbBzkrc3
+        Ozv79r25ilk9nABw82x8XMv37F0FL9hbWzE+H8zNhUH2finaUwuCJHBxsGG06TuJYskqlmzLLlomUKtW60cybEo34F3FfYHp
+        JKLIEI510mjUeYcFZSFVELqjptmobvaYUBYTLHCUH8CIqmXR4q6j+2rMcxRrYS46sC+lYp1dz5ESM1TR+lOEPKFAeCQ8Ed4I
+        A8L8kALQq0qgP6JWLOg53i9B+DnZYeqcMTFSJpEjliR5jt5aJUwB/VSakrYeDCGnfQ6HVzrV9VutNeRCFdYB4auGCD2PKoIT
+        Hzrc87hkri9atLPPeLd8sk9+yGRmG0jEnrLjt5Y156vmbPq+xxySGolvIb09nnQ8hPjCFzQX+oVIHMgoF6f4/9iKs3ycaYuJ
+        RfzxQ/AN/wuDfg==
+        ''')
+        self.assertIWbemClassObjectAttr(iti_obj, 'IntervalBetweenEvents', 0)
+        self.assertIWbemClassObjectAttr(iti_obj, 'SkipIfPassed', false)  # see comments on variable
+        self.assertIWbemClassObjectAttr(iti_obj, 'TimerId', '')
+
+        # __EventFilter - https://docs.microsoft.com/en-us/windows/win32/wmisdk/--eventfilter
+        ef_obj = self.createIWbemClassObject('''
+        eJydkr9Lw0AUx1/6C1GhJrWIP4oOjlIcHMRNmrSUtpY2oghCONOjBGpachdpJ3XTrYObzg4ujk7+DfoHuDs6KW71XRJtaDv5
+        4JN7d/e+975HrqJVD2MAcHmvvJ2zF/mqAg9Qyq4r331tJ/MqX6/6cyyBuwhA92BLucExAWq+oOb1gq4WNIB6tbp/zNwTZjpW
+        h1ttG7IR8GMJ2RSJYRTthmUSsV2nLcJpA9L+ht5jnJ7mWoQxSOKKcJRARL6MlJEj5ALpI0/IM/KBfCEZCWADqX0OMHTMBiNx
+        K6HYMLQzavO81eLUAcg5lPC2oxdVkNcAJK+tsL2CTGO36BQmeDuI4iQ1A+JYcC2bb+OyOGnXNClaFmVxmA/UcljdFRdk3LHs
+        ZqDZI6eUdYhJPVkM5ibJHsMyofCK/Rhz+A7C/NDhr67mUqfnCaMwO6lLWgp18arLxG66pOm3iwTfEVUppBLHSpJnK67A/0Mb
+        pslgFD1TwiSyAP6bkBZh/Df+xQ8W2n+V
+        ''')
+        self.assertIWbemClassObjectAttr(ef_obj, 'CreatorSID', None)
+        self.assertIWbemClassObjectAttr(ef_obj, 'EventAccess', '')
+        self.assertIWbemClassObjectAttr(ef_obj, 'EventNamespace', '')
+        self.assertIWbemClassObjectAttr(ef_obj, 'Name', '')
+        self.assertIWbemClassObjectAttr(ef_obj, 'Query', '')
+        self.assertIWbemClassObjectAttr(ef_obj, 'QueryLanguage', '')
+
+        # __FilterToConsumerBinding - https://docs.microsoft.com/en-us/windows/win32/wmisdk/--filtertoconsumerbinding
+        ftcb_obj = self.createIWbemClassObject('''
+        eJydks9rE0EUx79pqi22VLOlINhSDx68KOIPKIUWNJuEUEO0G/RSWLabaR2YzrQzs2lXEONNb0L/BwUPHnr14sGz+gd48q5H
+        9Rbf7MY00OjBB5/Z2Z33vvPe29eoNB+OA3j2yvvy1HwqPW/gDdauXvJ+vawsL3wuvVjM38kFrSJw8OCmd5eep+FXa341qAV+
+        rQKsN5utDZNsmljzXcuVxNcx5HaeuOY2YViXbR5H7nidiciyNubygyA1lu2URWQMztIXxwVidoqWXm+C1svEdWKPeEK8JT4Q
+        hQIwQ9wiVojHxCHxjvhIzL3vDVme0g/6vjqGLt1c5cIy3VJlJU2yw/QdTjnKbeC2MSrmWbLAn1NsuRvhGubKmyfOAN3iJG02
+        siN0+zlDs63lMKx0mLSDcJQ1i6zSQd1H6aLrojdK6jVRHJJKuLRLgM8E7zAdpDJ+pJVUiREppjLf6VEy34mfx13EplKCRVSO
+        VDaUiRADyfS+CjCbaUz2lUrDSleosCyLG/QL8pZlrcjtxMXbhb+2oh+MRkRqRMDiRHObUossO7BZOeOYGZXEkUtiUEMg1L6v
+        9uU9rTq8zbTJQk/h3KjQb8Oh0/2pce4e/t/qx1s3qwsnHNyYFBbx7zkj+w1KorBh
+        ''')
+        self.assertIWbemClassObjectAttr(ftcb_obj, 'Consumer', '')
+        self.assertIWbemClassObjectAttr(ftcb_obj, 'CreatorSID', None)
+        self.assertIWbemClassObjectAttr(ftcb_obj, 'DeliverSynchronously', false)  # see comments on variable
+        self.assertIWbemClassObjectAttr(ftcb_obj, 'DeliveryQoS', 0)
+        self.assertIWbemClassObjectAttr(ftcb_obj, 'Filter', '')
+        self.assertIWbemClassObjectAttr(ftcb_obj, 'MaintainSecurityContext', false)  # see comments on variable
+        self.assertIWbemClassObjectAttr(ftcb_obj, 'SlowDownProviders', false)  # see comments on variable
 
 
 # Process command-line arguments.

--- a/tests/dot11/test_Dot11Base.py
+++ b/tests/dot11/test_Dot11Base.py
@@ -102,4 +102,4 @@ class TestDot11Common(unittest.TestCase):
     
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11Common)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_Dot11Decoder.py
+++ b/tests/dot11/test_Dot11Decoder.py
@@ -70,4 +70,4 @@ class TestDot11Decoder(unittest.TestCase):
         self.assertTrue(str(dataclass).find('ImpactPacket.Data') > 0)
       
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11Decoder)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_Dot11HierarchicalUpdate.py
+++ b/tests/dot11/test_Dot11HierarchicalUpdate.py
@@ -127,4 +127,4 @@ class TestDot11HierarchicalUpdate(unittest.TestCase):
         self.assertEqual(self.packet3.body.get_buffer_as_string(), b"Header2Header1**NewBody**Tail1Tail2")
         
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11HierarchicalUpdate)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameControlACK.py
+++ b/tests/dot11/test_FrameControlACK.py
@@ -50,4 +50,4 @@ class TestDot11FrameControlACK(unittest.TestCase):
         self.assertEqual(self.ack.get_ra().tolist(), [0x12,0x08,0x54,0xac,0x2f,0x34])
        
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11FrameControlACK)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameControlCFEnd.py
+++ b/tests/dot11/test_FrameControlCFEnd.py
@@ -60,4 +60,4 @@ class TestDot11FrameControlCFEnd(unittest.TestCase):
         self.assertEqual(self.cfend.get_bssid().tolist(), [0x12,0x19,0xe0,0x98,0x04,0x34])
       
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11FrameControlCFEnd)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameControlCFEndCFACK.py
+++ b/tests/dot11/test_FrameControlCFEndCFACK.py
@@ -60,4 +60,4 @@ class TestDot11FrameControlCFEndCFACK(unittest.TestCase):
         self.assertEqual(self.cfendcfack.get_bssid().tolist(), [0x12,0xae,0x0f,0xb0,0xd9,0x34])
       
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11FrameControlCFEndCFACK)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameControlCTS.py
+++ b/tests/dot11/test_FrameControlCTS.py
@@ -51,4 +51,4 @@ class TestDot11FrameControlCTS(unittest.TestCase):
         self.assertEqual(self.cts.get_ra().tolist(), [0x12,0x19,0xe0,0x98,0x04,0x34])
       
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11FrameControlCTS)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameControlPSPoll.py
+++ b/tests/dot11/test_FrameControlPSPoll.py
@@ -60,4 +60,4 @@ class TestDot11FrameControlPSPoll(unittest.TestCase):
         self.assertEqual(self.pspoll.get_ta().tolist(), [0x12,0xbe,0xe5,0x05,0x4c,0x34])
      
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11FrameControlPSPoll)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameControlRTS.py
+++ b/tests/dot11/test_FrameControlRTS.py
@@ -60,4 +60,4 @@ class TestDot11FrameControlRTS(unittest.TestCase):
         self.assertEqual(self.rts.get_ta().tolist(), [0x12,0x23,0x4d,0x09,0x86,0x34])
       
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11FrameControlRTS)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameData.py
+++ b/tests/dot11/test_FrameData.py
@@ -98,4 +98,4 @@ class TestDot11DataFrames(unittest.TestCase):
         self.assertEqual(self.data.get_frame_body(), frame_body)
       
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11DataFrames)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameManagement.py
+++ b/tests/dot11/test_FrameManagement.py
@@ -181,4 +181,4 @@ class TestDot11ManagementBeaconFrames(unittest.TestCase):
         self.assertEqual(self.management_beacon.get_header_size(), 127)
         
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11ManagementBeaconFrames)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameManagementAssociationRequest.py
+++ b/tests/dot11/test_FrameManagementAssociationRequest.py
@@ -178,4 +178,4 @@ class TestDot11ManagementAssociationRequestFrames(unittest.TestCase):
         self.assertEqual(self.management_association_request.get_header_size(), 68+11)
         
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11ManagementAssociationRequestFrames)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameManagementAssociationResponse.py
+++ b/tests/dot11/test_FrameManagementAssociationResponse.py
@@ -162,4 +162,4 @@ class TestDot11ManagementAssociationResponseFrames(unittest.TestCase):
         self.assertEqual(self.management_association_response.get_header_size(), 33+11)
         
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11ManagementAssociationResponseFrames)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameManagementAuthentication.py
+++ b/tests/dot11/test_FrameManagementAuthentication.py
@@ -150,4 +150,4 @@ class TestDot11ManagementAuthenticationFrames(unittest.TestCase):
         self.assertEqual(self.management_authentication.get_header_size(), 28)
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11ManagementAuthenticationFrames)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameManagementDeauthentication.py
+++ b/tests/dot11/test_FrameManagementDeauthentication.py
@@ -127,4 +127,4 @@ class TestDot11ManagementBeaconFrames(unittest.TestCase):
         self.assertEqual(self.management_deauthentication.get_reason_code(), 0x8765)
         
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11ManagementBeaconFrames)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameManagementDisassociation.py
+++ b/tests/dot11/test_FrameManagementDisassociation.py
@@ -127,4 +127,4 @@ class TestDot11ManagementDisassociationFrames(unittest.TestCase):
         self.assertEqual(self.management_disassociation.get_reason_code(), 0x8765)
         
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11ManagementDisassociationFrames)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameManagementProbeRequest.py
+++ b/tests/dot11/test_FrameManagementProbeRequest.py
@@ -139,4 +139,4 @@ class TestDot11ManagementProbeRequestFrames(unittest.TestCase):
         self.assertEqual(self.management_probe_request.get_header_size(), 23-2)
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11ManagementProbeRequestFrames)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameManagementProbeResponse.py
+++ b/tests/dot11/test_FrameManagementProbeResponse.py
@@ -188,4 +188,4 @@ class TestDot11ManagementProbeResponseFrames(unittest.TestCase):
         self.assertEqual(self.management_probe_response.get_header_size(), 209+6+3+2)
         
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11ManagementProbeResponseFrames)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameManagementReassociationRequest.py
+++ b/tests/dot11/test_FrameManagementReassociationRequest.py
@@ -183,4 +183,4 @@ class TestDot11ManagementReassociationRequestFrames(unittest.TestCase):
         self.assertEqual(self.management_reassociation_request.get_header_size(), 74+11)
         
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11ManagementReassociationRequestFrames)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_FrameManagementReassociationResponse.py
+++ b/tests/dot11/test_FrameManagementReassociationResponse.py
@@ -162,4 +162,4 @@ class TestDot11ManagementReassociationResponseFrames(unittest.TestCase):
         self.assertEqual(self.management_reassociation_response.get_header_size(), 33+11)
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11ManagementReassociationResponseFrames)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_RadioTap.py
+++ b/tests/dot11/test_RadioTap.py
@@ -578,4 +578,4 @@ class TestRadioTap(unittest.TestCase):
 
 if __name__ == "__main__":
     suite = unittest.TestLoader().loadTestsFromTestCase(TestRadioTap)
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/dot11/test_RadioTapDecoder.py
+++ b/tests/dot11/test_RadioTapDecoder.py
@@ -107,4 +107,4 @@ class TestRadioTapDecoder(unittest.TestCase):
         self.assertEqual(p, None)
       
 suite = unittest.TestLoader().loadTestsFromTestCase(TestRadioTapDecoder)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_WEPDecoder.py
+++ b/tests/dot11/test_WEPDecoder.py
@@ -139,4 +139,4 @@ class TestDot11WEPData(unittest.TestCase):
         self.assertEqual(icmp.get_icmp_id(),0x0400)
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11WEPData)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_WEPEncoder.py
+++ b/tests/dot11/test_WEPEncoder.py
@@ -120,4 +120,4 @@ class TestDot11WEPData(unittest.TestCase):
         #print "\nDot11 encrypted [%s]"%hexlify(self.dot11.get_packet())
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11WEPData)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_WPA.py
+++ b/tests/dot11/test_WPA.py
@@ -110,4 +110,4 @@ class TestDot11WPAData(unittest.TestCase):
         self.assertEqual(self.wpa_data.get_icv(), 0x8edb7b9e)
         
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11WPAData)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_WPA2.py
+++ b/tests/dot11/test_WPA2.py
@@ -95,4 +95,4 @@ class TestDot11WPA2Data(unittest.TestCase):
         self.assertEqual(self.wpa2_data.get_MIC(), mic)
         
 suite = unittest.TestLoader().loadTestsFromTestCase(TestDot11WPA2Data)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_helper.py
+++ b/tests/dot11/test_helper.py
@@ -54,4 +54,4 @@ class TestHelpers(unittest.TestCase):
         
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestHelpers)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/dot11/test_wps.py
+++ b/tests/dot11/test_wps.py
@@ -53,4 +53,4 @@ class TestTLVContainer(unittest.TestCase):
         self.assertEquals(b"Sarlanga", tlvc.first(1))
 
 suite = unittest.TestLoader().loadTestsFromTestCase(TestTLVContainer)
-unittest.TextTestRunner(verbosity=1).run(suite)
+unittest.main(defaultTest='suite')

--- a/tests/misc/test_dpapi.py
+++ b/tests/misc/test_dpapi.py
@@ -203,4 +203,4 @@ class DPAPITests(unittest.TestCase):
 # Process command-line arguments.
 if __name__ == '__main__':
     suite = unittest.TestLoader().loadTestsFromTestCase(DPAPITests)
-    unittest.TextTestRunner(verbosity=1).run(suite)
+    unittest.main(defaultTest='suite')

--- a/tests/runall.sh
+++ b/tests/runall.sh
@@ -44,6 +44,8 @@ echo test_ntlm.py
 $RUN test_ntlm.py 2>&1 1>/dev/null | tee -a $OUTPUTFILE
 echo test_smbserver.py
 $RUN test_smbserver.py 2>&1 1>/dev/null | tee -a $OUTPUTFILE
+echo test_wmi.py OfflineTests
+$RUN test_wmi.py OfflineTests 2>&1 1>/dev/null | tee -a $OUTPUTFILE
 
 if [ -z "$NO_REMOTE" ]; then
     echo Testing SMB RPC/LDAP


### PR DESCRIPTION
This is a followup from what I've learned while debugging the issue described in #1069 (and a couple subsequent ones).

This PR includes several changes related with the parsing of WMI objects, I think they are all related, but if you prefer it to be split, just let me know. In the next sections I'll describe the functional changes I made. Along with them, I've also made some minor refactorings and/or renamings to better reflect my understanding of the [NdTable](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-wmio/65bcd0c2-b3f3-49a7-b4aa-c972cdc0774b) flags and make them clear through the code.

# Complete fix for `wmipersist.py`
At least in my tested targets, #1069 changes are enough to prevent `wmipersist.py` from failing with a `WBEM_E_INVALID_OBJECT` error, but not to make it work. The script is able to create the *timer event* &rarr; *event filter* &rarr; *VBA script event consumer* objects in the remote WMI database, but the *VBA script* is never executed. This depends on a single bit, which doesn't seem to be noticed while querying the target's WMI database with `wmic.exe` or *PowerShell*'s `Get-WmiObject`, you can find the complete explanation in https://github.com/SecureAuthCorp/impacket/pull/1069#issuecomment-835179409.

This PR fixes this in f1896d227994fa49fef9ecf45146fb8a929ed400, by following the aforementioned comment proposal (which also provides an alternative tailored workaround, just for `wmipersist.py`). On the way, I found another issue whose fix made #1069 workaround unnecessary, so I removed it in a9e7b647b2d5322ad00a337574eb25663f6b5b9e, see the next section.

Finally, 2546e4527aca91b1b9da18e514b2668101f8a55b improves `wmipersist.py` error parsing, as suggested in https://github.com/SecureAuthCorp/impacket/pull/1069#issuecomment-831453941.

# Fix WMI objects parsing by not interpreting zero properties as `None`
As already mentioned, I also faced a new issue, in which properties with zero integer values were being parsed as *unset* / `$null` / `None`. This can be reproduced with `wmiquery.py`, by following the steps provided in the [1<sup>st</sup> comment](#issuecomment-856435347).

This got fixed by parsing the `NdTable` in b1499ae82242be2002dd2790ab5691c27c6c5962, bc57bf7404a5821efc82887d0bed083c52f9b4d0 & e82af931328ddd0daa7998f0a3f4138d6f404c38, where I've struggled a little before making it work in all my known scenarios (those exercised through *Core Impact* testcase suites, plus the tests I've added to *Impacket*'s CI system).

# New offline testcases parsing some WMI objects
I've found that some concepts aren't fully clear in the [MS-WMIO] documentation, and that through the time, incoming PRs and internal changes have partially broken `impacket.dcerpc.v5.dcom.wmi` code, while trying to extend it for newer usage cases.

The best way to ensure that new functionality doesn't break existing one is to have tests included in the CI system, so GitHub rapidly notifies developers anytime they introduce a breaking change. Also, maintainers aren't likely to accept a PR with that ugly red cross!

So I've introduced a small test suite that currently parses offline date for the following WMI objects:
* [`Win32_CurrentTime`](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/wmitimepprov/win32-currenttime)
* [`ActiveScriptEventConsumer`](https://docs.microsoft.com/en-us/windows/win32/wmisdk/activescripteventconsumer)
* [`__IntervalTimerInstruction`](https://docs.microsoft.com/en-us/windows/win32/wmisdk/--intervaltimerinstruction)
* [`__EventFilter`](https://docs.microsoft.com/en-us/windows/win32/wmisdk/--eventfilter)
* [`__FilterToConsumerBinding`](https://docs.microsoft.com/en-us/windows/win32/wmisdk/--filtertoconsumerbinding)

The object data was captured while executing *Impacket* examples with slightly patched code against actual target machines. Every test documents the capture procedure in its *docstring*, providing guidance for new tests implementers.

Tests were added to `tests/SMB_RPC/test_wmi.py` as a new `OfflineTests` class, which is also executed in the CI system (see b68c35dced8ec4db5b54e893258bd23c72844ef4).

# Report failed testcases as failed GitHub actions
As explained in the [2<sup>nd</sup> comment](#issuecomment-857975974) of this PR, due to an unhandled error in the tests, I've discovered how to fix this, and did it in f5dab5ca76b60b9436f18d1ba5fd48abfa3626e1. This finally makes the previously mentioned red cross appear when an expected result isn't matched by a test.