### PR TITLE
Fixing Ccache to Kirbi conversion leaving service hostname out

### DIFF
--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -626,8 +626,9 @@ class CCache:
 
         krbCredInfo['sname'] = noValue
         krbCredInfo['sname']['name-type'] = credential['server'].header['name_type']
-        seq_set_iter(krbCredInfo['sname'], 'name-string',
-                     (credential['server'].components[0].fields['data'], credential['server'].realm.fields['data']))
+        tmp_service_class = credential['server'].components[0].fields['data']
+        tmp_service_hostname = credential['server'].components[1].fields['data']
+        seq_set_iter(krbCredInfo['sname'], 'name-string', (tmp_service_class, tmp_service_hostname))
 
         encKrbCredPart = EncKrbCredPart()
         seq_set_iter(encKrbCredPart, 'ticket-info', (krbCredInfo,))


### PR DESCRIPTION
This is a fix to #1264 
Conversion from Ccache to Kirbi was including the service realm instead of the service hostname in the `sname` components. 