### PR TITLE
addcomputer.py: Enable the machine account created via SAMR.

### DIFF
--- a/examples/addcomputer.py
+++ b/examples/addcomputer.py
@@ -17,6 +17,9 @@
 # Reference for:
 #     SMB, SAMR, LDAP
 #
+#  ToDo:
+# [ ]: Complete the process of joining a client computer to a domain via the SAMR protocol
+
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
@@ -528,6 +531,14 @@ class ADDCOMPUTER:
                 if self.__noAdd:
                     logging.info("Successfully set password of %s to %s." % (self.__computerName, self.__computerPassword))
                 else:
+                    checkForUser = samr.hSamrLookupNamesInDomain(dce, domainHandle, [self.__computerName])
+                    userRID = checkForUser['RelativeIds']['Element'][0]
+                    openUser = samr.hSamrOpenUser(dce, domainHandle, samr.MAXIMUM_ALLOWED, userRID)
+                    userHandle = openUser['UserHandle']
+                    req = samr.SAMPR_USER_INFO_BUFFER()
+                    req['tag'] = samr.USER_INFORMATION_CLASS.UserControlInformation
+                    req['Control']['UserAccountControl'] = samr.USER_WORKSTATION_TRUST_ACCOUNT
+                    samr.hSamrSetInformationUser2(dce, userHandle, req)
                     logging.info("Successfully added machine account %s with password %s." % (self.__computerName, self.__computerPassword))
 
         except Exception as e:


### PR DESCRIPTION
After adding a computer over SMB, the machine account is created but is disabled by default.  
This PR:
- Enables the machine account using the SamrSetInformationUser2 method as detailed in [[MS-SAMR] Section 4.2](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/bf8cfb76-24f7-42de-a95f-e5b9ec7435d0).

It fixes https://github.com/SecureAuthCorp/impacket/pull/667#issuecomment-557270362