### PR TITLE
Add support for loading CCache Version 3

### DIFF
--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -71,7 +71,7 @@ class KeyBlockV3(Structure):
         return "Key: (0x%x)%s" % (self['keytype'], hexlify(self['keyvalue']))
 
 
-class KeyBlock(Structure):
+class KeyBlockV4(Structure):
     structure = (
         ('keytype','!H=0'),
         ('etype','!H=0'),
@@ -195,7 +195,7 @@ class Credential:
         structure = (
             ('client',':', Principal),
             ('server',':', Principal),
-            ('key',':', KeyBlock),
+            ('key',':', KeyBlockV4),
             ('time',':', Times),
             ('is_skey','B=0'),
             ('tktflags','!L=0'),
@@ -470,7 +470,7 @@ class CCache:
         credential['server'] = tmpServer
         credential['is_skey'] = 0
 
-        credential['key'] = KeyBlock()
+        credential['key'] = KeyBlockV4()
         credential['key']['keytype'] = int(encASRepPart['key']['keytype'])
         credential['key']['keyvalue'] = encASRepPart['key']['keyvalue'].asOctets()
         credential['key']['keylen'] = len(credential['key']['keyvalue'])
@@ -530,7 +530,7 @@ class CCache:
         credential['server'] = tmpServer
         credential['is_skey'] = 0
 
-        credential['key'] = KeyBlock()
+        credential['key'] = KeyBlockV4()
         credential['key']['keytype'] = int(encTGSRepPart['key']['keytype'])
         credential['key']['keyvalue'] = encTGSRepPart['key']['keyvalue'].asOctets()
         credential['key']['keylen'] = len(credential['key']['keyvalue'])
@@ -612,7 +612,7 @@ class CCache:
         credential['server'] = tmpServer
         credential['is_skey'] = 0
 
-        credential['key'] = KeyBlock()
+        credential['key'] = KeyBlockV4()
         credential['key']['keytype'] = int(krbCredInfo['key']['keytype'])
         credential['key']['keyvalue'] = str(krbCredInfo['key']['keyvalue'])
         credential['key']['keylen'] = len(credential['key']['keyvalue'])


### PR DESCRIPTION
Recently ran into an environment that was using version 3 ccache. The ccache parser was originally written to only support version 4, which has some minor yet important differences. This PR adds support for V3 while taking care to not modify anything that will break existing implementations.

V3 ccaches will essentially be converted into V4 after being loaded. This only addresses the parsing of V3s, it does not add the capability to generate V3s.

The updates made are based off the ccache file format at:  
https://web.mit.edu/kerberos/krb5-devel/doc/formats/ccache_file_format.html  
  

Quick overview of the changes:

The ccache version is determined by the 2nd byte of data:  
`ccache_version = data[1]`

Ccache V3 does not contain a meta header, so that's skipped over in the ccache init:
```
else:
      data = data[2:]
```

Due to differences in their keyblocks, two new CredentialHeader classes were made:
`CredentialHeaderV4`: The old `CredentialHeader`, with KeyBlock updated to KeyBlockV4
`CredentialHeaderV3`: The old `CredentialHeader`, with KeyBlock updated to KeyBlockV3

Two new KeyBlock classes were made:
`KeyBlockV4`: The old KeyBlock, no changes
`KeyBlockV3`: A V3 KeyBlock where the encryption type field is repeated twice (for some reason).

