### PR TITLE
Connect to RPC using alternative credentials

### DIFF
--- a/examples/smbpasswd.py
+++ b/examples/smbpasswd.py
@@ -98,7 +98,7 @@ class SMBPasswd:
 			userHandle = samr.hSamrOpenUser(self.dce, domainHandle, userId=userRID)['UserHandle']
 		except Exception as e:
 			if 'STATUS_NO_SUCH_DOMAIN' in str(e):
-				logging.critical('Wrong realm. Try to set the domain name explicitly for the target user in format DOMAIN/username.')
+				logging.critical('Wrong realm. Try to set the domain name for the target user account explicitly in format DOMAIN/username.')
 				return
 			else:
 				raise e

--- a/examples/smbpasswd.py
+++ b/examples/smbpasswd.py
@@ -199,7 +199,7 @@ if __name__ == '__main__':
 			logging.critical('Please, provide either alternative password or NT hash for RPC authentication.')
 			sys.exit(1)
 		else:  # if options.altpass is not None and options.althash is not None
-			logging.critical('Argument -altpass not allowed with argument -altNTHash.')
+			logging.critical('Argument -altpass not allowed with argument -althash.')
 			sys.exit(1)
 	else:
 		altUsername = ''

--- a/examples/smbpasswd.py
+++ b/examples/smbpasswd.py
@@ -208,7 +208,7 @@ if __name__ == '__main__':
 		if altUsername == '':
 			smbpasswd.connect()
 		else:
-			logging.debug(f'Using {altUsername} credetials to connect to RPC.')
+			logging.debug('Using {} credetials to connect to RPC.'.format(altUsername))
 			smbpasswd.connect(altUsername, altPassword, altNTHash)
 	except Exception as e:
 		if any(msg in str(e) for msg in ['STATUS_PASSWORD_MUST_CHANGE', 'STATUS_PASSWORD_EXPIRED']):

--- a/examples/smbpasswd.py
+++ b/examples/smbpasswd.py
@@ -221,7 +221,7 @@ if __name__ == '__main__':
 		if altUsername == '':
 			smbpasswd.connect()
 		else:
-			logging.debug('Using {} credetials to connect to RPC.'.format(altUsername))
+			logging.debug('Using {}\\{} credetials to connect to RPC.'.format(altDomain, altUsername))
 			smbpasswd.connect(altDomain, altUsername, altPassword, altNTHash)
 	except Exception as e:
 		if any(msg in str(e) for msg in ['STATUS_PASSWORD_MUST_CHANGE', 'STATUS_PASSWORD_EXPIRED']):

--- a/examples/smbpasswd.py
+++ b/examples/smbpasswd.py
@@ -20,11 +20,13 @@
 #  		smbpasswd.py contoso.local/j.doe:'Passw0rd!'@DC1 -newpass 'N3wPassw0rd!'
 #  		smbpasswd.py contoso.local/j.doe:'Passw0rd!'@DC1 -newhashes :126502da14a98b58f2c319b81b3a49cb
 #  		smbpasswd.py contoso.local/j.doe:'Passw0rd!'@DC1 -newpass 'N3wPassw0rd!' -altuser administrator -altpass 'Adm1nPassw0rd!'
+#  		smbpasswd.py contoso.local/j.doe:'Passw0rd!'@DC1 -newhashes :126502da14a98b58f2c319b81b3a49cb -altuser CONTOSO/administrator -altpass 'Adm1nPassw0rd!' -admin
 #  		smbpasswd.py SRV01/administrator:'Passw0rd!'@10.10.13.37 -newhashes :126502da14a98b58f2c319b81b3a49cb -altuser CONTOSO/SrvAdm -althash 6fe945ead39a7a6a2091001d98a913ab
 #
 # Author:
-# 	@snovvcrash
+#  	@snovvcrash
 #  	@bransh
+#  	@alefburzmali
 #
 # References:
 #  	https://snovvcrash.github.io/2020/10/31/pretending-to-be-smbpasswd-with-impacket.html
@@ -33,6 +35,7 @@
 #  	https://github.com/SecureAuthCorp/impacket/pull/381
 #  	https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/acb3204a-da8b-478e-9139-1ea589edb880
 #  	https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/9699d8ca-e1a4-433c-a8c3-d7bebeb01476
+#  	https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-samr/538222f7-1b89-4811-949a-0eac62e38dce
 #
 
 import sys

--- a/impacket/dcerpc/v5/samr.py
+++ b/impacket/dcerpc/v5/samr.py
@@ -2912,7 +2912,7 @@ def hSamrSetPasswordInternal4New(dce, userHandle, password):
     request = SamrSetInformationUser2()
     request['UserHandle'] = userHandle
     request['UserInformationClass'] = USER_INFORMATION_CLASS.UserInternal4InformationNew
-    request['Buffer']['tag'] =  USER_INFORMATION_CLASS.UserInternal4InformationNew
+    request['Buffer']['tag'] = USER_INFORMATION_CLASS.UserInternal4InformationNew
     request['Buffer']['Internal4New']['I1']['WhichFields'] = 0x01000000 | 0x08000000
 
     request['Buffer']['Internal4New']['I1']['UserName'] = NULL
@@ -2947,6 +2947,30 @@ def hSamrSetPasswordInternal4New(dce, userHandle, password):
     cipher = ARC4.new(key)
     buffercrypt = cipher.encrypt(pwdbuff) + salt
 
-
     request['Buffer']['Internal4New']['UserPassword']['Buffer'] = buffercrypt
+    return dce.request(request)
+
+def hSamrSetNTInternal1(dce, userHandle, password, hashNT=''):
+    request = SamrSetInformationUser()
+    request['UserHandle'] = userHandle
+    request['UserInformationClass'] = USER_INFORMATION_CLASS.UserInternal1Information
+    request['Buffer']['tag'] = USER_INFORMATION_CLASS.UserInternal1Information
+
+    from impacket import crypto, ntlm
+
+    if hashNT == '':
+        hashNT = ntlm.NTOWFv1(password)
+    else:
+        try:
+            hashNT = unhexlify(hashNT)
+        except:
+            pass
+
+    session_key = dce.get_rpc_transport().get_smb_connection().getSessionKey()
+
+    request['Buffer']['Internal1']['EncryptedNtOwfPassword'] = crypto.SamEncryptNTLMHash(hashNT, session_key)
+    request['Buffer']['Internal1']['EncryptedLmOwfPassword'] = NULL
+    request['Buffer']['Internal1']['NtPasswordPresent'] = 1
+    request['Buffer']['Internal1']['LmPasswordPresent'] = 0
+
     return dce.request(request)

--- a/impacket/dcerpc/v5/samr.py
+++ b/impacket/dcerpc/v5/samr.py
@@ -2961,6 +2961,7 @@ def hSamrSetNTInternal1(dce, userHandle, password, hashNT=''):
     if hashNT == '':
         hashNT = ntlm.NTOWFv1(password)
     else:
+        # Let's convert the hashes to binary form, if not yet
         try:
             hashNT = unhexlify(hashNT)
         except:


### PR DESCRIPTION
Added `-altuser` and `-altpass` / `-althash` options to be used when binding to RPC.

When provided, RPC connection will be established on behalf of these alternative credentials.