### PR TITLE
Support HTTP WWW-Authenticate: Negotiate

### DIFF
--- a/impacket/examples/ntlmrelayx/clients/httprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/httprelayclient.py
@@ -84,6 +84,7 @@ class HTTPRelayClient(ProtocolClient):
             return challenge
         except (IndexError, KeyError, AttributeError):
             LOG.error('No NTLM challenge returned from server')
+            return False
 
     def sendAuth(self, authenticateMessageBlob, serverChallenge=None):
         if unpack('B', authenticateMessageBlob[:1])[0] == SPNEGO_NegTokenResp.SPNEGO_NEG_TOKEN_RESP:

--- a/impacket/examples/ntlmrelayx/clients/httprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/httprelayclient.py
@@ -64,7 +64,7 @@ class HTTPRelayClient(ProtocolClient):
                 return False
             if 'NTLM' in res.getheader('WWW-Authenticate'):
                 self.authenticationMethod = "NTLM"
-            if 'Negotiate' in res.getheader('WWW-Authenticate'):
+            elif 'Negotiate' in res.getheader('WWW-Authenticate'):
                 self.authenticationMethod = "Negotiate"
         except (KeyError, TypeError):
             LOG.error('No authentication requested by the server for url %s' % self.targetHost)

--- a/impacket/examples/ntlmrelayx/clients/httprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/httprelayclient.py
@@ -40,6 +40,7 @@ class HTTPRelayClient(ProtocolClient):
         self.negotiateMessage = None
         self.authenticateMessageBlob = None
         self.server = None
+        self.authenticationMethod = None
 
     def initConnection(self):
         self.session = HTTPConnection(self.targetHost,self.targetPort)
@@ -58,21 +59,29 @@ class HTTPRelayClient(ProtocolClient):
         if res.status != 401:
             LOG.info('Status code returned: %d. Authentication does not seem required for URL' % res.status)
         try:
-            if 'NTLM' not in res.getheader('WWW-Authenticate'):
+            if 'NTLM' not in res.getheader('WWW-Authenticate') and 'Negotiate' not in res.getheader('WWW-Authenticate'):
                 LOG.error('NTLM Auth not offered by URL, offered protocols: %s' % res.getheader('WWW-Authenticate'))
                 return False
+            if 'NTLM' in res.getheader('WWW-Authenticate'):
+                self.authenticationMethod = "NTLM"
+            if 'Negotiate' in res.getheader('WWW-Authenticate'):
+                self.authenticationMethod = "Negotiate"
         except (KeyError, TypeError):
             LOG.error('No authentication requested by the server for url %s' % self.targetHost)
-            return False
+            if self.serverConfig.isADCSAttack:
+                LOG.info('IIS cert server may allow anonymous authentication, sending NTLM auth anyways')
+                self.authenticationMethod = "NTLM"
+            else:
+                return False
 
         #Negotiate auth
         negotiate = base64.b64encode(negotiateMessage).decode("ascii")
-        headers = {'Authorization':'NTLM %s' % negotiate}
+        headers = {'Authorization':'%s %s' % (self.authenticationMethod, negotiate)}
         self.session.request('GET', self.path ,headers=headers)
         res = self.session.getresponse()
         res.read()
         try:
-            serverChallengeBase64 = re.search('NTLM ([a-zA-Z0-9+/]+={0,2})', res.getheader('WWW-Authenticate')).group(1)
+            serverChallengeBase64 = re.search(('%s ([a-zA-Z0-9+/]+={0,2})' % self.authenticationMethod), res.getheader('WWW-Authenticate')).group(1)
             serverChallenge = base64.b64decode(serverChallengeBase64)
             challenge = NTLMAuthChallenge()
             challenge.fromString(serverChallenge)
@@ -87,7 +96,7 @@ class HTTPRelayClient(ProtocolClient):
         else:
             token = authenticateMessageBlob
         auth = base64.b64encode(token).decode("ascii")
-        headers = {'Authorization':'NTLM %s' % auth}
+        headers = {'Authorization':'%s %s' % (self.authenticationMethod, auth)}
         self.session.request('GET', self.path,headers=headers)
         res = self.session.getresponse()
         if res.status == 401:

--- a/impacket/examples/ntlmrelayx/clients/httprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/httprelayclient.py
@@ -68,11 +68,7 @@ class HTTPRelayClient(ProtocolClient):
                 self.authenticationMethod = "Negotiate"
         except (KeyError, TypeError):
             LOG.error('No authentication requested by the server for url %s' % self.targetHost)
-            if self.serverConfig.isADCSAttack:
-                LOG.info('IIS cert server may allow anonymous authentication, sending NTLM auth anyways')
-                self.authenticationMethod = "NTLM"
-            else:
-                return False
+            return False
 
         #Negotiate auth
         negotiate = base64.b64encode(negotiateMessage).decode("ascii")


### PR DESCRIPTION
Servers advertising `WWW-Authenticate: Negotiate` should accept NTLM authentication with a different header. This has been tested against ADCS Web service.

