### PR TITLE
Feature: Adding option to specify NetBIOS Host name to all SMB traffic

### DIFF
--- a/examples/psexec.py
+++ b/examples/psexec.py
@@ -44,7 +44,7 @@ class RemComMessage(Structure):
     structure = (
         ('Command','4096s=""'),
         ('WorkingDir','260s=""'),
-        ('Priority','<L=0x20'),
+        ('Priority','<L=0x20'),         
         ('ProcessID','<L=0x01'),
         ('Machine','260s=""'),
         ('NoWait','<L=0'),
@@ -65,7 +65,7 @@ lock = Lock()
 class PSEXEC:
     def __init__(self, command, path, exeFile, copyFile, port=445,
                  username='', password='', domain='', hashes=None, aesKey=None, doKerberos=False, kdcHost=None, serviceName=None,
-                 remoteBinaryName=None):
+                 remoteBinaryName=None,netbiosName=None):
         self.__username = username
         self.__password = password
         self.__port = port
@@ -81,6 +81,8 @@ class PSEXEC:
         self.__kdcHost = kdcHost
         self.__serviceName = serviceName
         self.__remoteBinaryName = remoteBinaryName
+        # NETBIOS name
+        self.__netbios = netbiosName
         if hashes is not None:
             self.__lmhash, self.__nthash = hashes.split(':')
 
@@ -90,6 +92,7 @@ class PSEXEC:
         rpctransport = transport.DCERPCTransportFactory(stringbinding)
         rpctransport.set_dport(self.__port)
         rpctransport.setRemoteHost(remoteHost)
+        rpctransport.set_netbiosname(self.__netbios)
         if hasattr(rpctransport, 'set_credentials'):
             # This method exists only for selected protocol sequences.
             rpctransport.set_credentials(self.__username, self.__password, self.__domain, self.__lmhash,
@@ -629,6 +632,8 @@ if __name__ == '__main__':
                        help='Destination port to connect to SMB Server')
     group.add_argument('-service-name', action='store', metavar="service_name", default = '', help='The name of the service'
                                                                                 ' used to trigger the payload')
+    group.add_argument('-netbios-name', action='store', metavar="netbios_name",default= None, help='The name of the NeBios client'
+                                                                                ' used to establish  the SMBConnection')
     group.add_argument('-remote-binary-name', action='store', metavar="remote_binary_name", default = None, help='This will '
                                                             'be the name of the executable uploaded on the target')
 
@@ -678,5 +683,5 @@ if __name__ == '__main__':
         command = 'cmd.exe'
 
     executer = PSEXEC(command, options.path, options.file, options.c, int(options.port), username, password, domain, options.hashes,
-                      options.aesKey, options.k, options.dc_ip, options.service_name, options.remote_binary_name)
+                      options.aesKey, options.k, options.dc_ip, options.service_name, options.remote_binary_name, options.netbios_name)
     executer.run(remoteName, options.target_ip)

--- a/impacket/dcerpc/v5/transport.py
+++ b/impacket/dcerpc/v5/transport.py
@@ -470,7 +470,7 @@ class SMBTransport(DCERPCTransport):
     """Implementation of ncacn_np protocol sequence"""
 
     def __init__(self, remoteName, dstport=445, filename='', username='', password='', domain='', lmhash='', nthash='',
-                 aesKey='', TGT=None, TGS=None, remote_host='', smb_connection=0, doKerberos=False, kdcHost=None, myName=None):
+                 aesKey='', TGT=None, TGS=None, remote_host='', smb_connection=0, doKerberos=False, kdcHost=None):
         DCERPCTransport.__init__(self, remoteName, dstport)
         self.__socket = None
         self.__tid = 0
@@ -496,8 +496,8 @@ class SMBTransport(DCERPCTransport):
 
     def preferred_dialect(self, dialect):
         self.__prefDialect = dialect
-    def set_netbiosname(self,myName):
-        self._netbiosName =myName
+    def set_netbiosname(self,netbios):
+        self._netbiosName =netbios
     def setup_smb_connection(self):
         if not self.__smb_connection :
             if self._netbiosName is not None:


### PR DESCRIPTION
Previous PR did not add the NetBIOS name to subsequent SMB messages. Fixed using Global variable. 
![image](https://user-images.githubusercontent.com/60630639/172529342-3995cc65-0cbf-4f9e-ab4e-37599de79bf7.png)
On the Target Host
![image](https://user-images.githubusercontent.com/60630639/172529390-db92c50d-093c-4732-a2af-75ce05de7b23.png)

More Stealth can be done, but this is just another feature that I personally would want to implement. 