### PR TITLE
major speedup for ntds parsing

### DIFF
--- a/impacket/ese.py
+++ b/impacket/ese.py
@@ -790,7 +790,7 @@ class ESENT_DB:
 
         return None
 
-    def getNextRow(self, cursor):
+    def getNextRow(self, cursor, filter_tables = None):
         cursor['CurrentTag'] += 1
 
         tag = self.__getNextTag(cursor)
@@ -805,11 +805,11 @@ class ESENT_DB:
             else:
                 cursor['CurrentPageData'] = self.getPage(page.record['NextPageNumber'])
                 cursor['CurrentTag'] = 0
-                return self.getNextRow(cursor)
+                return self.getNextRow(cursor, filter_tables = filter_tables)
         else:
-            return self.__tagToRecord(cursor, tag['EntryData'])
+            return self.__tagToRecord(cursor, tag['EntryData'], filter_tables = filter_tables)
 
-    def __tagToRecord(self, cursor, tag):
+    def __tagToRecord(self, cursor, tag, filter_tables = None):
         # So my brain doesn't forget, the data record is composed of:
         # Header
         # Fixed Size Data (ID < 127)
@@ -849,6 +849,9 @@ class ESENT_DB:
         columns = cursor['TableData']['Columns'] 
         
         for column in list(columns.keys()):
+            if filter_tables is not None:
+                if column not in filter_tables:
+                    continue
             columnRecord = columns[column]['Record']
             #columnRecord.dump()
             if columnRecord['Identifier'] <= dataDefinitionHeader['LastFixedSize']:

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1862,7 +1862,10 @@ class NTDSHashes:
         self.__outputFileName = outputFileName
         self.__justUser = justUser
         self.__perSecretCallback = perSecretCallback
-        self.__filter_tables_usersecret = {
+		
+		# these are all the columns that we need to get the secrets. 
+		# If in the future someone finds other columns containing interesting things please extend ths table.
+        self.__filter_tables_usersecret = { 
             self.NAME_TO_INTERNAL['objectSid'] : 1,
             self.NAME_TO_INTERNAL['dBCSPwd'] : 1,
             self.NAME_TO_INTERNAL['name'] : 1,
@@ -1875,6 +1878,7 @@ class NTDSHashes:
             self.NAME_TO_INTERNAL['pwdLastSet'] : 1,
             self.NAME_TO_INTERNAL['userAccountControl'] : 1,
             self.NAME_TO_INTERNAL['supplementalCredentials'] : 1,
+            self.NAME_TO_INTERNAL['pekList'] : 1,
         
         }
 
@@ -1886,7 +1890,7 @@ class NTDSHashes:
         peklist = None
         while True:
             try:
-                record = self.__ESEDB.getNextRow(self.__cursor, filter_tables={ self.NAME_TO_INTERNAL['pekList'] : 1, self.NAME_TO_INTERNAL['sAMAccountType'] : 1})
+                record = self.__ESEDB.getNextRow(self.__cursor, filter_tables=self.__filter_tables_usersecret)
             except:
                 LOG.error('Error while calling getNextRow(), trying the next one')
                 continue

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1862,6 +1862,21 @@ class NTDSHashes:
         self.__outputFileName = outputFileName
         self.__justUser = justUser
         self.__perSecretCallback = perSecretCallback
+        self.__filter_tables_usersecret = {
+            self.NAME_TO_INTERNAL['objectSid'] : 1,
+            self.NAME_TO_INTERNAL['dBCSPwd'] : 1,
+            self.NAME_TO_INTERNAL['name'] : 1,
+            self.NAME_TO_INTERNAL['sAMAccountType'] : 1,
+            self.NAME_TO_INTERNAL['unicodePwd'] : 1,
+            self.NAME_TO_INTERNAL['sAMAccountName'] : 1,
+            self.NAME_TO_INTERNAL['userPrincipalName'] : 1,
+            self.NAME_TO_INTERNAL['ntPwdHistory'] : 1,
+            self.NAME_TO_INTERNAL['lmPwdHistory'] : 1,
+            self.NAME_TO_INTERNAL['pwdLastSet'] : 1,
+            self.NAME_TO_INTERNAL['userAccountControl'] : 1,
+            self.NAME_TO_INTERNAL['supplementalCredentials'] : 1,
+        
+        }
 
     def getResumeSessionFile(self):
         return self.__resumeSession.getFileName()
@@ -1871,7 +1886,7 @@ class NTDSHashes:
         peklist = None
         while True:
             try:
-                record = self.__ESEDB.getNextRow(self.__cursor)
+                record = self.__ESEDB.getNextRow(self.__cursor, filter_tables={ self.NAME_TO_INTERNAL['pekList'] : 1, self.NAME_TO_INTERNAL['sAMAccountType'] : 1})
             except:
                 LOG.error('Error while calling getNextRow(), trying the next one')
                 continue
@@ -2391,7 +2406,7 @@ class NTDSHashes:
                     # Now let's keep moving through the NTDS file and decrypting what we find
                     while True:
                         try:
-                            record = self.__ESEDB.getNextRow(self.__cursor)
+                            record = self.__ESEDB.getNextRow(self.__cursor, filter_tables=self.__filter_tables_usersecret)
                         except:
                             LOG.error('Error while calling getNextRow(), trying the next one')
                             continue


### PR DESCRIPTION
By extending the ESE class' row reading and parsing functions we can add an additional filters to specify which columns we want to parse. Using this method the script will not parse columns we don't need thus introducing a major speedup.
The code has been tested on 3 NTDS.dit files : 250Mb, 1Gb , 7Gb of size. The results match the original parser code's result but the speed is increased.
A real-life 7Gb NTDS.dit file parsing time has been reduced from 72 minutes to 18 minutes.