### PR TITLE
Modify search filter for stealth kerberoasting

### DIFF
--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -282,13 +282,11 @@ class GetUserSPNs:
                 raise
 
         # Building the search filter
-        searchFilter = "(&(servicePrincipalName=*)(UserAccountControl:1.2.840.113556.1.4.803:=512)" \
-                       "(!(UserAccountControl:1.2.840.113556.1.4.803:=2))(!(objectCategory=computer))"
-
         if self.__requestUser is not None:
-            searchFilter += '(sAMAccountName:=%s))' % self.__requestUser
+            searchFilter = '(sAMAccountName:=%s)' % self.__requestUser
         else:
-            searchFilter += ')'
+            searchFilter = "(&(servicePrincipalName=*)(UserAccountControl:1.2.840.113556.1.4.803:=512)" \
+               "(!(UserAccountControl:1.2.840.113556.1.4.803:=2))(!(objectCategory=computer)))" 
 
         try:
             resp = ldapConnection.search(searchFilter=searchFilter,


### PR DESCRIPTION
Some monitoring systems as [Defender for Identity](https://techcommunity.microsoft.com/t5/security-compliance-and-identity/detecting-ldap-based-kerberoasting-with-azure-atp/ba-p/462448) could detect ldap recognition for kerberoasting with filter ` (servicePrincipalName=*)`

The stealth way is collecting the information without that filter and then searching for targets offline.

If only one TGS is going to be requested I think it is not needed to ensure that the user has an associated SPN, since it is assumed that it has been done previously.