### PR TITLE
Fix typo that made sp_start_job unusable

### DIFF
--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -61,7 +61,7 @@ if __name__ == '__main__':
             except:
                 pass
 
-        def sp_start_job(self, s):
+        def do_sp_start_job(self, s):
             try:
                 self.sql.sql_query("DECLARE @job NVARCHAR(100);"
                                    "SET @job='IdxDefrag'+CONVERT(NVARCHAR(36),NEWID());"


### PR DESCRIPTION
commands are found by prepending the `do_` prefix to the function name, and `sp_start_job` function name is missing the `do_` prefix so it is impossible to call it.