### PR TITLE
ticketer: Add support for MIT Kerberos V

### DIFF
--- a/examples/ticketer.py
+++ b/examples/ticketer.py
@@ -671,7 +671,7 @@ class TICKETER:
         cipherText = cipher.encrypt(key, 2, encodedEncTicketPart, None)
 
         kdcRep['ticket']['enc-part']['cipher'] = cipherText
-        kdcRep['ticket']['enc-part']['kvno'] = 2
+        kdcRep['ticket']['enc-part']['kvno'] = self.__options.kvno
 
         # Lastly.. we have to encrypt the kdcRep['enc-part'] part
         # with a key we chose. It actually doesn't really matter since nobody uses it (could it be trash?)
@@ -734,8 +734,9 @@ if __name__ == '__main__':
     parser.add_argument('-request', action='store_true', default=False, help='Requests ticket to domain and clones it '
                         'changing only the supplied information. It requires specifying -user')
     parser.add_argument('-domain', action='store', required=True, help='the fully qualified domain name (e.g. contoso.com)')
-    parser.add_argument('-domain-sid', action='store', required=True, help='Domain SID of the target domain the ticker will be '
+    parser.add_argument('-domain-sid', action='store', required=False, help='Domain SID of the target domain the ticker will be '
                                                             'generated for')
+    parser.add_argument('-kvno', action='store', required=False, help='kvno of the signing key (for MIT Kerberos V only)', type=int)
     parser.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key used for signing the ticket '
                                                                              '(128 or 256 bits)')
     parser.add_argument('-nthash', action="store", help='NT hash used for signing the ticket')
@@ -790,6 +791,17 @@ if __name__ == '__main__':
     if options.domain is None:
         logging.critical('Domain should be specified!')
         sys.exit(1)
+
+    if options.domain_sid is None and options.kvno is None:
+        logging.critical('Domain SID (for Microsoft) or kvno (for MIT) must be specified')
+        sys.exit(1)
+    if options.domain_sid is None:
+        # From https://docs.microsoft.com/en-us/windows/security/identity-protection/access-control/security-identifiers
+        options.domain_sid = 'S-1-5-21-1004336348-1177238915-682003330'
+    if options.kvno is None:
+        # kvno is ignored by Microsoft's implementation
+        # https://docs.microsoft.com/en-us/archive/blogs/openspecification/to-kvno-or-not-to-kvno-what-is-the-version
+        options.kvno = 2
 
     if options.aesKey is None and options.nthash is None and options.keytab is None:
         logging.error('You have to specify either aesKey, or nthash, or keytab')


### PR DESCRIPTION
TGTs indicate the kvno of the key used to sign them. Microsoft's
implementation of Kerberos 5 does not verify that the kvno specified
matches an existing key. MIT Kerberos V, on the other hand, does.
The use of a hard-coded kvno (with value 2) causes MIT's implementation
to refuse tickets signed by ticketer.py

This patch adds support for the `-kvno` argument. It lets users
specify the kvno of the signing key. Additionally, since a domain's
SID only exists in Active Directory, the argument becomes optional.

At least 1 of the argument must be specified. If the kvno is not specified,
the currently hard-coded value is used as the default. If the domain SID
is not specified, a default value is used. Note that, to prevent users from
specifying a kvno when targeting an AD, a note about only using the kvno
argument for targeting MIT is given.

For reference, do note Microsoft did document that it ignores the kvno field:
https://docs.microsoft.com/en-us/archive/blogs/openspecification/to-kvno-or-not-to-kvno-what-is-the-version

Take note that I only changed one (1) `kvno` field, but the change MIGHT
have to be propagated to other instances for certain tickets and installations.
Feel free to propagate if you believe it is necessary.