### PR TITLE
Fix default NTLM server challenge in smbserver.py

### DIFF
--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -4598,7 +4598,7 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
         if self.__serverConfig.has_option('global', 'challenge'):
             self.__challenge = unhexlify(self.__serverConfig.get('global', 'challenge'))
         else:
-            self.__challenge = b'A' * 16
+            self.__challenge = b'A' * 8
 
         if self.__serverConfig.has_option("global", "jtr_dump_path"):
             self.__jtr_dump_path = self.__serverConfig.get("global", "jtr_dump_path")


### PR DESCRIPTION
NTLM server challenges are 8 byte (64 bit):
https://github.com/SecureAuthCorp/impacket/blob/68fd6b799f179eed5b3cccfd7cb60850626b0b24/impacket/ntlm.py#L355

The default configuration for `smbserver.py` specifies 16 bytes of `A`. In general, this works because Impacket only packs the first 8 bytes and discards the rest.

However, the logged hashes (e.g. by `ntlmrelayx.py`) contain all 16 bytes and therefore cannot be recognized by Hashcat, resulting in an error.