### PR TITLE
Ntlmrelayx logging

### DIFF
--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -360,7 +360,6 @@ if __name__ == '__main__':
 
     try:
        options = parser.parse_args()
-       print(options)
     except Exception as e:
        logging.error(str(e))
        sys.exit(1)

--- a/examples/ntlmrelayx.py
+++ b/examples/ntlmrelayx.py
@@ -240,6 +240,7 @@ if __name__ == '__main__':
     parser.add_argument('-i','--interactive', action='store_true',help='Launch an smbclient or LDAP console instead'
                         'of executing a command after a successful relay. This console will listen locally on a '
                         ' tcp port and can be reached with for example netcat.')
+    parser.add_argument('-lf','--log-file', action='store',help='path to logfile where all stdout will be logged as well.')
 
     # Interface address specification
     parser.add_argument('-ip','--interface-ip', action='store', metavar='INTERFACE_IP', help='IP address of interface to '
@@ -359,6 +360,7 @@ if __name__ == '__main__':
 
     try:
        options = parser.parse_args()
+       print(options)
     except Exception as e:
        logging.error(str(e))
        sys.exit(1)
@@ -368,7 +370,7 @@ if __name__ == '__main__':
        sys.exit(1)
 
     # Init the example's logger theme
-    logger.init(options.ts)
+    logger.init(options.ts, options.log_file)
 
     if options.debug is True:
         logging.getLogger().setLevel(logging.DEBUG)

--- a/impacket/examples/logger.py
+++ b/impacket/examples/logger.py
@@ -51,12 +51,18 @@ class ImpacketFormatterTimeStamp(ImpacketFormatter):
   def formatTime(self, record, datefmt=None):
       return ImpacketFormatter.formatTime(self, record, datefmt="%Y-%m-%d %H:%M:%S")
 
-def init(ts=False):
+def init(ts=False, logfile=None):
+    handlers = []
     # We add a StreamHandler and formatter to the root logger
-    handler = logging.StreamHandler(sys.stdout)
+    handlers.append(logging.StreamHandler(sys.stdout))
+    if logfile:
+        handlers.append(logging.FileHandler(logfile))
     if not ts:
-        handler.setFormatter(ImpacketFormatter())
+        for handler in handlers:
+            handler.setFormatter(ImpacketFormatter())
     else:
-        handler.setFormatter(ImpacketFormatterTimeStamp())
-    logging.getLogger().addHandler(handler)
+        for handler in handlers:
+            handler.setFormatter(ImpacketFormatterTimeStamp())
+    for handler in handlers:
+        logging.getLogger().addHandler(handler)
     logging.getLogger().setLevel(logging.INFO)


### PR DESCRIPTION
This slight modification makes it possible to write the full output of `ntlmrelayx.py` to a logfile.

I was having trouble using the `tee` command when attempting to write all information to log. This fixes my issue. This is especially convenient when new users are created in LDAP, since the login-information could otherwise be lost.