### PR TITLE
Update mimikatz.py to not trigger the AV on windows

### DIFF
--- a/examples/mimikatz.py
+++ b/examples/mimikatz.py
@@ -45,16 +45,7 @@ except ImportError:
   import readline
 
 
-mimikatz_intro = r"""
-  .#####.   mimikatz RPC interface
- .## ^ ##.  "A La Vie, A L' Amour "
- ## / \ ##  /* * *
- ## \ / ##   Benjamin DELPY `gentilkiwi` ( benjamin@gentilkiwi.com )
- '## v ##'   http://blog.gentilkiwi.com/mimikatz             (oe.eo)
-  '#####'    Impacket client by Alberto Solino (@agsolino)    * * */
-
-
-Type help for list of commands"""
+mimikatz_intro = r"""Type help for list of commands"""
 
 
 class MimikatzShell(cmd.Cmd):


### PR DESCRIPTION
Hello

Related to this issue #911 but when you try to use impacket on Windows the installation is blocked because of 4 line of code on the mimikatz script.
This PR fix that and allows you to proceed the installation of the lib without any problem. At least for this is working well on my side with defender.

![image](https://user-images.githubusercontent.com/5891788/163355098-c8149f2f-e25b-46f3-a669-8cb21153d711.png)
