### PR TITLE
Added 'mget' to smbclient.py 

### DIFF
--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -1,4 +1,4 @@
-# SECUREAUTH LABS. Copyright 2018 SecureAuth Corporation. All rights reserved.
+# SECUREAUTH LABS. Copyright 2021 SecureAuth Corporation. All rights reserved.
 #
 # This software is provided under under a slightly modified version
 # of the Apache Software License. See the accompanying LICENSE file

--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -114,6 +114,7 @@ class MiniImpacketShell(cmd.Cmd):
  rmdir {dirname} - removes the directory under the current path
  put {filename} - uploads the filename into the current path
  get {filename} - downloads the filename from the current path
+ mget {mask} - downloads all files from the current directory matching the provided mask
  cat {filename} - reads the filename from the current path
  mount {target,path} - creates a mount point from {path} to {target} (admin required)
  umount {path} - removes the mount point at {path} without deleting the directory (admin required)
@@ -448,6 +449,28 @@ class MiniImpacketShell(cmd.Cmd):
                 ]
             else:
                 return items
+
+    def do_mget(self, mask):
+        if self.tid is None:
+            LOG.error("No share selected")
+            return
+        self.do_ls(mask,display=False)
+        if len(self.completion) == 0:
+            LOG.error("No files found matching the provided mask")
+            return 
+        for file_tuple in self.completion:
+            filename = file_tuple[0]
+            filename = filename.replace('/','\\')
+            fh = open(ntpath.basename(filename),'wb')
+            pathname = ntpath.join(self.pwd,filename)
+            try:
+                LOG.info("Downloading %s" % (filename))
+                self.smb.getFile(self.share, pathname, fh.write)
+            except:
+                fh.close()
+                os.remove(filename)
+                raise
+            fh.close()
 
     def do_get(self, filename):
         if self.tid is None:

--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -451,6 +451,9 @@ class MiniImpacketShell(cmd.Cmd):
                 return items
 
     def do_mget(self, mask):
+        if mask == '':
+            LOG.error("A mask must be provided")
+            return
         if self.tid is None:
             LOG.error("No share selected")
             return

--- a/impacket/examples/smbclient.py
+++ b/impacket/examples/smbclient.py
@@ -462,18 +462,19 @@ class MiniImpacketShell(cmd.Cmd):
             LOG.error("No files found matching the provided mask")
             return 
         for file_tuple in self.completion:
-            filename = file_tuple[0]
-            filename = filename.replace('/','\\')
-            fh = open(ntpath.basename(filename),'wb')
-            pathname = ntpath.join(self.pwd,filename)
-            try:
-                LOG.info("Downloading %s" % (filename))
-                self.smb.getFile(self.share, pathname, fh.write)
-            except:
+            if file_tuple[1] == 0:
+                filename = file_tuple[0]
+                filename = filename.replace('/', '\\')
+                fh = open(ntpath.basename(filename), 'wb')
+                pathname = ntpath.join(self.pwd, filename)
+                try:
+                    LOG.info("Downloading %s" % (filename))
+                    self.smb.getFile(self.share, pathname, fh.write)
+                except:
+                    fh.close()
+                    os.remove(filename)
+                    raise
                 fh.close()
-                os.remove(filename)
-                raise
-            fh.close()
 
     def do_get(self, filename):
         if self.tid is None:


### PR DESCRIPTION
This command allows for the downloading of multiple files, much like the 'mget' command of smbclient(1).

This a greatly desired function of smbclient.py and helps when dealing with download a large number of files from a directory. 
Very minimal changes were required to implement this, so it should be an easy addition.

The image below shows the result of the new 'mget' command.
![smbclient-mget](https://user-images.githubusercontent.com/30613497/121425583-30dbe100-c938-11eb-9d4d-d8f0d1d1c815.png)

