### PR TITLE
Fixes #1079 psexec.py decoding problems on multi bytes characters

### DIFF
--- a/examples/psexec.py
+++ b/examples/psexec.py
@@ -19,6 +19,7 @@
 
 import sys
 import os
+import re
 import cmd
 import logging
 from threading import Thread, Lock
@@ -37,6 +38,7 @@ from impacket.examples import remcomsvc, serviceinstall
 from impacket.examples.utils import parse_target
 from impacket.krb5.keytab import Keytab
 
+CODEC = sys.stdout.encoding
 
 class RemComMessage(Structure):
     structure = (
@@ -83,18 +85,15 @@ class PSEXEC:
             self.__lmhash, self.__nthash = hashes.split(':')
 
     def run(self, remoteName, remoteHost):
-
         stringbinding = r'ncacn_np:%s[\pipe\svcctl]' % remoteName
         logging.debug('StringBinding %s'%stringbinding)
         rpctransport = transport.DCERPCTransportFactory(stringbinding)
         rpctransport.set_dport(self.__port)
         rpctransport.setRemoteHost(remoteHost)
-
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
             rpctransport.set_credentials(self.__username, self.__password, self.__domain, self.__lmhash,
                                          self.__nthash, self.__aesKey)
-
         rpctransport.set_kerberos(self.__doKerberos, self.__kdcHost)
         self.doStuff(rpctransport)
 
@@ -266,26 +265,67 @@ class RemoteStdOutPipe(Pipes):
 
     def run(self):
         self.connectPipe()
+
+        global LastDataSent
+        __stdoutOutputBuffer, __stdoutData = b'', b''
+
         while True:
             try:
-                ans = self.server.readFile(self.tid,self.fid, 0, 1024)
+                stdout_ans = self.server.readFile(self.tid, self.fid, 0, 1024)
             except:
                 pass
             else:
                 try:
-                    global LastDataSent
-                    if ans != LastDataSent:
-                        sys.stdout.write(ans.decode('cp437'))
-                        sys.stdout.flush()
+                    if stdout_ans != LastDataSent:
+                        if len(stdout_ans) != 0:
+                            # Append new data to the buffer while there is data to read
+                            __stdoutOutputBuffer += stdout_ans
+
+                    promptRegex = rb'([a-zA-Z]:[\\\/])((([a-zA-Z0-9 -\.]+)[\\\/])+(([a-zA-Z0-9 -\.]+))?)?>$'
+                    endsWithPrompt = bool(re.match(promptRegex, __stdoutOutputBuffer) is not None)
+                    if endsWithPrompt == True:
+                        # All data, we shouldn't have encoding errors
+                        # Adding a space after the prompt because it's beautiful
+                        __stdoutData = __stdoutOutputBuffer + b" "
+                        # Remainder data for next iteration
+                        __stdoutOutputBuffer = b""
+
+                        # print("[+] endsWithPrompt")
+                        # print(" | __stdoutData:",__stdoutData)
+                        # print(" | __stdoutOutputBuffer:",__stdoutOutputBuffer)
+                    elif b'\n' in __stdoutOutputBuffer:
+                        # We have read a line, print buffer if it is not empty
+                        lines = __stdoutOutputBuffer.split(b"\n")
+                        # All lines, we shouldn't have encoding errors
+                        __stdoutData = b"\n".join(lines[:-1]) + b"\n"
+                        # Remainder data for next iteration
+                        __stdoutOutputBuffer = lines[-1]
+                        # print("[+] newline in __stdoutOutputBuffer")
+                        # print(" | __stdoutData:",__stdoutData)
+                        # print(" | __stdoutOutputBuffer:",__stdoutOutputBuffer)
+
+                    if len(__stdoutData) != 0:
+                        # There is data to print
+                        try:
+                            sys.stdout.write(__stdoutData.decode(CODEC))
+                            sys.stdout.flush()
+                            __stdoutData = b""
+                        except UnicodeDecodeError:
+                            logging.error('Decoding error detected, consider running chcp.com at the target,\nmap the result with '
+                                          'https://docs.python.org/3/library/codecs.html#standard-encodings\nand then execute smbexec.py '
+                                          'again with -codec and the corresponding codec')
+                            print(__stdoutData.decode(CODEC, errors='replace'))
+                            __stdoutData = b""
                     else:
-                        # Don't echo what I sent, and clear it up
-                        LastDataSent = ''
+                        # Don't echo the command that was sent, and clear it up
+                        LastDataSent = ""
                     # Just in case this got out of sync, i'm cleaning it up if there are more than 10 chars,
                     # it will give false positives tho.. we should find a better way to handle this.
-                    if LastDataSent > 10:
-                        LastDataSent = ''
+                    # if LastDataSent > 10:
+                    #     LastDataSent = ''
                 except:
                     pass
+
 
 class RemoteStdErrPipe(Pipes):
     def __init__(self, transport, pipe, permisssions):
@@ -293,15 +333,59 @@ class RemoteStdErrPipe(Pipes):
 
     def run(self):
         self.connectPipe()
+
+        # while True:
+        #     try:
+        #         ans = self.server.readFile(self.tid,self.fid, 0, 1024)
+        #     except:
+        #         pass
+        #     else:
+        #         try:
+        #             sys.stderr.write(str(ans))
+        #             sys.stderr.flush()
+        #         except:
+        #             pass
+
+        __stderrOutputBuffer, __stderrData = b'', b''
+
         while True:
             try:
-                ans = self.server.readFile(self.tid,self.fid, 0, 1024)
+                stderr_ans = self.server.readFile(self.tid, self.fid, 0, 1024)
             except:
                 pass
             else:
                 try:
-                    sys.stderr.write(str(ans))
-                    sys.stderr.flush()
+                    if len(stderr_ans) != 0:
+                        # Append new data to the buffer while there is data to read
+                        __stderrOutputBuffer += stderr_ans
+
+                    if b'\n' in __stderrOutputBuffer:
+                        # We have read a line, print buffer if it is not empty
+                        lines = __stderrOutputBuffer.split(b"\n")
+                        # All lines, we shouldn't have encoding errors
+                        __stderrData = b"\n".join(lines[:-1]) + b"\n"
+                        # Remainder data for next iteration
+                        __stderrOutputBuffer = lines[-1]
+
+                    if len(__stderrData) != 0:
+                        # There is data to print
+                        try:
+                            sys.stdout.write(__stderrData.decode(CODEC))
+                            sys.stdout.flush()
+                            __stderrData = b""
+                        except UnicodeDecodeError:
+                            logging.error('Decoding error detected, consider running chcp.com at the target,\nmap the result with '
+                                          'https://docs.python.org/3/library/codecs.html#standard-encodings\nand then execute smbexec.py '
+                                          'again with -codec and the corresponding codec')
+                            print(__stderrData.decode(CODEC, errors='replace'))
+                            __stderrData = b""
+                    else:
+                        # Don't echo the command that was sent, and clear it up
+                        LastDataSent = ""
+                    # Just in case this got out of sync, i'm cleaning it up if there are more than 10 chars,
+                    # it will give false positives tho.. we should find a better way to handle this.
+                    # if LastDataSent > 10:
+                    #     LastDataSent = ''
                 except:
                     pass
 
@@ -402,9 +486,9 @@ class RemoteShell(cmd.Cmd):
 
     def default(self, line):
         if PY3:
-            self.send_data(line.encode('cp437')+b'\r\n')
+            self.send_data(line.encode(CODEC)+b'\r\n')
         else:
-            self.send_data(line.decode(sys.stdin.encoding).encode('cp437')+'\r\n')
+            self.send_data(line.decode(sys.stdin.encoding).encode(CODEC)+'\r\n')
 
     def send_data(self, data, hideOutput = True):
         if hideOutput is True:
@@ -439,6 +523,11 @@ if __name__ == '__main__':
     parser.add_argument('-file', action='store', help="alternative RemCom binary (be sure it doesn't require CRT)")
     parser.add_argument('-ts', action='store_true', help='adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-codec', action='store', help='Sets encoding used (codec) from the target\'s output (default '
+                                                       '"%s"). If errors are detected, run chcp.com at the target, '
+                                                       'map the result with '
+                          'https://docs.python.org/3/library/codecs.html#standard-encodings and then execute smbexec.py '
+                          'again with -codec and the corresponding codec ' % CODEC)
 
     group = parser.add_argument_group('authentication')
 
@@ -474,6 +563,12 @@ if __name__ == '__main__':
 
     # Init the example's logger theme
     logger.init(options.ts)
+
+    if options.codec is not None:
+        CODEC = options.codec
+    else:
+        if CODEC is None:
+            CODEC = 'utf-8'
 
     if options.debug is True:
         logging.getLogger().setLevel(logging.DEBUG)


### PR DESCRIPTION

When characters are printed to `stdin` and `stderr` pipes, [psexec.py](https://github.com/SecureAuthCorp/impacket/blob/master/examples/psexec.py) decodes them as `cp437` encoding. Therefore multi-bytes characters such as simplified Chinese (zh-CN) alphabet would decode incorrectly as shown here:

```
psexec.py -ts -debug 'WIN2008/Administrator:Admin123!@192.168.2.108'
```
![2021-10-03_10-37](https://user-images.githubusercontent.com/79218792/135750970-bf1c51f2-2008-446a-9134-aab29a5a9e2a.png)

## With smbexec.py

It works fine in the latest version of [smbexec.py](https://github.com/SecureAuthCorp/impacket/blob/master/examples/smbexec.py):

```
smbexec.py 'WIN2008/Administrator:Admin123!@192.168.2.108'
```

![2021-10-03_10-40](https://user-images.githubusercontent.com/79218792/135751017-3d72eb6d-3ce2-43b8-98ad-242b512511a0.png)

## Solution

I fixed the encoding problems in [psexec.py](https://github.com/SecureAuthCorp/impacket/blob/master/examples/psexec.py) in [pull request xxxx](https://github.com/SecureAuthCorp/impacket/pull/1174). I refracted the print loop in `stdin` and `stderr` pipes to handle encodings and added a `-codec` option like in [smbexec.py](https://github.com/SecureAuthCorp/impacket/blob/master/examples/smbexec.py) if you need to force an encoding:

```
psexec.py -ts -debug 'WIN2008/Administrator:Admin123!@192.168.2.108' -codec utf-8
```

It now works fine:

![2021-10-03_12-56](https://user-images.githubusercontent.com/79218792/135751018-ef607c9a-5c88-4e23-95fb-dabd5d26a22d.png)

Best regards,
**Podalirius**
