### PR TITLE
Return server time in case of clock skew with KDC

### DIFF
--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -25,7 +25,6 @@ from pyasn1.type.useful import GeneralizedTime
 from six import b
 from binascii import unhexlify, hexlify
 
-
 from impacket.krb5.asn1 import AS_REQ, AP_REQ, TGS_REQ, KERB_PA_PAC_REQUEST, KRB_ERROR, PA_ENC_TS_ENC, AS_REP, TGS_REP, \
     EncryptedData, Authenticator, EncASRepPart, EncTGSRepPart, seq_set, seq_set_iter, KERB_ERROR_DATA, METHOD_DATA, \
     ETYPE_INFO2, ETYPE_INFO, AP_REP, EncAPRepPart

--- a/impacket/krb5/kerberosv5.py
+++ b/impacket/krb5/kerberosv5.py
@@ -76,16 +76,16 @@ def sendReceive(data, host, kdcHost):
         return r
 
     if krbError.getErrorCode() != constants.ErrorCodes.KDC_ERR_PREAUTH_REQUIRED.value:
-        if krbError.getErrorCode() == constants.ErrorCodes.KRB_AP_ERR_SKEW.value:
-            try:
-                for i in decoder.decode(r):
-                    if type(i) == Sequence:
-                        for k in vars(i)["_componentValues"]:
-                            if type(k) == GeneralizedTime:
-                                server_time = datetime.datetime.strptime(k.asOctets().decode("utf-8"), "%Y%m%d%H%M%SZ")
-                                LOG.debug("Server time (UTC): %s" % server_time)
-            except Exception as e:
-                LOG.debug("Couldn't get server time for some reason: %s" % e)
+        try:
+            for i in decoder.decode(r):
+                if type(i) == Sequence:
+                    for k in vars(i)["_componentValues"]:
+                        if type(k) == GeneralizedTime:
+                            server_time = datetime.datetime.strptime(k.asOctets().decode("utf-8"), "%Y%m%d%H%M%SZ")
+                            LOG.debug("Server time (UTC): %s" % server_time)
+        except:
+            # Couldn't get server time for some reason
+            pass
         raise krbError
 
     return r


### PR DESCRIPTION
This small addition made by @Hackndo and I allows users to retrieve the server time in case of a `KRB_AP_ERR_SKEW` error when attempting a Kerberos pre-authentication. This will work for every script that relies on the `sendReceive()` function.

![Screenshot from 2021-07-30 19-32-07](https://user-images.githubusercontent.com/40902872/127690434-40c77422-8c6b-46eb-bd50-0d3c28ec9852.png)
