### PR TITLE
Fixed entropy parameter handling in dpapi.py/unprotect

### DIFF
--- a/examples/dpapi.py
+++ b/examples/dpapi.py
@@ -490,7 +490,7 @@ class DPAPI:
                     entropy = fp2.read()
                     fp2.close()
                 elif self.options.entropy is not None:
-                    entropy = b(self.options.entropy) + b'\x00'
+                    entropy = b(self.options.entropy)
                 else:
                     entropy = None
 


### PR DESCRIPTION
In dpapi.py - unprotect, when receiving entropy as a string and not from a file, an extra null-byte is added.
This should not be the case. 