### PR TITLE
Changing corrupted source link

### DIFF
--- a/examples/secretsdump.py
+++ b/examples/secretsdump.py
@@ -43,7 +43,7 @@
 #   - https://code.google.com/p/creddump/
 #   - https://lab.mediaservice.net/code/cachedump.rb
 #   - https://insecurety.net/?p=768
-#   - http://www.beginningtoseethelight.org/ntsecurity/index.htm
+#   - https://web.archive.org/web/20190717124313/http://www.beginningtoseethelight.org/ntsecurity/index.htm
 #   - https://www.exploit-db.com/docs/english/18244-active-domain-offline-hash-dump-&-forensic-analysis.pdf
 #   - https://www.passcape.com/index.php?section=blog&cmd=details&id=15
 #

--- a/impacket/examples/secretsdump.py
+++ b/impacket/examples/secretsdump.py
@@ -41,7 +41,7 @@
 #   - https://code.google.com/p/creddump/
 #   - https://lab.mediaservice.net/code/cachedump.rb
 #   - https://insecurety.net/?p=768
-#   - http://www.beginningtoseethelight.org/ntsecurity/index.htm
+#   - https://web.archive.org/web/20190717124313/http://www.beginningtoseethelight.org/ntsecurity/index.htm
 #   - https://www.exploit-db.com/docs/english/18244-active-domain-offline-hash-dump-&-forensic-analysis.pdf
 #   - https://www.passcape.com/index.php?section=blog&cmd=details&id=15
 #
@@ -161,7 +161,7 @@ class DOMAIN_ACCOUNT_F(Structure):
 #        ('Unknown4','<L=0'),
     )
 
-# Great help from here http://www.beginningtoseethelight.org/ntsecurity/index.htm
+# Great help from here https://web.archive.org/web/20190717124313/http://www.beginningtoseethelight.org/ntsecurity/index.htm
 class USER_ACCOUNT_V(Structure):
     structure = (
         ('Unknown','12s=b""'),


### PR DESCRIPTION
Source `http://www.beginningtoseethelight.org/ntsecurity/index.htm` is currently redirecting to advertisement websites.

In order to make this knowledge still available and to avoid annoying advertisement, I suggest to replace this link by this new link, which is using archive.org: `https://web.archive.org/web/20190717124313/http://www.beginningtoseethelight.org/ntsecurity/index.htm`.
