### PR TITLE
Fix for "TypeError: sequence item 0: expected str instance, bytes found"

### DIFF
--- a/impacket/dcerpc/v5/dcom/oaut.py
+++ b/impacket/dcerpc/v5/dcom/oaut.py
@@ -25,6 +25,7 @@
 from __future__ import division
 from __future__ import print_function
 import random
+from six import PY3
 from struct import pack, unpack
 
 from impacket import LOG
@@ -1023,7 +1024,7 @@ class ITypeInfo(IRemUnknown2):
     def GetTypeComp(self):
         request = ITypeInfo_GetTypeComp()
         resp = self.request(request, iid = self._iid, uuid = self.get_iPid())
-        return ITypeComp(INTERFACE(self.get_cinstance(), ''.join(resp['ppTComp']['abData']), self.get_ipidRemUnknown(), target = self.get_target()))
+        return ITypeComp(INTERFACE(self.get_cinstance(), (b'' if PY3 else '').join(resp['ppTComp']['abData']), self.get_ipidRemUnknown(), target = self.get_target()))
 
     def GetFuncDesc(self, index):
         request = ITypeInfo_GetFuncDesc()
@@ -1061,7 +1062,7 @@ class IDispatch(IRemUnknown2):
         request['iTInfo'] = 0
         request['lcid'] = 0
         resp = self.request(request, iid = self._iid, uuid = self.get_iPid())
-        return ITypeInfo(INTERFACE(self.get_cinstance(), ''.join(resp['ppTInfo']['abData']), self.get_ipidRemUnknown(), target = self.get_target()))
+        return ITypeInfo(INTERFACE(self.get_cinstance(), (b'' if PY3 else '').join(resp['ppTInfo']['abData']), self.get_ipidRemUnknown(), target = self.get_target()))
 
     def GetIDsOfNames(self, rgszNames, lcid = 0):
         request = IDispatch_GetIDsOfNames()


### PR DESCRIPTION
When calling `iMMC.GetTypeInfo()` on an `IDispatch` using Python 3.9.7 in my case I encountered this error:

```
  File "/censored/venv/lib/python3.9/site-packages/impacket/dcerpc/v5/dcom/oaut.py", line 1065, in GetTypeInfo
    return ITypeInfo(INTERFACE(self.get_cinstance(), ''.join(resp['ppTInfo']['abData']), self.get_ipidRemUnknown(), target = self.get_target()))
TypeError: sequence item 0: expected str instance, bytes found
```

I believe this is a PY2/PY3 compatibility problem and I am including a fix that resolved this locally.

Once this fix was applied I could then call `enumerateMethods()` function without any issues.