### PR TITLE
Complying MS-RPCH with HTTP/1.1

### DIFF
--- a/impacket/dcerpc/v5/rpch.py
+++ b/impacket/dcerpc/v5/rpch.py
@@ -611,7 +611,8 @@ class RPCProxyClient(HTTPClientSecurityProvider):
             except (IndexError, KeyError, AttributeError):
                 raise RPCProxyClientException('RPC Proxy CONN/A1 request failed')
 
-        if b'Transfer-Encoding: chunked' in resp:
+        resp_ascii = resp.decode("ASCII", errors='replace')
+        if "transfer-encoding: chunked" in resp_ascii.lower():
             self.__serverChunked = True
 
         # If the body is here, let's send it to rpc_out_recv1()


### PR DESCRIPTION
One of the WAFs from Gartner Magic Quadrant might convert HTTP header names in responses to lowercase. This fix allows the MS-RPCH implementation to work in such a case.