### PR TITLE
Disable anonymous logon in ntlmrelayx

### DIFF
--- a/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
+++ b/impacket/examples/ntlmrelayx/servers/smbrelayserver.py
@@ -72,6 +72,8 @@ class SMBRelayServer(Thread):
         else:
             smbConfig.set("global", "SMB2Support", "False")
 
+        smbConfig.set("global", "anonymous_logon", "False")
+
         if self.config.outputFile is not None:
             smbConfig.set('global','jtr_dump_path',self.config.outputFile)
 

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -2978,9 +2978,13 @@ class SMB2Commands:
                 # No credentials provided, let's grant access
                 if authenticateMessage['flags'] & ntlm.NTLMSSP_NEGOTIATE_ANONYMOUS:
                     isAnonymus = True
+                    if smbServer._SMBSERVER__anonymousLogon == False:
+                        errorCode = STATUS_ACCESS_DENIED
+                    else:
+                        errorCode = STATUS_SUCCESS
                 else:
                     isGuest = True
-                errorCode = STATUS_SUCCESS
+                    errorCode = STATUS_SUCCESS
 
             if errorCode == STATUS_SUCCESS:
                 connData['Authenticated'] = True
@@ -3961,6 +3965,9 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
         # SMB2 Support flag = default not active
         self.__SMB2Support = False
 
+        # Allow anonymous logon
+        self.__anonymousLogon = True
+
         # Our list of commands we will answer, by default the NOT IMPLEMENTED one
         self.__smbCommandsHandler = SMBCommands()
         self.__smbTrans2Handler = TRANS2Commands()
@@ -4600,6 +4607,12 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
             self.__SMB2Support = self.__serverConfig.getboolean("global", "SMB2Support")
         else:
             self.__SMB2Support = False
+
+
+        if self.__serverConfig.has_option("global", "anonymous_logon"):
+            self.__anonymousLogon = self.__serverConfig.getboolean("global", "anonymous_logon")
+        else:
+            self.__anonymousLogon = True
 
         if self.__logFile != 'None':
             logging.basicConfig(filename=self.__logFile,


### PR DESCRIPTION
By default, SMBSERVER allows anonymous logon. For ntlmrelayx, this
is not desired since we're not interested in relaying an anonymous
session, and ntlmrelayx even skips anonymous logons. After the patch for
the PetitPotam exploit, the service now tries to logon with an anonymous
session, but if we're returning STATUS_ACCESS_DENIED, the service will
continue to NTLM authentication. This patch will create a new option for SMBSERVER
that can disable anonymous logon via config_parser/serverConfig.
Anonymous logon sessions will now return STATUS_ACCESS_DENIED.