### PR TITLE
Improve hash and crypt performance using default hmac,hashlib libraries

### DIFF
--- a/impacket/crypto_wrapper.py
+++ b/impacket/crypto_wrapper.py
@@ -1,0 +1,73 @@
+try:
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+    from cryptography.hazmat.primitives.ciphers.aead import AESCCM
+
+    AES_MODE_CBC = modes.CBC
+    AES_MODE_ECB = modes.ECB
+    AES_MODE_CFB = modes.CFB
+    DES_MODE_CBC = modes.CBC
+    DES_MODE_ECB = modes.ECB
+
+    class CipherWrapper(object):
+        def __init__(self, cipher):
+            self._cipher = cipher
+
+        def encrypt(self, data):
+            encryptor = self._cipher.encryptor()
+            return encryptor.update(data) + encryptor.finalize()
+
+        def decrypt(self, data):
+            decryptor = self._cipher.decryptor()
+            return decryptor.update(data) + decryptor.finalize()
+
+    def create_aes_cipher(key, mode, *args):
+        return CipherWrapper(Cipher(algorithms.AES(key), mode(*args)))
+
+    def create_3des_cipher(key, mode, *args):
+        return CipherWrapper(Cipher(algorithms.TripleDES(key), mode(*args)))
+
+    def create_des_cipher(key, mode, *args):
+        return create_3des_cipher(key*3, mode, *args)
+
+    def create_rc4_cipher(key):
+        return CipherWrapper(Cipher(algorithms.ARC4(key), mode=None))
+
+    def aes_ccm_encrypt_and_digest(key, nonce, data, associated_data, tag_length=16):
+        aesccm = AESCCM(key, tag_length)
+        encrypted_with_tag = aesccm.encrypt(nonce, data, associated_data)
+        return encrypted_with_tag[:-tag_length], encrypted_with_tag[-tag_length:]
+
+    def aes_ccm_decrypt_and_verify(key, nonce, data, tag, associated_data, tag_length=16):
+        aesccm = AESCCM(key, tag_length)
+        return aesccm.decrypt(nonce, data + tag, associated_data)
+
+except ImportError:
+    from Cryptodome.Cipher import AES, DES3, ARC4, DES
+
+    AES_MODE_CBC = AES.MODE_CBC
+    AES_MODE_ECB = AES.MODE_ECB
+    AES_MODE_CFB = AES.MODE_CFB
+    DES_MODE_CBC = DES.MODE_CBC
+    DES_MODE_ECB = DES.MODE_ECB
+
+    def create_aes_cipher(key, mode, *args):
+        return AES.new(key, mode, *args)
+
+    def create_3des_cipher(key, mode, *args):
+        return DES3.new(key, mode, *args)
+
+    def create_des_cipher(key, mode, *args):
+        return DES.new(key, mode, *args)
+
+    def create_rc4_cipher(key):
+        return ARC4.new(key)
+
+    def aes_ccm_encrypt_and_digest(key, nonce, data, associated_data, tag_length=16):
+        aesccm = AES.new(key, AES.MODE_CCM,  nonce, mac_len=tag_length)
+        aesccm.update(associated_data)
+        return aesccm.encrypt_and_digest(data)
+
+    def aes_ccm_decrypt_and_verify(key, nonce, data, tag, associated_data, tag_length=16):
+        aesccm = AES.new(key, AES.MODE_CCM,  nonce, mac_len=tag_length)
+        aesccm.update(associated_data)
+        return aesccm.decrypt_and_verify(data, tag)

--- a/impacket/dcerpc/v5/drsuapi.py
+++ b/impacket/dcerpc/v5/drsuapi.py
@@ -42,12 +42,7 @@ from impacket.krb5 import crypto
 from pyasn1.type import univ
 from pyasn1.codec.ber import decoder
 from impacket.crypto import transformKey
-
-try:
-    from Cryptodome.Cipher import ARC4, DES
-except Exception:
-    LOG.critical("Warning: You don't have any crypto installed. You need pycryptodomex")
-    LOG.critical("See https://pypi.org/project/pycryptodomex/")
+from impacket import crypto_wrapper
 
 MSRPC_UUID_DRSUAPI = uuidtup_to_bin(('E3514235-4B06-11D1-AB04-00C04FC2DCD2','4.0'))
 
@@ -1388,8 +1383,8 @@ def deriveKey(baseKey):
 def removeDESLayer(cryptedHash, rid):
         Key1,Key2 = deriveKey(rid)
 
-        Crypt1 = DES.new(Key1, DES.MODE_ECB)
-        Crypt2 = DES.new(Key2, DES.MODE_ECB)
+        Crypt1 = crypto_wrapper.create_des_cipher(Key1, crypto_wrapper.DES_MODE_ECB)
+        Crypt2 = crypto_wrapper.create_des_cipher(Key2, crypto_wrapper.DES_MODE_ECB)
 
         decryptedHash = Crypt1.decrypt(cryptedHash[:8]) + Crypt2.decrypt(cryptedHash[8:])
 
@@ -1404,12 +1399,12 @@ def DecryptAttributeValue(dce, attribute):
 
     encryptedPayload = ENCRYPTED_PAYLOAD(attribute)
 
-    md5 = hashlib.new('md5')
+    md5 = hashlib.md5()
     md5.update(sessionKey)
     md5.update(encryptedPayload['Salt'])
     finalMD5 = md5.digest()
 
-    cipher = ARC4.new(finalMD5)
+    cipher = crypto_wrapper.create_rc4_cipher(finalMD5)
     plainText = cipher.decrypt(attribute[16:])
 
     #chkSum = (binascii.crc32(plainText[4:])) & 0xffffffff

--- a/impacket/dcerpc/v5/rpcrt.py
+++ b/impacket/dcerpc/v5/rpcrt.py
@@ -23,7 +23,7 @@ import logging
 import socket
 import sys
 from binascii import unhexlify
-from Cryptodome.Cipher import ARC4
+from impacket import crypto_wrapper
 
 from impacket import ntlm, LOG
 from impacket.structure import Structure,pack,unpack
@@ -1098,9 +1098,9 @@ class DCERPC_v5(DCERPC):
                         self.__clientSealingKey = ntlm.SEALKEY(self.__flags, self.__sessionKey)
                         self.__serverSealingKey = ntlm.SEALKEY(self.__flags, self.__sessionKey,b"Server")
                         # Preparing the keys handle states
-                        cipher3 = ARC4.new(self.__clientSealingKey)
+                        cipher3 = crypto_wrapper.create_rc4_cipher(self.__clientSealingKey)
                         self.__clientSealingHandle = cipher3.encrypt
-                        cipher4 = ARC4.new(self.__serverSealingKey)
+                        cipher4 = crypto_wrapper.create_rc4_cipher(self.__serverSealingKey)
                         self.__serverSealingHandle = cipher4.encrypt
                     else:
                         # Same key for everything
@@ -1108,7 +1108,7 @@ class DCERPC_v5(DCERPC):
                         self.__serverSigningKey = self.__sessionKey
                         self.__clientSealingKey = self.__sessionKey
                         self.__serverSealingKey = self.__sessionKey
-                        cipher = ARC4.new(self.__clientSigningKey)
+                        cipher = crypto_wrapper.create_rc4_cipher(self.__clientSigningKey)
                         self.__clientSealingHandle = cipher.encrypt
                         self.__serverSealingHandle = cipher.encrypt
                 elif self.__auth_type == RPC_C_AUTHN_NETLOGON:

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -22,12 +22,11 @@ import datetime
 import binascii
 import codecs
 import re
+import hashlib
 import ldap3
 import ldapdomaindump
 from ldap3.core.results import RESULT_UNWILLING_TO_PERFORM
 from ldap3.utils.conv import escape_filter_chars
-import os
-from Cryptodome.Hash import MD4
 
 from impacket import LOG
 from impacket.examples.ldap_shell import LdapShell
@@ -36,7 +35,7 @@ from impacket.examples.ntlmrelayx.utils.tcpshell import TcpShell
 from impacket.ldap import ldaptypes
 from impacket.ldap.ldaptypes import ACCESS_ALLOWED_OBJECT_ACE, ACCESS_MASK, ACCESS_ALLOWED_ACE, ACE, OBJECTTYPE_GUID_MAP
 from impacket.uuid import string_to_bin, bin_to_string
-from impacket.structure import Structure, hexdump
+from impacket.structure import Structure
 
 # This is new from ldap3 v2.5
 try:
@@ -682,7 +681,7 @@ class LDAPAttack(ProtocolAttack):
                         data = entry['attributes']['msDS-ManagedPassword']
                         blob = MSDS_MANAGEDPASSWORD_BLOB()
                         blob.fromString(data)
-                        hash = MD4.new ()
+                        hash = hashlib.new('md4')
                         hash.update (blob['CurrentPassword'][:-2])
                         passwd = binascii.hexlify(hash.digest()).decode("utf-8")
                         userpass = sam + ':::' + passwd

--- a/impacket/examples/ntlmrelayx/clients/dcsyncclient.py
+++ b/impacket/examples/ntlmrelayx/clients/dcsyncclient.py
@@ -15,7 +15,7 @@
 from struct import unpack, pack
 from binascii import hexlify, unhexlify
 import traceback
-from Cryptodome.Cipher import ARC4
+from impacket import crypto_wrapper
 from impacket import LOG, ntlm
 from impacket.smbconnection import SMBConnection
 from impacket.examples.ntlmrelayx.clients import ProtocolClient
@@ -412,9 +412,9 @@ class DCSYNCRelayClient(ProtocolClient):
             self.session._DCERPC_v5__clientSealingKey = ntlm.SEALKEY(flags, signingKey)
             self.session._DCERPC_v5__serverSealingKey = ntlm.SEALKEY(flags, signingKey,b"Server")
             # Preparing the keys handle states
-            cipher3 = ARC4.new(self.session._DCERPC_v5__clientSealingKey)
+            cipher3 = crypto_wrapper.create_rc4_cipher(self.session._DCERPC_v5__clientSealingKey)
             self.session._DCERPC_v5__clientSealingHandle = cipher3.encrypt
-            cipher4 = ARC4.new(self.session._DCERPC_v5__serverSealingKey)
+            cipher4 = crypto_wrapper.create_rc4_cipher(self.session._DCERPC_v5__serverSealingKey)
             self.session._DCERPC_v5__serverSealingHandle = cipher4.encrypt
         else:
             # Same key for everything
@@ -422,7 +422,7 @@ class DCSYNCRelayClient(ProtocolClient):
             self.session._DCERPC_v5__serverSigningKey = signingKey
             self.session._DCERPC_v5__clientSealingKey = signingKey
             self.session._DCERPC_v5__serverSealingKey = signingKey
-            cipher = ARC4.new(self.session._DCERPC_v5__clientSigningKey)
+            cipher = crypto_wrapper.create_rc4_cipher(self.session._DCERPC_v5__clientSigningKey)
             self.session._DCERPC_v5__clientSealingHandle = cipher.encrypt
             self.session._DCERPC_v5__serverSealingHandle = cipher.encrypt
         self.session._DCERPC_v5__sequence = 0

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -49,6 +49,7 @@ from __future__ import division
 from __future__ import print_function
 import codecs
 import hashlib
+import hmac
 import logging
 import ntpath
 import os
@@ -83,12 +84,7 @@ from impacket.uuid import string_to_bin
 from impacket.crypto import transformKey
 from impacket.krb5 import constants
 from impacket.krb5.crypto import string_to_key
-try:
-    from Cryptodome.Cipher import DES, ARC4, AES
-    from Cryptodome.Hash import HMAC, MD4, MD5
-except ImportError:
-    LOG.critical("Warning: You don't have any crypto installed. You need pycryptodomex")
-    LOG.critical("See https://pypi.org/project/pycryptodomex/")
+from impacket import crypto_wrapper
 
 
 # Structures
@@ -1084,11 +1080,11 @@ class CryptoCommon:
     def decryptAES(key, value, iv=b'\x00'*16):
         plainText = b''
         if iv != b'\x00'*16:
-            aes256 = AES.new(key,AES.MODE_CBC, iv)
+            aes256 = crypto_wrapper.create_aes_cipher(key, crypto_wrapper.AES_MODE_CBC, iv)
 
         for index in range(0, len(value), 16):
             if iv == b'\x00'*16:
-                aes256 = AES.new(key,AES.MODE_CBC, iv)
+                aes256 = crypto_wrapper.create_aes_cipher(key, crypto_wrapper.AES_MODE_CBC, iv)
             cipherBuffer = value[index:index+16]
             # Pad buffer to 16 bytes
             if len(cipherBuffer) < 16:
@@ -1156,7 +1152,7 @@ class SAMHashes(OfflineRegistry):
         self.__perSecretCallback = perSecretCallback
 
     def MD5(self, data):
-        md5 = hashlib.new('md5')
+        md5 = hashlib.md5()
         md5.update(data)
         return md5.digest()
 
@@ -1173,7 +1169,7 @@ class SAMHashes(OfflineRegistry):
             samKeyData = SAM_KEY_DATA(domainData['Key0'])
 
             rc4Key = self.MD5(samKeyData['Salt'] + QWERTY + self.__bootKey + DIGITS)
-            rc4 = ARC4.new(rc4Key)
+            rc4 = crypto_wrapper.create_rc4_cipher(rc4Key)
             self.__hashedBootKey = rc4.encrypt(samKeyData['Key']+samKeyData['CheckSum'])
 
             # Verify key with checksum
@@ -1194,12 +1190,12 @@ class SAMHashes(OfflineRegistry):
         # plus hashedBootKey stuff
         Key1,Key2 = self.__cryptoCommon.deriveKey(rid)
 
-        Crypt1 = DES.new(Key1, DES.MODE_ECB)
-        Crypt2 = DES.new(Key2, DES.MODE_ECB)
+        Crypt1 = crypto_wrapper.create_des_cipher(Key1, crypto_wrapper.DES_MODE_ECB)
+        Crypt2 = crypto_wrapper.create_des_cipher(Key2, crypto_wrapper.DES_MODE_ECB)
 
         if newStyle is False:
             rc4Key = self.MD5( self.__hashedBootKey[:0x10] + pack("<L",rid) + constant )
-            rc4 = ARC4.new(rc4Key)
+            rc4 = crypto_wrapper.create_rc4_cipher(rc4Key)
             key = rc4.encrypt(cryptedHash['Hash'])
         else:
             key = self.__cryptoCommon.decryptAES(self.__hashedBootKey[:0x10], cryptedHash['Hash'], cryptedHash['Salt'])[:16]
@@ -1311,7 +1307,7 @@ class LSASecrets(OfflineRegistry):
         self.__history = history
 
     def MD5(self, data):
-        md5 = hashlib.new('md5')
+        md5 = hashlib.md5()
         md5.update(data)
         return md5.digest()
 
@@ -1334,7 +1330,7 @@ class LSASecrets(OfflineRegistry):
             cipherText = value[:8]
             tmpStrKey = key0[:7]
             tmpKey = transformKey(tmpStrKey)
-            Crypt1 = DES.new(tmpKey, DES.MODE_ECB)
+            Crypt1 = crypto_wrapper.create_des_cipher(tmpKey, crypto_wrapper.DES_MODE_ECB)
             plainText += Crypt1.decrypt(cipherText)
             key0 = key0[7:]
             value = value[8:]
@@ -1346,10 +1342,9 @@ class LSASecrets(OfflineRegistry):
         return secret['Secret']
 
     def __decryptHash(self, key, value, iv):
-        hmac_md5 = HMAC.new(key,iv,MD5)
-        rc4key = hmac_md5.digest()
+        rc4key = hmac.digest(key, iv, 'md5')
 
-        rc4 = ARC4.new(rc4key)
+        rc4 = crypto_wrapper.create_rc4_cipher(rc4key)
         data = rc4.encrypt(value)
         return data
 
@@ -1363,12 +1358,12 @@ class LSASecrets(OfflineRegistry):
             self.__LSAKey = record['Secret'][52:][:32]
 
         else:
-            md5 = hashlib.new('md5')
+            md5 = hashlib.md5()
             md5.update(self.__bootKey)
             for i in range(1000):
                 md5.update(value[60:76])
             tmpKey = md5.digest()
-            rc4 = ARC4.new(tmpKey)
+            rc4 = crypto_wrapper.create_rc4_cipher(tmpKey)
             plainText = rc4.decrypt(value[12:60])
             self.__LSAKey = plainText[0x10:0x20]
 
@@ -1539,7 +1534,7 @@ class LSASecrets(OfflineRegistry):
                                                                hexlify(dpapi['UserKey']).decode('latin-1'))
         elif upperName.startswith('$MACHINE.ACC'):
             # compute MD4 of the secret.. yes.. that is the nthash? :-o
-            md4 = MD4.new()
+            md4 = hashlib.new('md4')
             md4.update(secretItem)
             if hasattr(self.__remoteOps, 'getMachineNameAndDomain'):
                 machine, domain = self.__remoteOps.getMachineNameAndDomain()
@@ -1893,12 +1888,12 @@ class NTDSHashes:
             encryptedPekList = self.PEKLIST_ENC(peklist)
             if encryptedPekList['Header'][:4] == b'\x02\x00\x00\x00':
                 # Up to Windows 2012 R2 looks like header starts this way
-                md5 = hashlib.new('md5')
+                md5 = hashlib.md5()
                 md5.update(self.__bootKey)
                 for i in range(1000):
                     md5.update(encryptedPekList['KeyMaterial'])
                 tmpKey = md5.digest()
-                rc4 = ARC4.new(tmpKey)
+                rc4 = crypto_wrapper.create_rc4_cipher(tmpKey)
                 decryptedPekList = self.PEKLIST_PLAIN(rc4.encrypt(encryptedPekList['EncryptedPek']))
                 PEKLen = len(self.PEK_KEY())
                 for i in range(len( decryptedPekList['DecryptedPek'] ) // PEKLen ):
@@ -1934,13 +1929,13 @@ class NTDSHashes:
                     pos += 20
 
     def __removeRC4Layer(self, cryptedHash):
-        md5 = hashlib.new('md5')
+        md5 = hashlib.md5()
         # PEK index can be found on header of each ciphered blob (pos 8-10)
         pekIndex = hexlify(cryptedHash['Header'])
         md5.update(self.__PEK[int(pekIndex[8:10])])
         md5.update(cryptedHash['KeyMaterial'])
         tmpKey = md5.digest()
-        rc4 = ARC4.new(tmpKey)
+        rc4 = crypto_wrapper.create_rc4_cipher(tmpKey)
         plainText = rc4.encrypt(cryptedHash['EncryptedHash'])
 
         return plainText
@@ -1948,8 +1943,8 @@ class NTDSHashes:
     def __removeDESLayer(self, cryptedHash, rid):
         Key1,Key2 = self.__cryptoCommon.deriveKey(int(rid))
 
-        Crypt1 = DES.new(Key1, DES.MODE_ECB)
-        Crypt2 = DES.new(Key2, DES.MODE_ECB)
+        Crypt1 = crypto_wrapper.create_des_cipher(Key1, crypto_wrapper.DES_MODE_ECB)
+        Crypt2 = crypto_wrapper.create_des_cipher(Key2, crypto_wrapper.DES_MODE_ECB)
 
         decryptedHash = Crypt1.decrypt(cryptedHash[:8]) + Crypt2.decrypt(cryptedHash[8:])
 

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -4204,7 +4204,7 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
     def signSMBv2(self, packet, signingSessionKey):
         packet['Signature'] = b'\x00' * 16
         packet['Flags'] |= smb2.SMB2_FLAGS_SIGNED
-        signature = hmac.new(signingSessionKey, packet.getData(), hashlib.sha256).digest()
+        signature = hmac.digest(signingSessionKey, packet.getData(), 'sha256')
         packet['Signature'] = signature[:16]
         # print "%s" % packet['Signature'].encode('hex')
 


### PR DESCRIPTION
And using cryptography (with fallback to pycryptodome) to crypt/decrpt - due to issue https://github.com/Legrandin/pycryptodome/issues/534, which also improve performance.

I replaced most usages in cryptodome but not yet all of them