### PR TITLE
SMBServer: Missed info level for SMB2 FileBothDirectoryInfo

### DIFF
--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -454,8 +454,8 @@ def findFirst2(path, fileName, level, searchAttributes, pktFlags=smb.SMB.FLAGS2_
 
         item['FileName'] = os.path.basename(i).encode(encoding)
 
-        if level in [smb.SMB_FIND_FILE_BOTH_DIRECTORY_INFO, smb.SMB_FIND_FILE_ID_BOTH_DIRECTORY_INFO,
-                     smb2.SMB2_FILE_ID_BOTH_DIRECTORY_INFO]:
+        if level in [smb.SMB_FIND_FILE_BOTH_DIRECTORY_INFO, smb2.SMB2_FILE_BOTH_DIRECTORY_INFO,
+                     smb.SMB_FIND_FILE_ID_BOTH_DIRECTORY_INFO, smb2.SMB2_FILE_ID_BOTH_DIRECTORY_INFO]:
             item['EaSize'] = 0
             item['EndOfFile'] = size
             item['AllocationSize'] = size


### PR DESCRIPTION
The response item was created but no fields were filled in. This should fix #1205.