### PR TITLE
Added error handling in LDAP during NTLM Authentication

### DIFF
--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -296,6 +296,12 @@ class LDAPConnection:
             negotiate = getNTLMSSPType1('', domain)
             bindRequest['authentication']['sicilyNegotiate'] = negotiate.getData()
             response = self.sendReceive(bindRequest)[0]['protocolOp']
+            if response['bindResponse']['resultCode'] != ResultCode('success'):
+                raise LDAPSessionError(
+                    errorString='Error in bindRequest during the NTLMAuthNegotiate request -> %s: %s' %
+                                (response['bindResponse']['resultCode'].prettyPrint(),
+                                 response['bindResponse']['diagnosticMessage'])
+                )
 
             # NTLM Challenge
             type2 = response['bindResponse']['matchedDN']


### PR DESCRIPTION
If NTLM is disabled, the LDAP bind request using NTLM will fail during the NTLM negotiation.