### PR TITLE
ATSVC: Fixed NetrJobEnum struct

### DIFF
--- a/impacket/dcerpc/v5/atsvc.py
+++ b/impacket/dcerpc/v5/atsvc.py
@@ -150,7 +150,7 @@ class NetrJobEnum(NDRCALL):
         ('ServerName',ATSVC_HANDLE),
         ('pEnumContainer', AT_ENUM_CONTAINER),
         ('PreferedMaximumLength', DWORD),
-        ('pResumeHandle', DWORD),
+        ('pResumeHandle', LPDWORD),
     )
 
 class NetrJobEnumResponse(NDRCALL):


### PR DESCRIPTION
`NetrJobEnum` incorrectly defined `pResumeHandle` as `DWORD` instead of `LPDWORD`.