### PR TITLE
GetUserSPNs.py - Printed TGS in Debug Logging

### DIFF
--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 # Impacket - Collection of Python classes for working with network protocols.
 #
 # SECUREAUTH LABS. Copyright (C) 2022 SecureAuth Corporation. All rights reserved.
@@ -187,6 +187,7 @@ class GetUserSPNs:
                 constants.EncryptionTypes.rc4_hmac.value, username, decodedTGS['ticket']['realm'], spn.replace(':', '~'),
                 hexlify(decodedTGS['ticket']['enc-part']['cipher'][:16].asOctets()).decode(),
                 hexlify(decodedTGS['ticket']['enc-part']['cipher'][16:].asOctets()).decode())
+            logging.debug('RC4 TGS: %s' % entry)
             if fd is None:
                 print(entry)
             else:
@@ -195,7 +196,8 @@ class GetUserSPNs:
             entry = '$krb5tgs$%d$%s$%s$*%s*$%s$%s' % (
                 constants.EncryptionTypes.aes128_cts_hmac_sha1_96.value, username, decodedTGS['ticket']['realm'], spn.replace(':', '~'),
                 hexlify(decodedTGS['ticket']['enc-part']['cipher'][-12:].asOctets()).decode(),
-                hexlify(decodedTGS['ticket']['enc-part']['cipher'][:-12:].asOctets()).decode)
+                hexlify(decodedTGS['ticket']['enc-part']['cipher'][:-12:].asOctets()).decode())
+            logging.debug('AES128 TGS: %s' % entry)
             if fd is None:
                 print(entry)
             else:
@@ -205,6 +207,7 @@ class GetUserSPNs:
                 constants.EncryptionTypes.aes256_cts_hmac_sha1_96.value, username, decodedTGS['ticket']['realm'], spn.replace(':', '~'),
                 hexlify(decodedTGS['ticket']['enc-part']['cipher'][-12:].asOctets()).decode(),
                 hexlify(decodedTGS['ticket']['enc-part']['cipher'][:-12:].asOctets()).decode())
+            logging.debug('AES256 TGS: %s' % entry)
             if fd is None:
                 print(entry)
             else:
@@ -214,6 +217,7 @@ class GetUserSPNs:
                 constants.EncryptionTypes.des_cbc_md5.value, username, decodedTGS['ticket']['realm'], spn.replace(':', '~'),
                 hexlify(decodedTGS['ticket']['enc-part']['cipher'][:16].asOctets()).decode(),
                 hexlify(decodedTGS['ticket']['enc-part']['cipher'][16:].asOctets()).decode())
+            logging.debug('DES TGS: %s' % entry)
             if fd is None:
                 print(entry)
             else:

--- a/examples/GetUserSPNs.py
+++ b/examples/GetUserSPNs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python
 # Impacket - Collection of Python classes for working with network protocols.
 #
 # SECUREAUTH LABS. Copyright (C) 2022 SecureAuth Corporation. All rights reserved.


### PR DESCRIPTION
By default, the debug logging is relatively lackluster, not a lot of useful information is provided to you. One thing you might notice is no information regarding the tickets is actually provided. ![image](https://user-images.githubusercontent.com/44957111/172079071-7d31112e-a84b-4587-a9ce-89a4ab8e8160.png)

In this pull request, I've added more verbose logging, this being the printing of the received ticket in the hashcat compatible format. Personally, I've always found this quite odd that you **must** output the hashes to a file and are not printed to the terminal.
![image](https://user-images.githubusercontent.com/44957111/172079007-0a058846-2bcf-4469-9dee-e0e449f36d5f.png)

If anyone else decides to review the PR and wants some future ideas that could be done:
- Save like eTypes to their own files (when provided filename [ex. hash] append the eType to the end of it [ex. hasheType17, hasheType18, hasheType21, etc.)
- Add various debugging levels (1,2,3) that print out more verbose information 1 being basic info (could/couldn't connect to dc), 2 being slightly more advanced (TGS), 3 being full breakdown of data requested (ex. eType, User, Realm, Checksum, Cipher Text, etc.)