### PR TITLE
Removed non-ASCII char that's failing

### DIFF
--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -1573,7 +1573,7 @@ class LSASecrets(OfflineRegistry):
                     output.append(" - Version : %d" % strDecoded['version'])
                     for qk in strDecoded['questions']:
                         output.append(" | Question: %s" % qk['question'])
-                        output.append(" | └──> Answer: %s" % qk['answer'])
+                        output.append(" | |--> Answer: %s" % qk['answer'])
                     output = '\n'.join(output)
                     secret = 'Security Questions for user %s: \n%s' % (sid, output)
                 else:


### PR DESCRIPTION
This is failing in Python 2.7 and throwing warnings on other version, but wasn't catched but in the new test refactor.