### PR TITLE
NRPC: Fixed NetrLogonControl2(Ex)Response structures

### DIFF
--- a/impacket/dcerpc/v5/nrpc.py
+++ b/impacket/dcerpc/v5/nrpc.py
@@ -2559,7 +2559,7 @@ class NetrLogonControl2Ex(NDRCALL):
 
 class NetrLogonControl2ExResponse(NDRCALL):
     structure = (
-       ('Buffer',NETLOGON_CONTROL_DATA_INFORMATION),
+       ('Buffer', NETLOGON_CONTROL_QUERY_INFORMATION),
        ('ErrorCode',NET_API_STATUS),
     )
 
@@ -2575,7 +2575,7 @@ class NetrLogonControl2(NDRCALL):
 
 class NetrLogonControl2Response(NDRCALL):
     structure = (
-       ('Buffer',NETLOGON_CONTROL_DATA_INFORMATION),
+       ('Buffer', NETLOGON_CONTROL_QUERY_INFORMATION),
        ('ErrorCode',NET_API_STATUS),
     )
 


### PR DESCRIPTION
- Structures for the `NetrLogonControl2` and `NetrLogonControl2Ex` call responses were using `NETLOGON_CONTROL_DATA_INFORMATION` instead of `NETLOGON_CONTROL_QUERY_INFORMATION`.

Reference: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/df7e5dd1-ebcc-4754-9da0-2e0bded82d29