### PR TITLE
Patch ccache no file

### DIFF
--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -659,5 +659,8 @@ class CCache:
 
 if __name__ == '__main__':
     import os
-    ccache = CCache.loadFile(os.getenv('KRB5CCNAME'))
-    ccache.prettyPrint()
+    if os.path.isfile(os.getenv('KRB5CCNAME')):
+        ccache = CCache.loadFile(os.getenv('KRB5CCNAME'))
+        ccache.prettyPrint()
+    else:
+        print("ccache file does not exist. please set the ccache file path to KRB5CCNAME's os environment value.")

--- a/impacket/smbconnection.py
+++ b/impacket/smbconnection.py
@@ -314,6 +314,8 @@ class SMBConnection:
                 ccache = CCache.loadFile(os.getenv('KRB5CCNAME'))
             except:
                 # No cache present
+                if not (os.getenv('KRB5CCNAME')!=None and os.path.isfile(os.getenv('KRB5CCNAME'))):
+                    LOG.error("The ccache file does not exist. Please set the ccache file path to KRB5CCNAME's os environment value.")
                 pass
             else:
                 LOG.debug("Using Kerberos Cache: %s" % os.getenv('KRB5CCNAME'))


### PR DESCRIPTION
Hello, 

I added the error message if the ccache file does not exist on os.getenv('KRB5CCNAME').
Without this error handling, the error message shows only "[-] invalid principal syntax" by https://github.com/SecureAuthCorp/impacket/blob/master/impacket/krb5/types.py#L90
This is not easy for junior pentesters to use wmiexec.py and similar tools in examples dir.

Thank you for reading.
Best regards, 
 