### PR TITLE
Tests: Refactored configuration of remote test cases

### DIFF
--- a/tests/SMB_RPC/test_bkrp.py
+++ b/tests/SMB_RPC/test_bkrp.py
@@ -30,14 +30,9 @@ class BKRPTests(RemoteTestCase):
 
     def connect(self):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username,self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
         dce.connect()

--- a/tests/SMB_RPC/test_dcomrt.py
+++ b/tests/SMB_RPC/test_dcomrt.py
@@ -37,14 +37,9 @@ class DCOMTests(RemoteTestCase):
 
     def connect(self):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username,self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         dce.set_auth_level(ntlm.NTLM_AUTH_PKT_INTEGRITY)
         dce.connect()
@@ -176,13 +171,7 @@ class DCOMTests(RemoteTestCase):
         iTypeInfo.GetTypeAttr()
 
     def tes_comev(self):
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
-
-        dcom = dcomrt.DCOMConnection(self.machine, self.username, self.password, self.domain, lmhash, nthash)
+        dcom = dcomrt.DCOMConnection(self.machine, self.username, self.password, self.domain, self.lmhash, self.nthash)
         iInterface = dcom.CoCreateInstanceEx(comev.CLSID_EventSystem, comev.IID_IEventSystem)
 
         #scm = dcomrt.IRemoteSCMActivator(dce)

--- a/tests/SMB_RPC/test_dhcpm.py
+++ b/tests/SMB_RPC/test_dhcpm.py
@@ -28,14 +28,9 @@ class DHCPMTests(RemoteTestCase):
 
     def connect(self, version):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
         #dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_INTEGRITY)

--- a/tests/SMB_RPC/test_drsuapi.py
+++ b/tests/SMB_RPC/test_drsuapi.py
@@ -31,14 +31,9 @@ class DRSRTests(RemoteTestCase):
 
     def connect(self):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding )
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username,self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_INTEGRITY)
         dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
@@ -82,14 +77,9 @@ class DRSRTests(RemoteTestCase):
 
     def connect2(self):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding )
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_INTEGRITY)
         #dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)

--- a/tests/SMB_RPC/test_epm.py
+++ b/tests/SMB_RPC/test_epm.py
@@ -21,14 +21,9 @@ from impacket.uuid import string_to_bin, uuidtup_to_bin
 class EPMTests(RemoteTestCase):
     def connect(self):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         dce.connect()
         dce.bind(epm.MSRPC_UUID_PORTMAP, transfer_syntax = self.ts)

--- a/tests/SMB_RPC/test_even.py
+++ b/tests/SMB_RPC/test_even.py
@@ -28,14 +28,9 @@ class RRPTests(RemoteTestCase):
 
     def connect(self):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         #dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_INTEGRITY)
         dce.connect()

--- a/tests/SMB_RPC/test_even6.py
+++ b/tests/SMB_RPC/test_even6.py
@@ -22,14 +22,9 @@ class EVEN6Tests(RemoteTestCase):
 
     def connect(self, version):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username, self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
         dce.connect()

--- a/tests/SMB_RPC/test_fasp.py
+++ b/tests/SMB_RPC/test_fasp.py
@@ -27,14 +27,9 @@ class FASPTests(RemoteTestCase):
 
     def connect(self):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username, self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_PRIVACY)
         dce.connect()

--- a/tests/SMB_RPC/test_ldap.py
+++ b/tests/SMB_RPC/test_ldap.py
@@ -91,14 +91,9 @@ class LDAPTests(RemoteTestCase):
         self.dummySearch(ldapConnection)
 
     def test_kerberosLoginHashes(self):
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(":")
-        else:
-            lmhash = ""
-            nthash = ""
         ldapConnection = self.connect(False)
         ldapConnection.kerberosLogin(
-            self.username, "", self.domain, lmhash, nthash, "", None, None
+            self.username, "", self.domain, self.lmhash, self.nthash, "", None, None
         )
 
         self.dummySearch(ldapConnection)
@@ -106,24 +101,19 @@ class LDAPTests(RemoteTestCase):
     def test_kerberosLoginKeys(self):
         ldapConnection = self.connect(False)
         ldapConnection.kerberosLogin(
-            self.username, "", self.domain, "", "", self.aesKey, None, None
+            self.username, "", self.domain, "", "", self.aes_key_128, None, None
         )
 
         self.dummySearch(ldapConnection)
 
     def test_sicilyNtlmHashes(self):
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(":")
-        else:
-            lmhash = ""
-            nthash = ""
         ldapConnection = self.connect(False)
         ldapConnection.login(
             user=self.username,
             password=self.password,
             domain=self.domain,
-            lmhash=lmhash,
-            nthash=nthash,
+            lmhash=self.lmhash,
+            nthash=self.nthash,
         )
 
         self.dummySearch(ldapConnection)
@@ -138,8 +128,7 @@ class LDAPTests(RemoteTestCase):
 class TCPTransport(LDAPTests, unittest.TestCase):
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config()
-        self.aesKey = self.config_file.get("SMBTransport", "aesKey128")
+        self.set_tcp_transport_config(aes_keys=True)
         self.url = "ldap://%s" % self.serverName
         self.baseDN = "dc=%s, dc=%s" % (
             self.domain.split(".")[0],

--- a/tests/SMB_RPC/test_lsad.py
+++ b/tests/SMB_RPC/test_lsad.py
@@ -58,14 +58,9 @@ class LSADTests(RemoteTestCase):
 
     def connect(self):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         dce.connect()
         dce.bind(lsad.MSRPC_UUID_LSAD, transfer_syntax = self.ts)

--- a/tests/SMB_RPC/test_lsat.py
+++ b/tests/SMB_RPC/test_lsat.py
@@ -33,14 +33,9 @@ class LSATTests(RemoteTestCase):
 
     def connect(self):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         #dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_INTEGRITY)
         dce.connect()

--- a/tests/SMB_RPC/test_mgmt.py
+++ b/tests/SMB_RPC/test_mgmt.py
@@ -21,14 +21,9 @@ class MGMTTests(RemoteTestCase):
 
     def connect(self):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         dce.connect()
         dce.bind(mgmt.MSRPC_UUID_MGMT, transfer_syntax = self.ts)

--- a/tests/SMB_RPC/test_nrpc.py
+++ b/tests/SMB_RPC/test_nrpc.py
@@ -69,14 +69,9 @@ class NRPCTests(RemoteTestCase):
 
     def connect(self):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
-        if len(self.machineUserHashes) > 0:
-            lmhash, nthash = self.machineUserHashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.machineUser, '', self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.machine_user, '', self.domain, self.machine_user_lmhash, self.machine_user_nthash)
         dce = rpctransport.get_dce_rpc()
         # dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_INTEGRITY)
         dce.connect()
@@ -85,17 +80,13 @@ class NRPCTests(RemoteTestCase):
         resp.dump()
         serverChallenge = resp['ServerChallenge']
 
-        if self.machineUserHashes == '':
-            ntHash = None
-        else:
-            ntHash = unhexlify(self.machineUserHashes.split(':')[1])
-
-        self.sessionKey = nrpc.ComputeSessionKeyStrongKey('', b'12345678', serverChallenge, ntHash)
+        nthash = unhexlify(self.machine_user_nthash) if self.machine_user_nthash else None
+        self.sessionKey = nrpc.ComputeSessionKeyStrongKey('', b'12345678', serverChallenge, nthash)
 
         ppp = nrpc.ComputeNetlogonCredential(b'12345678', self.sessionKey)
 
         try:
-            resp = nrpc.hNetrServerAuthenticate3(dce, NULL, self.machineUser + '\x00',
+            resp = nrpc.hNetrServerAuthenticate3(dce, NULL, self.machine_user + '\x00',
                                                  nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel,
                                                  self.serverName + '\x00', ppp, 0x600FFFFF)
             resp.dump()
@@ -314,18 +305,14 @@ class NRPCTests(RemoteTestCase):
         resp.dump()
         serverChallenge = resp['ServerChallenge']
 
-        if self.machineUserHashes == '':
-            ntHash = None
-        else:
-            ntHash = unhexlify(self.machineUserHashes.split(':')[1])
-
-        sessionKey = nrpc.ComputeSessionKeyStrongKey(self.password, b'12345678', serverChallenge, ntHash)
+        nthash = unhexlify(self.machine_user_nthash) if self.machine_user_nthash else None
+        sessionKey = nrpc.ComputeSessionKeyStrongKey(self.password, b'12345678', serverChallenge, nthash)
 
         ppp = nrpc.ComputeNetlogonCredential(b'12345678', sessionKey)
 
         request = nrpc.NetrServerAuthenticate3()
         request['PrimaryName'] = NULL
-        request['AccountName'] = self.machineUser + '\x00'
+        request['AccountName'] = self.machine_user + '\x00'
         request['SecureChannelType'] = nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel
         request['ComputerName'] = self.serverName + '\x00'
         request['ClientCredential'] = ppp
@@ -340,16 +327,12 @@ class NRPCTests(RemoteTestCase):
         resp.dump()
         serverChallenge = resp['ServerChallenge']
 
-        if self.machineUserHashes == '':
-            ntHash = None
-        else:
-            ntHash = unhexlify(self.machineUserHashes.split(':')[1])
-
-        sessionKey = nrpc.ComputeSessionKeyStrongKey(self.password, b'12345678', serverChallenge, ntHash)
+        nthash = unhexlify(self.machine_user_nthash) if self.machine_user_nthash else None
+        sessionKey = nrpc.ComputeSessionKeyStrongKey(self.password, b'12345678', serverChallenge, nthash)
 
         ppp = nrpc.ComputeNetlogonCredential(b'12345678', sessionKey)
 
-        resp = nrpc.hNetrServerAuthenticate3(dce, NULL, self.machineUser + '\x00',
+        resp = nrpc.hNetrServerAuthenticate3(dce, NULL, self.machine_user + '\x00',
                                              nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel
                                              , self.serverName + '\x00', ppp, 0x600FFFFF)
         resp.dump()
@@ -365,16 +348,12 @@ class NRPCTests(RemoteTestCase):
         resp.dump()
         serverChallenge = resp['ServerChallenge']
 
-        if self.machineUserHashes == '':
-            ntHash = None
-        else:
-            ntHash = unhexlify(self.machineUserHashes.split(':')[1])
-
-        sessionKey = nrpc.ComputeSessionKeyStrongKey(self.password, b'12345678', serverChallenge, ntHash)
+        nthash = unhexlify(self.machine_user_nthash) if self.machine_user_nthash else None
+        sessionKey = nrpc.ComputeSessionKeyStrongKey(self.password, b'12345678', serverChallenge, nthash)
 
         ppp = nrpc.ComputeNetlogonCredential(b'12345678', sessionKey)
 
-        resp = nrpc.hNetrServerAuthenticate2(dce, NULL, self.machineUser + '\x00',
+        resp = nrpc.hNetrServerAuthenticate2(dce, NULL, self.machine_user + '\x00',
                                              nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel
                                              , self.serverName + '\x00', ppp, 0x600FFFFF)
         resp.dump()
@@ -385,18 +364,14 @@ class NRPCTests(RemoteTestCase):
         resp.dump()
         serverChallenge = resp['ServerChallenge']
 
-        if self.machineUserHashes == '':
-            ntHash = None
-        else:
-            ntHash = unhexlify(self.machineUserHashes.split(':')[1])
-
-        sessionKey = nrpc.ComputeSessionKeyStrongKey(self.password, b'12345678', serverChallenge, ntHash)
+        nthash = unhexlify(self.machine_user_nthash) if self.machine_user_nthash else None
+        sessionKey = nrpc.ComputeSessionKeyStrongKey(self.password, b'12345678', serverChallenge, nthash)
 
         ppp = nrpc.ComputeNetlogonCredential(b'12345678', sessionKey)
 
         request = nrpc.NetrServerAuthenticate2()
         request['PrimaryName'] = NULL
-        request['AccountName'] = self.machineUser + '\x00'
+        request['AccountName'] = self.machine_user + '\x00'
         request['SecureChannelType'] = nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel
         request['ComputerName'] = self.serverName + '\x00'
         request['ClientCredential'] = ppp
@@ -416,18 +391,14 @@ class NRPCTests(RemoteTestCase):
         resp.dump()
         serverChallenge = resp['ServerChallenge']
 
-        if self.machineUserHashes == '':
-            ntHash = None
-        else:
-            ntHash = unhexlify(self.machineUserHashes.split(':')[1])
-
-        sessionKey = nrpc.ComputeSessionKeyStrongKey(self.password, b'12345678', serverChallenge, ntHash)
+        nthash = unhexlify(self.machine_user_nthash) if self.machine_user_nthash else None
+        sessionKey = nrpc.ComputeSessionKeyStrongKey(self.password, b'12345678', serverChallenge, nthash)
 
         ppp = nrpc.ComputeNetlogonCredential(b'12345678', sessionKey)
 
         request = nrpc.NetrServerAuthenticate()
         request['PrimaryName'] = NULL
-        request['AccountName'] = self.machineUser + '\x00'
+        request['AccountName'] = self.machine_user + '\x00'
         request['SecureChannelType'] = nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel
         request['ComputerName'] = self.serverName + '\x00'
         request['ClientCredential'] = ppp
@@ -445,18 +416,14 @@ class NRPCTests(RemoteTestCase):
         resp.dump()
         serverChallenge = resp['ServerChallenge']
 
-        if self.machineUserHashes == '':
-            ntHash = None
-        else:
-            ntHash = unhexlify(self.machineUserHashes.split(':')[1])
-
-        sessionKey = nrpc.ComputeSessionKeyStrongKey(self.password, b'12345678', serverChallenge, ntHash)
+        nthash = unhexlify(self.machine_user_nthash) if self.machine_user_nthash else None
+        sessionKey = nrpc.ComputeSessionKeyStrongKey(self.password, b'12345678', serverChallenge, nthash)
 
         ppp = nrpc.ComputeNetlogonCredential(b'12345678', sessionKey)
 
         resp.dump()
         try:
-            resp = nrpc.hNetrServerAuthenticate(dce, NULL, self.machineUser + '\x00',
+            resp = nrpc.hNetrServerAuthenticate(dce, NULL, self.machine_user + '\x00',
                                                 nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel,
                                                 self.serverName + '\x00', ppp)
             resp.dump()
@@ -468,7 +435,7 @@ class NRPCTests(RemoteTestCase):
         dce, rpctransport = self.connect()
         request = nrpc.NetrServerPasswordGet()
         request['PrimaryName'] = NULL
-        request['AccountName'] = self.machineUser + '\x00'
+        request['AccountName'] = self.machine_user + '\x00'
         request['AccountType'] = nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel
         request['ComputerName'] = self.serverName + '\x00'
         request['Authenticator'] = self.update_authenticator()
@@ -483,7 +450,7 @@ class NRPCTests(RemoteTestCase):
     def test_hNetrServerPasswordGet(self):
         dce, rpctransport = self.connect()
         try:
-            resp = nrpc.hNetrServerPasswordGet(dce, NULL, self.machineUser + '\x00',
+            resp = nrpc.hNetrServerPasswordGet(dce, NULL, self.machine_user + '\x00',
                                                nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel,
                                                self.serverName + '\x00', self.update_authenticator())
             resp.dump()
@@ -495,7 +462,7 @@ class NRPCTests(RemoteTestCase):
         dce, rpctransport = self.connect()
         request = nrpc.NetrServerTrustPasswordsGet()
         request['TrustedDcName'] = NULL
-        request['AccountName'] = self.machineUser + '\x00'
+        request['AccountName'] = self.machine_user + '\x00'
         request['SecureChannelType'] = nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel
         request['ComputerName'] = self.serverName + '\x00'
         request['Authenticator'] = self.update_authenticator()
@@ -505,7 +472,7 @@ class NRPCTests(RemoteTestCase):
 
     def aaa_hNetrServerTrustPasswordsGet(self):
         dce, rpctransport = self.connect()
-        resp = nrpc.hNetrServerTrustPasswordsGet(dce, NULL, self.machineUser,
+        resp = nrpc.hNetrServerTrustPasswordsGet(dce, NULL, self.machine_user,
                                                  nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel,
                                                  self.serverName, self.update_authenticator())
         resp.dump()
@@ -515,7 +482,7 @@ class NRPCTests(RemoteTestCase):
         dce, rpctransport = self.connect()
         request = nrpc.NetrServerPasswordSet2()
         request['PrimaryName'] = NULL
-        request['AccountName'] = self.machineUser + '\x00'
+        request['AccountName'] = self.machine_user + '\x00'
         request['SecureChannelType'] = nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel
         request['ComputerName'] = self.serverName + '\x00'
         request['Authenticator'] = self.update_authenticator()
@@ -544,7 +511,7 @@ class NRPCTests(RemoteTestCase):
         cnp['Length'] = 0x8
 
         try:
-            resp = nrpc.hNetrServerPasswordSet2(dce, NULL, self.machineUser,
+            resp = nrpc.hNetrServerPasswordSet2(dce, NULL, self.machine_user,
                                                  nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel,
                                                  self.serverName, self.update_authenticator(), cnp.getData())
             resp.dump()
@@ -610,11 +577,9 @@ class NRPCTests(RemoteTestCase):
         request['LogonInformation']['LogonInteractive']['Identity']['UserName'] = self.username
         request['LogonInformation']['LogonInteractive']['Identity']['Workstation'] = ''
 
-
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-            lmhash = unhexlify(lmhash)
-            nthash = unhexlify(nthash)
+        if len(self.hashes):
+            lmhash = unhexlify(self.lmhash)
+            nthash = unhexlify(self.nthash)
         else:
             lmhash = ntlm.LMOWFv1(self.password)
             nthash = ntlm.NTOWFv1(self.password)
@@ -652,10 +617,9 @@ class NRPCTests(RemoteTestCase):
             'ParameterControl'] = 2 + 2 ** 14 + 2 ** 7 + 2 ** 9 + 2 ** 5 + 2 ** 11
         request['LogonInformation']['LogonInteractive']['Identity']['UserName'] = self.username
         request['LogonInformation']['LogonInteractive']['Identity']['Workstation'] = ''
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-            lmhash = unhexlify(lmhash)
-            nthash = unhexlify(nthash)
+        if len(self.hashes):
+            lmhash = unhexlify(self.lmhash)
+            nthash = unhexlify(self.nthash)
         else:
             lmhash = ntlm.LMOWFv1(self.password)
             nthash = ntlm.NTOWFv1(self.password)
@@ -696,10 +660,9 @@ class NRPCTests(RemoteTestCase):
         request['LogonInformation']['LogonInteractive']['Identity']['ParameterControl'] = 2
         request['LogonInformation']['LogonInteractive']['Identity']['UserName'] = self.username
         request['LogonInformation']['LogonInteractive']['Identity']['Workstation'] = ''
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-            lmhash = unhexlify(lmhash)
-            nthash = unhexlify(nthash)
+        if len(self.hashes):
+            lmhash = unhexlify(self.lmhash)
+            nthash = unhexlify(self.nthash)
         else:
             lmhash = ntlm.LMOWFv1(self.password)
             nthash = ntlm.NTOWFv1(self.password)
@@ -867,7 +830,7 @@ class NRPCTests(RemoteTestCase):
         dce, rpctransport = self.connect()
         request = nrpc.NetrServerGetTrustInfo()
         request['TrustedDcName'] = NULL
-        request['AccountName'] = self.machineUser + '\x00'
+        request['AccountName'] = self.machine_user + '\x00'
         request['SecureChannelType'] = nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel
         request['ComputerName'] = self.serverName + '\x00'
         request['Authenticator'] = self.update_authenticator()
@@ -881,7 +844,7 @@ class NRPCTests(RemoteTestCase):
     def test_hNetrServerGetTrustInfo(self):
         dce, rpctransport = self.connect()
         try:
-            resp = nrpc.hNetrServerGetTrustInfo(dce, NULL, self.machineUser,
+            resp = nrpc.hNetrServerGetTrustInfo(dce, NULL, self.machine_user,
                                                 nrpc.NETLOGON_SECURE_CHANNEL_TYPE.WorkstationSecureChannel,
                                                 self.serverName, self.update_authenticator())
             resp.dump()
@@ -1047,9 +1010,7 @@ class TCPTransport(NRPCTests, unittest.TestCase):
 
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config()
-        self.machineUser = self.config_file.get('TCPTransport', 'machineuser')
-        self.machineUserHashes = self.config_file.get('TCPTransport', 'machineuserhashes')
+        self.set_tcp_transport_config(machine_account=True)
         self.stringBinding = epm.hept_map(self.machine, nrpc.MSRPC_UUID_NRPC, protocol='ncacn_ip_tcp')
 
 
@@ -1058,9 +1019,7 @@ class SMBTransport(NRPCTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
-        self.machineUser = self.config_file.get('SMBTransport', 'machineuser')
-        self.machineUserHashes = self.config_file.get('SMBTransport', 'machineuserhashes')
+        self.set_smb_transport_config(machine_account=True)
         self.stringBinding = r'ncacn_np:%s[\PIPE\netlogon]' % self.machine
 
 

--- a/tests/SMB_RPC/test_rpcrt.py
+++ b/tests/SMB_RPC/test_rpcrt.py
@@ -19,7 +19,7 @@ from impacket.dcerpc.v5.dtypes import RPC_UNICODE_STRING
 # easiest one
 class DCERPCTests(RemoteTestCase):
 
-    def connectDCE(self, username, password, domain, lm='', nt='', aesKey='', TGT=None, TGS=None, tfragment=0,
+    def connectDCE(self, username, password, domain, lm='', nt='', aes_key='', TGT=None, TGS=None, tfragment=0,
                    dceFragment=0,
                    auth_type=RPC_C_AUTHN_WINNT, auth_level=RPC_C_AUTHN_LEVEL_NONE, dceAuth=True, doKerberos=False,
                    bind=epm.MSRPC_UUID_PORTMAP):
@@ -27,7 +27,7 @@ class DCERPCTests(RemoteTestCase):
 
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(username, password, domain, lm, nt, aesKey, TGT, TGS)
+            rpctransport.set_credentials(username, password, domain, lm, nt, aes_key, TGT, TGS)
             rpctransport.set_kerberos(doKerberos, kdcHost=self.machine)
 
         rpctransport.set_max_fragment_size(tfragment)
@@ -49,8 +49,7 @@ class DCERPCTests(RemoteTestCase):
         dce.disconnect()
 
     def test_connectionHashes(self):
-        lmhash, nthash = self.hashes.split(':')
-        dce = self.connectDCE(self.username, '', self.domain, lmhash, nthash, dceAuth=False)
+        dce = self.connectDCE(self.username, '', self.domain, self.lmhash, self.nthash, dceAuth=False)
         dce.disconnect()
 
     def test_dceAuth(self):
@@ -64,30 +63,27 @@ class DCERPCTests(RemoteTestCase):
         dce.disconnect()
 
     def test_dceAuthHasHashes(self):
-        lmhash, nthash = self.hashes.split(':')
-        dce = self.connectDCE(self.username, '', self.domain, lmhash, nthash, dceAuth=True)
+        dce = self.connectDCE(self.username, '', self.domain, self.lmhash, self.nthash, dceAuth=True)
         epm.hept_lookup(self.machine)
         dce.disconnect()
 
     def test_dceAuthHasHashesKerberos(self):
-        lmhash, nthash = self.hashes.split(':')
-        dce = self.connectDCE(self.username, '', self.domain, lmhash, nthash, dceAuth=True, doKerberos=True)
+        dce = self.connectDCE(self.username, '', self.domain, self.lmhash, self.nthash, dceAuth=True, doKerberos=True)
         epm.hept_lookup(self.machine)
         dce.disconnect()
 
     def test_dceAuthHasAes128Kerberos(self):
-        dce = self.connectDCE(self.username, '', self.domain, '', '', self.aesKey128, dceAuth=True, doKerberos=True)
+        dce = self.connectDCE(self.username, '', self.domain, '', '', self.aes_key_128, dceAuth=True, doKerberos=True)
         epm.hept_lookup(self.machine)
         dce.disconnect()
 
     def test_dceAuthHasAes256Kerberos(self):
-        dce = self.connectDCE(self.username, '', self.domain, '', '', self.aesKey256, dceAuth=True, doKerberos=True)
+        dce = self.connectDCE(self.username, '', self.domain, '', '', self.aes_key_256, dceAuth=True, doKerberos=True)
         epm.hept_lookup(self.machine)
         dce.disconnect()
 
     def test_dceTransportFragmentation(self):
-        lmhash, nthash = self.hashes.split(':')
-        dce = self.connectDCE(self.username, '', self.domain, lmhash, nthash, tfragment=1, dceAuth=True, doKerberos=False)
+        dce = self.connectDCE(self.username, '', self.domain, self.lmhash, self.nthash, tfragment=1, dceAuth=True, doKerberos=False)
         request = epm.ept_lookup()
         request['inquiry_type'] = epm.RPC_C_EP_ALL_ELTS
         request['object'] = NULL
@@ -98,8 +94,7 @@ class DCERPCTests(RemoteTestCase):
         dce.disconnect()
 
     def test_dceFragmentation(self):
-        lmhash, nthash = self.hashes.split(':')
-        dce = self.connectDCE(self.username, '', self.domain, lmhash, nthash, dceFragment=1, dceAuth=True, doKerberos=False)
+        dce = self.connectDCE(self.username, '', self.domain, self.lmhash, self.nthash, dceFragment=1, dceAuth=True, doKerberos=False)
         request = epm.ept_lookup()
         request['inquiry_type'] = epm.RPC_C_EP_ALL_ELTS
         request['object'] = NULL
@@ -115,11 +110,10 @@ class DCERPCTests(RemoteTestCase):
             structure = (
                 ('Name', RPC_UNICODE_STRING),
             )
-        lmhash, nthash = self.hashes.split(':')
         oldBinding = self.stringBinding
         self.stringBinding = epm.hept_map(self.machine, samr.MSRPC_UUID_SAMR, protocol = 'ncacn_ip_tcp')
         print(self.stringBinding)
-        dce = self.connectDCE(self.username, '', self.domain, lmhash, nthash, dceFragment=0,
+        dce = self.connectDCE(self.username, '', self.domain, self.lmhash, self.nthash, dceFragment=0,
                               auth_level=RPC_C_AUTHN_LEVEL_PKT_INTEGRITY, auth_type=RPC_C_AUTHN_GSS_NEGOTIATE,
                               dceAuth=True,
                               doKerberos=True, bind=samr.MSRPC_UUID_SAMR)
@@ -145,8 +139,7 @@ class DCERPCTests(RemoteTestCase):
         dce.disconnect()
 
     def test_dceFragmentationWINNTPacketIntegrity(self):
-        lmhash, nthash = self.hashes.split(':')
-        dce = self.connectDCE(self.username, '', self.domain, lmhash, nthash, dceFragment=1,
+        dce = self.connectDCE(self.username, '', self.domain, self.lmhash, self.nthash, dceFragment=1,
                               auth_level=RPC_C_AUTHN_LEVEL_PKT_INTEGRITY, dceAuth=True, doKerberos=False)
         request = epm.ept_lookup()
         request['inquiry_type'] = epm.RPC_C_EP_ALL_ELTS
@@ -158,8 +151,7 @@ class DCERPCTests(RemoteTestCase):
         dce.disconnect()
 
     def test_dceFragmentationWINNTPacketPrivacy(self):
-        lmhash, nthash = self.hashes.split(':')
-        dce = self.connectDCE(self.username, '', self.domain, lmhash, nthash, dceFragment=1,
+        dce = self.connectDCE(self.username, '', self.domain, self.lmhash, self.nthash, dceFragment=1,
                               auth_level=RPC_C_AUTHN_LEVEL_PKT_PRIVACY, dceAuth=True, doKerberos=False)
         request = epm.ept_lookup()
         request['inquiry_type'] = epm.RPC_C_EP_ALL_ELTS
@@ -171,8 +163,7 @@ class DCERPCTests(RemoteTestCase):
         dce.disconnect()
 
     def test_dceFragmentationKerberosPacketIntegrity(self):
-        lmhash, nthash = self.hashes.split(':')
-        dce = self.connectDCE(self.username, '', self.domain, lmhash, nthash, dceFragment=1,
+        dce = self.connectDCE(self.username, '', self.domain, self.lmhash, self.nthash, dceFragment=1,
                               auth_type=RPC_C_AUTHN_GSS_NEGOTIATE,
                               auth_level=RPC_C_AUTHN_LEVEL_PKT_INTEGRITY, dceAuth=True, doKerberos=True)
         request = epm.ept_lookup()
@@ -185,8 +176,7 @@ class DCERPCTests(RemoteTestCase):
         dce.disconnect()
 
     def test_dceFragmentationKerberosPacketPrivacy(self):
-        lmhash, nthash = self.hashes.split(':')
-        dce = self.connectDCE(self.username, '', self.domain, lmhash, nthash, dceFragment=1,
+        dce = self.connectDCE(self.username, '', self.domain, self.lmhash, self.nthash, dceFragment=1,
                               auth_type=RPC_C_AUTHN_GSS_NEGOTIATE,
                               auth_level=RPC_C_AUTHN_LEVEL_PKT_PRIVACY, dceAuth=True, doKerberos=True)
         request = epm.ept_lookup()
@@ -225,8 +215,7 @@ class DCERPCTests(RemoteTestCase):
         dce.disconnect()
 
     def test_HashesWINNTPacketIntegrity(self):
-        lmhash, nthash = self.hashes.split(':')
-        dce = self.connectDCE(self.username, '', self.domain, lmhash, nthash,
+        dce = self.connectDCE(self.username, '', self.domain, self.lmhash, self.nthash,
                               auth_level=RPC_C_AUTHN_LEVEL_PKT_INTEGRITY, dceAuth=True, doKerberos=False)
         request = epm.ept_lookup()
         request['inquiry_type'] = epm.RPC_C_EP_ALL_ELTS
@@ -238,8 +227,7 @@ class DCERPCTests(RemoteTestCase):
         dce.disconnect()
 
     def test_HashesKerberosPacketIntegrity(self):
-        lmhash, nthash = self.hashes.split(':')
-        dce = self.connectDCE(self.username, '', self.domain, lmhash, nthash, auth_type=RPC_C_AUTHN_GSS_NEGOTIATE,
+        dce = self.connectDCE(self.username, '', self.domain, self.lmhash, self.nthash, auth_type=RPC_C_AUTHN_GSS_NEGOTIATE,
                               auth_level=RPC_C_AUTHN_LEVEL_PKT_INTEGRITY, dceAuth=True, doKerberos=True)
         request = epm.ept_lookup()
         request['inquiry_type'] = epm.RPC_C_EP_ALL_ELTS
@@ -253,7 +241,7 @@ class DCERPCTests(RemoteTestCase):
         dce.disconnect()
 
     def test_Aes128KerberosPacketIntegrity(self):
-        dce = self.connectDCE(self.username, '', self.domain, '', '', self.aesKey128,
+        dce = self.connectDCE(self.username, '', self.domain, '', '', self.aes_key_128,
                               auth_type=RPC_C_AUTHN_GSS_NEGOTIATE, auth_level=RPC_C_AUTHN_LEVEL_PKT_INTEGRITY,
                               dceAuth=True, doKerberos=True)
         request = epm.ept_lookup()
@@ -268,7 +256,7 @@ class DCERPCTests(RemoteTestCase):
         dce.disconnect()
 
     def test_Aes256KerberosPacketIntegrity(self):
-        dce = self.connectDCE(self.username, '', self.domain, '', '', self.aesKey256,
+        dce = self.connectDCE(self.username, '', self.domain, '', '', self.aes_key_256,
                               auth_type=RPC_C_AUTHN_GSS_NEGOTIATE, auth_level=RPC_C_AUTHN_LEVEL_PKT_INTEGRITY,
                               dceAuth=True, doKerberos=True)
         request = epm.ept_lookup()
@@ -326,8 +314,7 @@ class DCERPCTests(RemoteTestCase):
         dce.disconnect()
 
     def test_HashesWINNTPacketPrivacy(self):
-        lmhash, nthash = self.hashes.split(':')
-        dce = self.connectDCE(self.username, '', self.domain, lmhash, nthash, auth_level=RPC_C_AUTHN_LEVEL_PKT_PRIVACY,
+        dce = self.connectDCE(self.username, '', self.domain, self.lmhash, self.nthash, auth_level=RPC_C_AUTHN_LEVEL_PKT_PRIVACY,
                               dceAuth=True, doKerberos=False)
         request = epm.ept_lookup()
         request['inquiry_type'] = epm.RPC_C_EP_ALL_ELTS
@@ -339,8 +326,7 @@ class DCERPCTests(RemoteTestCase):
         dce.disconnect()
 
     def test_HashesKerberosPacketPrivacy(self):
-        lmhash, nthash = self.hashes.split(':')
-        dce = self.connectDCE(self.username, '', self.domain, lmhash, nthash, auth_type=RPC_C_AUTHN_GSS_NEGOTIATE,
+        dce = self.connectDCE(self.username, '', self.domain, self.lmhash, self.nthash, auth_type=RPC_C_AUTHN_GSS_NEGOTIATE,
                               auth_level=RPC_C_AUTHN_LEVEL_PKT_PRIVACY, dceAuth=True, doKerberos=True)
         request = epm.ept_lookup()
         request['inquiry_type'] = epm.RPC_C_EP_ALL_ELTS
@@ -354,7 +340,7 @@ class DCERPCTests(RemoteTestCase):
         dce.disconnect()
 
     def test_Aes128KerberosPacketPrivacy(self):
-        dce = self.connectDCE(self.username, '', self.domain, '', '', self.aesKey128,
+        dce = self.connectDCE(self.username, '', self.domain, '', '', self.aes_key_128,
                               auth_type=RPC_C_AUTHN_GSS_NEGOTIATE, auth_level=RPC_C_AUTHN_LEVEL_PKT_PRIVACY,
                               dceAuth=True, doKerberos=True)
         request = epm.ept_lookup()
@@ -369,7 +355,7 @@ class DCERPCTests(RemoteTestCase):
         dce.disconnect()
 
     def test_Aes256KerberosPacketPrivacy(self):
-        dce = self.connectDCE(self.username, '', self.domain, '', '', self.aesKey256,
+        dce = self.connectDCE(self.username, '', self.domain, '', '', self.aes_key_256,
                               auth_type=RPC_C_AUTHN_GSS_NEGOTIATE, auth_level=RPC_C_AUTHN_LEVEL_PKT_PRIVACY,
                               dceAuth=True, doKerberos=True)
         request = epm.ept_lookup()
@@ -405,9 +391,7 @@ class TCPTransport(DCERPCTests, unittest.TestCase):
 
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config()
-        self.aesKey256 = self.config_file.get('TCPTransport', 'aesKey256')
-        self.aesKey128 = self.config_file.get('TCPTransport', 'aesKey128')
+        self.set_tcp_transport_config(aes_keys=True)
         self.stringBinding = r'ncacn_ip_tcp:%s' % self.machine
 
 
@@ -416,9 +400,7 @@ class SMBTransport(DCERPCTests, unittest.TestCase):
     def setUp(self):
         # Put specific configuration for target machine with SMB_002
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
-        self.aesKey256 = self.config_file.get('SMBTransport', 'aesKey256')
-        self.aesKey128 = self.config_file.get('SMBTransport', 'aesKey128')
+        self.set_smb_transport_config(aes_keys=True)
         self.stringBinding = r'ncacn_np:%s[\pipe\epmapper]' % self.machine
 
 

--- a/tests/SMB_RPC/test_rprn.py
+++ b/tests/SMB_RPC/test_rprn.py
@@ -34,14 +34,9 @@ class RPRNTests(RemoteTestCase):
 
     def connect(self):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username,self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         #dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_INTEGRITY)
         dce.connect()

--- a/tests/SMB_RPC/test_rrp.py
+++ b/tests/SMB_RPC/test_rrp.py
@@ -55,14 +55,9 @@ class RRPTests(RemoteTestCase):
 
     def connect_scmr(self):
         rpctransport = transport.DCERPCTransportFactory(r'ncacn_np:%s[\pipe\svcctl]' % self.machine)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username, self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         # dce.set_max_fragment_size(32)
         dce.connect()
@@ -100,14 +95,9 @@ class RRPTests(RemoteTestCase):
             self.rrpStarted = True
 
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         #dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_INTEGRITY)
         dce.connect()

--- a/tests/SMB_RPC/test_samr.py
+++ b/tests/SMB_RPC/test_samr.py
@@ -143,14 +143,9 @@ class SAMRTests(RemoteTestCase):
     def connect(self):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
         #rpctransport.set_dport(self.dport)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         dce.connect()
         #dce.set_auth_level(ntlm.NTLM_AUTH_PKT_PRIVACY)

--- a/tests/SMB_RPC/test_scmr.py
+++ b/tests/SMB_RPC/test_scmr.py
@@ -127,14 +127,9 @@ class SCMRTests(RemoteTestCase):
  
     def connect(self):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         #dce.set_max_fragment_size(32)
         dce.connect()

--- a/tests/SMB_RPC/test_secretsdump.py
+++ b/tests/SMB_RPC/test_secretsdump.py
@@ -26,7 +26,7 @@ class DumpSecrets:
         self.__domain = domain
         self.__lmhash = ''
         self.__nthash = ''
-        self.__aesKey = options.aesKey
+        self.__aes_key_128 = options.aes_key_128
         self.__smbConnection = None
         self.__remoteOps = None
         self.__SAMHashes = None
@@ -59,7 +59,7 @@ class DumpSecrets:
         self.__smbConnection = SMBConnection(self.__remoteName, self.__remoteHost)
         if self.__doKerberos:
             self.__smbConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash,
-                                               self.__nthash, self.__aesKey, self.__kdcHost)
+                                               self.__nthash, self.__aes_key_128, self.__kdcHost)
         else:
             self.__smbConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
 
@@ -224,7 +224,7 @@ class DumpSecrets:
                 raise
 
 class Options(object):
-    aesKey=None
+    aes_key_128 = None
     bootkey=None
     dc_ip=None
     debug=False
@@ -297,8 +297,7 @@ class Tests(SecretsDumpTests, unittest.TestCase):
 
     def setUp(self):
         super(Tests, self).setUp()
-        self.set_smb_transport_config()
-        self.aesKey = self.config_file.get('SMBTransport', 'aesKey128')
+        self.set_smb_transport_config(aes_keys=True)
 
 
 if __name__ == "__main__":

--- a/tests/SMB_RPC/test_smb.py
+++ b/tests/SMB_RPC/test_smb.py
@@ -50,18 +50,17 @@ class SMBTests(RemoteTestCase):
         smb.logoff()
 
     def test_reconnectKerberosHashes(self):
-        lmhash, nthash = self.hashes.split(':')
         smb = self.create_connection()
-        smb.kerberosLogin(self.username, '', self.domain, lmhash, nthash, '')
+        smb.kerberosLogin(self.username, '', self.domain, self.lmhash, self.nthash, '')
         credentials = smb.getCredentials()
-        self.assertTrue( credentials == (self.username, '', self.domain, unhexlify(lmhash), unhexlify(nthash), '', None, None) )
+        self.assertTrue( credentials == (self.username, '', self.domain, unhexlify(self.lmhash), unhexlify(self.nthash), '', None, None) )
         UNC = '\\\\%s\\%s' % (self.machine, self.share)
         smb.connectTree(UNC)
         smb.logoff()
         smb.reconnect()
         credentials = smb.getCredentials()
         self.assertTrue(
-            credentials == (self.username, '', self.domain, unhexlify(lmhash), unhexlify(nthash), '', None, None))
+            credentials == (self.username, '', self.domain, unhexlify(self.lmhash), unhexlify(self.nthash), '', None, None))
         UNC = '\\\\%s\\%s' % (self.machine, self.share)
         smb.connectTree(UNC)
         smb.logoff()
@@ -100,19 +99,17 @@ class SMBTests(RemoteTestCase):
         del(smb)
 
     def test_loginHashes(self):
-        lmhash, nthash = self.hashes.split(':')
         smb = self.create_connection()
-        smb.login(self.username, '', self.domain, lmhash, nthash)
+        smb.login(self.username, '', self.domain, self.lmhash, self.nthash)
         credentials = smb.getCredentials()
-        self.assertTrue( credentials == (self.username, '', self.domain, unhexlify(lmhash), unhexlify(nthash), '', None, None) )
+        self.assertTrue( credentials == (self.username, '', self.domain, unhexlify(self.lmhash), unhexlify(self.nthash), '', None, None) )
         smb.logoff()
 
     def test_loginKerberosHashes(self):
-        lmhash, nthash = self.hashes.split(':')
         smb = self.create_connection()
-        smb.kerberosLogin(self.username, '', self.domain, lmhash, nthash, '')
+        smb.kerberosLogin(self.username, '', self.domain, self.lmhash, self.nthash, '')
         credentials = smb.getCredentials()
-        self.assertTrue( credentials == (self.username, '', self.domain, unhexlify(lmhash), unhexlify(nthash), '', None, None) )
+        self.assertTrue( credentials == (self.username, '', self.domain, unhexlify(self.lmhash), unhexlify(self.nthash), '', None, None) )
         UNC = '\\\\%s\\%s' % (self.machine, self.share)
         smb.connectTree(UNC)
         smb.logoff()
@@ -128,9 +125,9 @@ class SMBTests(RemoteTestCase):
 
     def test_loginKerberosAES(self):
         smb = self.create_connection()
-        smb.kerberosLogin(self.username, '', self.domain, '', '', self.aesKey)
+        smb.kerberosLogin(self.username, '', self.domain, '', '', self.aes_key_128)
         credentials = smb.getCredentials()
-        self.assertTrue( credentials == (self.username, '', self.domain, '','',self.aesKey, None, None) )
+        self.assertTrue(credentials == (self.username, '', self.domain, '', '', self.aes_key_128, None, None))
         UNC = '\\\\%s\\%s' % (self.machine, self.share)
         smb.connectTree(UNC)
         smb.logoff()
@@ -281,8 +278,7 @@ class SMB1Tests(SMBTests, unittest.TestCase):
 
     def setUp(self):
         super(SMB1Tests, self).setUp()
-        self.set_smb_transport_config()
-        self.aesKey = self.config_file.get('SMBTransport', 'aesKey128')
+        self.set_smb_transport_config(aes_keys=True)
         self.share = 'C$'
         self.file = '/TEST'
         self.directory = '/BETO'

--- a/tests/SMB_RPC/test_srvs.py
+++ b/tests/SMB_RPC/test_srvs.py
@@ -71,14 +71,9 @@ class SRVSTests(RemoteTestCase):
 
     def connect(self):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         dce.connect()
         dce.bind(srvs.MSRPC_UUID_SRVS, transfer_syntax = self.ts)

--- a/tests/SMB_RPC/test_tsch.py
+++ b/tests/SMB_RPC/test_tsch.py
@@ -76,15 +76,10 @@ from impacket.system_errors import ERROR_NOT_SUPPORTED
 class TSCHTests(RemoteTestCase):
 
     def connect(self, stringBinding, bindUUID):
-        rpctransport = transport.DCERPCTransportFactory(stringBinding )
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
+        rpctransport = transport.DCERPCTransportFactory(stringBinding)
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username, self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         dce.set_auth_level(RPC_C_AUTHN_LEVEL_PKT_INTEGRITY)
         dce.connect()

--- a/tests/SMB_RPC/test_wkst.py
+++ b/tests/SMB_RPC/test_wkst.py
@@ -43,14 +43,9 @@ class WKSTTests(RemoteTestCase):
 
     def connect(self):
         rpctransport = transport.DCERPCTransportFactory(self.stringBinding)
-        if len(self.hashes) > 0:
-            lmhash, nthash = self.hashes.split(':')
-        else:
-            lmhash = ''
-            nthash = ''
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
-            rpctransport.set_credentials(self.username,self.password, self.domain, lmhash, nthash)
+            rpctransport.set_credentials(self.username,self.password, self.domain, self.lmhash, self.nthash)
         dce = rpctransport.get_dce_rpc()
         dce.connect()
         dce.bind(wkst.MSRPC_UUID_WKST, transfer_syntax = self.ts)

--- a/tests/SMB_RPC/test_wmi.py
+++ b/tests/SMB_RPC/test_wmi.py
@@ -201,11 +201,6 @@ class TCPTransport(WMITests, unittest.TestCase):
     def setUp(self):
         super(TCPTransport, self).setUp()
         self.set_tcp_transport_config()
-        if len(self.hashes) > 0:
-            self.lmhash, self.nthash = self.hashes.split(':')
-        else:
-            self.lmhash = ''
-            self.nthash = ''
         self.stringBinding = r'ncacn_ip_tcp:%s' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -13,23 +13,70 @@ from six.moves.configparser import ConfigParser
 
 
 class RemoteTestCase(object):
+    """Remote Test Case Base Class
+
+    Holds configuration parameters for all remote base classes. Configuration is by
+    default loaded from `tests/dctests.cfg`, but a different path can be specified with
+    the REMOTE_CONFIG environment variable.
+
+    Configuration parameters can be found in the `tests/dcetests.cfg.template` file.
+    """
+
     def set_config_file(self):
+        """Reads the configuration file
+        """
         config_file_path = getenv("REMOTE_CONFIG", join("tests", "dcetests.cfg"))
-        self.config_file = ConfigParser()
-        self.config_file.read(config_file_path)
+        self._config_file = ConfigParser()
+        self._config_file.read(config_file_path)
 
-    def set_transport_config(self, transport):
-        self.username = self.config_file.get(transport, "username")
-        self.domain = self.config_file.get(transport, "domain")
-        self.serverName = self.config_file.get(transport, "servername")
-        self.password = self.config_file.get(transport, "password")
-        self.machine = self.config_file.get(transport, "machine")
-        self.hashes = self.config_file.get(transport, "hashes")
+    def set_transport_config(self, transport, machine_account=False, aes_keys=False):
+        """Set configuration for the specified transport.
+        """
+        self.username = self._config_file.get(transport, "username")
+        self.domain = self._config_file.get(transport, "domain")
+        self.serverName = self._config_file.get(transport, "servername")
+        self.password = self._config_file.get(transport, "password")
+        self.machine = self._config_file.get(transport, "machine")
+        self.hashes = self._config_file.get(transport, "hashes")
+        if len(self.hashes):
+            self.lmhash, self.nthash = self.hashes.split(':')
+        else:
+            self.lmhash = ''
+            self.nthash = ''
 
-    def set_smb_transport_config(self):
+        if machine_account:
+            self.machine_user = self._config_file.get(transport, "machineuser")
+            self.machine_user_hashes = self._config_file.get(transport, "machineuserhashes")
+            if len(self.machine_user_hashes):
+                self.machine_user_lmhash, self.machine_user_nthash = self.machine_user_hashes.split(':')
+            else:
+                self.machine_user_lmhash = ''
+                self.machine_user_nthash = ''
+
+        if aes_keys:
+            self.aes_key_128 = self._config_file.get(transport, 'aesKey128')
+            self.aes_key_256 = self._config_file.get(transport, 'aesKey256')
+
+    def set_smb_transport_config(self, machine_account=False, aes_keys=False):
+        """Read SMB Transport parameters from the configuration file.
+
+        :param machine_account: whether to read the machine account config or not
+        :type machine_account: bool
+
+        :param aes_keys: whether to read the AES keys config or not
+        :type aes_keys: bool
+        """
         self.set_config_file()
-        self.set_transport_config("SMBTransport")
+        self.set_transport_config("SMBTransport", machine_account, aes_keys)
 
-    def set_tcp_transport_config(self):
+    def set_tcp_transport_config(self, machine_account=False, aes_keys=False):
+        """Read TCP Transport parameters from the configuration file.
+
+        :param machine_account: whether to read the machine account config or not
+        :type machine_account: bool
+
+        :param aes_keys: whether to read the AES keys config or not
+        :type aes_keys: bool
+        """
         self.set_config_file()
-        self.set_transport_config("TCPTransport")
+        self.set_transport_config("TCPTransport", machine_account, aes_keys)


### PR DESCRIPTION
Refactored configuration to avoid duplicated code.

Main changes are:
* Moved AES keys config to base class
* Moved hash split to base class
* Made machine hashes parameters optional
* Made AES keys parameters optional
* Updated testing guide