### PR TITLE
Tests: Simplify remote configuration

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -17,13 +17,13 @@ prior setup.
 If you want to run the full set of library test cases, you need to prepare your
 environment by completing the following steps:
 
+1. Install testing requirements. You can use the following command to do so:
+
+         python3 -m pip install tox -r requirements-test.txt
+
 1. [Install and configure a target Active Directory Domain Controller](#active-directory-setup-and-configuration).
 
 1. [Configure remote test cases](#configure-remote-test-cases).
-
-1. Install testing requirements. You can use the following command to do so:
-   
-         python3 -m pip install tox -r requirements-test.txt
 
 
 Running tests
@@ -221,14 +221,19 @@ Configure Remote Test Cases
 
 Create a copy of the [dcetest.cfg.template](tests/dcetests.cfg.template) file and
 configure it with the necessary information associated to the Active Directory you
-configured. By default, the remote test cases will look for the file in 
-`test/dcetests.cg`, but you can specify another filename using the `REMOTE_CONFIG` environment
-variable.
+configured. Path to the configuration file to use when running tests can be then
+specified in the following ways:
+
+  * Using the pytest `--remote-config` command-line option.
+  * Using the pytest `remote-config` option in `tox.ini`.  
+  * Using the `REMOTE_CONFIG` environment variable.
+  * Default to loading from `tests/dcetests.cg`.
 
 For example, you can keep configuration of different environments in
 separate files, and specify which one you want the test to run against:
 
-        $ REMOTE_CONFIG=/test/dcetests-win2019.cfg pytest
+        $ pytest --remote-config=tests/dcetests-win2016.cfg
+        $ pytest --remote-config=tests/dcetests-win2019.cfg
 
 Make sure you set a user with proper administrative privileges on the
 target Active Directory domain and that the user hashes and keys match with those
@@ -239,4 +244,4 @@ Make sure also to have full network visibility into the target hosts and be able
 resolve DNS queries for the Active Directory Domain configured. If you don't want to
 change your test machine's DNS settings to point to the AD DNS server, you can
 configure your system to statically resolve (e.g. via `/etc/hosts` file) the host
-and domain FQDN to the server's IP address. 
+and domain FQDN to the server's IP address.

--- a/tests/SMB_RPC/test_bkrp.py
+++ b/tests/SMB_RPC/test_bkrp.py
@@ -194,7 +194,7 @@ class SMBTransport(BKRPTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_np:%s[\PIPE\protected_storage]' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 

--- a/tests/SMB_RPC/test_dcomrt.py
+++ b/tests/SMB_RPC/test_dcomrt.py
@@ -294,7 +294,7 @@ class TCPTransport(DCOMTests, unittest.TestCase):
 
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_ip_tcp:%s' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 

--- a/tests/SMB_RPC/test_dhcpm.py
+++ b/tests/SMB_RPC/test_dhcpm.py
@@ -145,7 +145,7 @@ class SMBTransport(DHCPMTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_np:%s[\PIPE\dhcpserver]' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 
@@ -163,7 +163,7 @@ class TCPTransport(DHCPMTests, unittest.TestCase):
 
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config()
+        self.set_transport_config()
         self.stringBinding = epm.hept_map(self.machine, dhcpm.MSRPC_UUID_DHCPSRV2, protocol='ncacn_ip_tcp')
         #self.stringBinding = epm.hept_map(self.machine, dhcpm.MSRPC_UUID_DHCPSRV, protocol = 'ncacn_ip_tcp')
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')

--- a/tests/SMB_RPC/test_drsuapi.py
+++ b/tests/SMB_RPC/test_drsuapi.py
@@ -451,7 +451,7 @@ class SMBTransport(DRSRTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_np:%s[\PIPE\lsass]' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 
@@ -469,7 +469,7 @@ class TCPTransport(DRSRTests, unittest.TestCase):
 
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config()
+        self.set_transport_config()
         self.stringBinding = epm.hept_map(self.machine, drsuapi.MSRPC_UUID_DRSUAPI, protocol='ncacn_ip_tcp')
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 

--- a/tests/SMB_RPC/test_epm.py
+++ b/tests/SMB_RPC/test_epm.py
@@ -112,7 +112,7 @@ class SMBTransport(EPMTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_np:%s[\pipe\epmapper]' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 
@@ -130,7 +130,7 @@ class TCPTransport(EPMTests, unittest.TestCase):
 
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_ip_tcp:%s[135]' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 

--- a/tests/SMB_RPC/test_even.py
+++ b/tests/SMB_RPC/test_even.py
@@ -225,7 +225,7 @@ class SMBTransport(RRPTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_np:%s[\PIPE\eventlog]' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 

--- a/tests/SMB_RPC/test_even6.py
+++ b/tests/SMB_RPC/test_even6.py
@@ -107,7 +107,7 @@ class SMBTransport(EVEN6Tests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_np:%s[\PIPE\eventlog]' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 
@@ -125,7 +125,7 @@ class TCPTransport(EVEN6Tests, unittest.TestCase):
 
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config()
+        self.set_transport_config()
         self.stringBinding = epm.hept_map(self.machine, even6.MSRPC_UUID_EVEN6, protocol='ncacn_ip_tcp')
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 

--- a/tests/SMB_RPC/test_fasp.py
+++ b/tests/SMB_RPC/test_fasp.py
@@ -76,7 +76,7 @@ class TCPTransport(FASPTests, unittest.TestCase):
 
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config()
+        self.set_transport_config()
         self.stringBinding = epm.hept_map(self.machine, fasp.MSRPC_UUID_FASP, protocol='ncacn_ip_tcp')
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 

--- a/tests/SMB_RPC/test_ldap.py
+++ b/tests/SMB_RPC/test_ldap.py
@@ -133,7 +133,7 @@ class LDAPTests(RemoteTestCase):
 class TCPTransport(LDAPTests, unittest.TestCase):
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config(aes_keys=True)
+        self.set_transport_config(aes_keys=True)
         self.url = "ldap://%s" % self.serverName
         self.baseDN = "dc=%s, dc=%s" % (
             self.domain.split(".")[0],

--- a/tests/SMB_RPC/test_lsad.py
+++ b/tests/SMB_RPC/test_lsad.py
@@ -1030,7 +1030,7 @@ class SMBTransport(LSADTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_np:%s[\PIPE\lsarpc]' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 

--- a/tests/SMB_RPC/test_lsat.py
+++ b/tests/SMB_RPC/test_lsat.py
@@ -330,7 +330,7 @@ class SMBTransport(LSATTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_np:%s[\PIPE\lsarpc]' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 

--- a/tests/SMB_RPC/test_mgmt.py
+++ b/tests/SMB_RPC/test_mgmt.py
@@ -120,7 +120,7 @@ class SMBTransport(MGMTTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_np:%s[\pipe\epmapper]' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 
@@ -138,7 +138,7 @@ class TCPTransport(MGMTTests, unittest.TestCase):
 
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_ip_tcp:%s[135]' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 

--- a/tests/SMB_RPC/test_mimilib.py
+++ b/tests/SMB_RPC/test_mimilib.py
@@ -104,7 +104,7 @@ class TCPTransport(RRPTests, unittest.TestCase):
 
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config()
+        self.set_transport_config()
         self.stringBinding = epm.hept_map(self.machine, mimilib.MSRPC_UUID_MIMIKATZ, protocol='ncacn_ip_tcp')
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 

--- a/tests/SMB_RPC/test_nmb.py
+++ b/tests/SMB_RPC/test_nmb.py
@@ -19,7 +19,7 @@ class NMBTests(RemoteTestCase, unittest.TestCase):
 
     def setUp(self):
         super(NMBTests, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
 
     def create_connection(self):
         pass

--- a/tests/SMB_RPC/test_nrpc.py
+++ b/tests/SMB_RPC/test_nrpc.py
@@ -1013,7 +1013,7 @@ class TCPTransport(NRPCTests, unittest.TestCase):
 
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config(machine_account=True)
+        self.set_transport_config(machine_account=True)
         self.stringBinding = epm.hept_map(self.machine, nrpc.MSRPC_UUID_NRPC, protocol='ncacn_ip_tcp')
 
 
@@ -1022,7 +1022,7 @@ class SMBTransport(NRPCTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config(machine_account=True)
+        self.set_transport_config(machine_account=True)
         self.stringBinding = r'ncacn_np:%s[\PIPE\netlogon]' % self.machine
 
 

--- a/tests/SMB_RPC/test_rpch.py
+++ b/tests/SMB_RPC/test_rpch.py
@@ -23,7 +23,7 @@ class RPCHTest(RemoteTestCase, unittest.TestCase):
 
     def setUp(self):
         super(RPCHTest, self).setUp()
-        self.set_tcp_transport_config()
+        self.set_transport_config()
 
     def test_1(self):
         # Direct connection to ncacn_http service, RPC over HTTP v1

--- a/tests/SMB_RPC/test_rpcrt.py
+++ b/tests/SMB_RPC/test_rpcrt.py
@@ -399,7 +399,7 @@ class TCPTransport(DCERPCTests, unittest.TestCase):
 
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config(aes_keys=True)
+        self.set_transport_config(aes_keys=True)
         self.stringBinding = r'ncacn_ip_tcp:%s' % self.machine
 
 
@@ -408,7 +408,7 @@ class SMBTransport(DCERPCTests, unittest.TestCase):
     def setUp(self):
         # Put specific configuration for target machine with SMB_002
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config(aes_keys=True)
+        self.set_transport_config(aes_keys=True)
         self.stringBinding = r'ncacn_np:%s[\pipe\epmapper]' % self.machine
 
 

--- a/tests/SMB_RPC/test_rprn.py
+++ b/tests/SMB_RPC/test_rprn.py
@@ -204,7 +204,7 @@ class SMBTransport(RPRNTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_np:%s[\PIPE\spoolss]' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
         self.rrpStarted = False

--- a/tests/SMB_RPC/test_rrp.py
+++ b/tests/SMB_RPC/test_rrp.py
@@ -729,7 +729,7 @@ class SMBTransport(RRPTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_np:%s[\PIPE\winreg]' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
         self.rrpStarted = False
@@ -748,7 +748,7 @@ class TCPTransport(RRPTests, unittest.TestCase):
 
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config()
+        self.set_transport_config()
         self.stringBinding = epm.hept_map(self.machine, rrp.MSRPC_UUID_RRP, protocol='ncacn_ip_tcp')
         self.rrpStarted = False
 

--- a/tests/SMB_RPC/test_samr.py
+++ b/tests/SMB_RPC/test_samr.py
@@ -2745,7 +2745,7 @@ class SMBTransport(SAMRTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
         self.stringBinding = epm.hept_map(self.machine, samr.MSRPC_UUID_SAMR, protocol='ncacn_np')
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 
@@ -2763,7 +2763,7 @@ class TCPTransport(SAMRTests, unittest.TestCase):
 
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config()
+        self.set_transport_config()
         self.stringBinding = epm.hept_map(self.machine, samr.MSRPC_UUID_SAMR, protocol='ncacn_ip_tcp')
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 

--- a/tests/SMB_RPC/test_scmr.py
+++ b/tests/SMB_RPC/test_scmr.py
@@ -659,7 +659,7 @@ class SMBTransport(SCMRTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_np:%s[\pipe\svcctl]' % self.machine
 
 
@@ -668,7 +668,7 @@ class TCPTransport(SCMRTests, unittest.TestCase):
 
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config()
+        self.set_transport_config()
         self.stringBinding = epm.hept_map(self.machine, scmr.MSRPC_UUID_SCMR, protocol='ncacn_ip_tcp')
 
 

--- a/tests/SMB_RPC/test_secretsdump.py
+++ b/tests/SMB_RPC/test_secretsdump.py
@@ -305,7 +305,7 @@ class Tests(SecretsDumpTests, unittest.TestCase):
 
     def setUp(self):
         super(Tests, self).setUp()
-        self.set_smb_transport_config(aes_keys=True)
+        self.set_transport_config(aes_keys=True)
 
 
 if __name__ == "__main__":

--- a/tests/SMB_RPC/test_smb.py
+++ b/tests/SMB_RPC/test_smb.py
@@ -284,7 +284,7 @@ class SMB1Tests(SMBTests, unittest.TestCase):
 
     def setUp(self):
         super(SMB1Tests, self).setUp()
-        self.set_smb_transport_config(aes_keys=True)
+        self.set_transport_config(aes_keys=True)
         self.share = 'C$'
         self.file = '/TEST'
         self.directory = '/BETO'

--- a/tests/SMB_RPC/test_srvs.py
+++ b/tests/SMB_RPC/test_srvs.py
@@ -1145,7 +1145,7 @@ class SMBTransport(SRVSTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_np:%s[\PIPE\srvsvc]' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 

--- a/tests/SMB_RPC/test_tsch.py
+++ b/tests/SMB_RPC/test_tsch.py
@@ -1035,7 +1035,7 @@ class SMBTransport(TSCHTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
         self.stringBindingAtSvc = r'ncacn_np:%s[\PIPE\atsvc]' % self.machine
         self.stringBindingAtSvc = r'ncacn_np:%s[\PIPE\atsvc]' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')

--- a/tests/SMB_RPC/test_wkst.py
+++ b/tests/SMB_RPC/test_wkst.py
@@ -586,7 +586,7 @@ class SMBTransport(WKSTTests, unittest.TestCase):
 
     def setUp(self):
         super(SMBTransport, self).setUp()
-        self.set_smb_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_np:%s[\PIPE\wkssvc]' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 

--- a/tests/SMB_RPC/test_wmi.py
+++ b/tests/SMB_RPC/test_wmi.py
@@ -204,7 +204,7 @@ class TCPTransport(WMITests, unittest.TestCase):
 
     def setUp(self):
         super(TCPTransport, self).setUp()
-        self.set_tcp_transport_config()
+        self.set_transport_config()
         self.stringBinding = r'ncacn_ip_tcp:%s' % self.machine
         self.ts = ('8a885d04-1ceb-11c9-9fe8-08002b104860', '2.0')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+# SECUREAUTH LABS. Copyright 2021 SecureAuth Corporation. All rights reserved.
+#
+# This software is provided under under a slightly modified version
+# of the Apache Software License. See the accompanying LICENSE file
+# for more information.
+#
+# Tests configuration
+#
+import pytest
+from . import set_remote_config_file_path, set_transport_config
+
+
+def pytest_configure(config):
+    """Hook that sets remote configuration file path as specified in pytest command line
+    or ini option, and apply the configuration options to the pytest `config` object.
+    """
+    config_file = config.getoption("--remote-config")
+    if not config_file:
+        config_file = config.getini("remote-config")
+    if config_file:
+        set_remote_config_file_path(config_file)
+        set_transport_config(config)
+
+
+def pytest_addoption(parser):
+    """Hook that adds pytest options for configuring the remote configuration
+    file.
+    """
+    parser.addoption("--remote-config", dest="remote_config", metavar="FILE",
+                     help="Configuration file for remote tests")
+    parser.addini("remote-config", help="Configuration file for remote tests", type="pathlist")
+
+
+@pytest.fixture(scope="class", name="remote")
+def remote_config(request):
+    """Remote Test Case configuration fixture
+
+    Sets the configuration attributes in the test class for easier access.
+    """
+    set_transport_config(request.cls)

--- a/tests/dcetests.cfg.template
+++ b/tests/dcetests.cfg.template
@@ -19,23 +19,3 @@ domain =
 machineuser =
 # Domain joined machine NetBIOS name hashes (grab them with secretsdump)
 machineuserhashes =
-
-[SMBTransport]
-# NetBIOS Name
-servername =
-# Targets IP
-machine =
-username =
-password =
-# NTLM Hash, you can grab it with secretsdump
-hashes =
-# Kerberos AES 256 Key, you can grab it with secretsdump
-aesKey256 =
-# Kerberos AES 128 Key, you can grab it with secretsdump
-aesKey128 =
-# It must be the domain FQDN
-domain =
-# This need to be a domain joined machine NetBIOS name
-machineuser =
-# Domain joined machine NetBIOS name hashes (grab them with secretsdump)
-machineuserhashes =


### PR DESCRIPTION
* Merged TCP and SMB transport configuration into only one.
* Abstracted remote configuration parsing routines into functions.
* Remote config file can now be specified as pytest option.
* Added some notes on testing guide.