### PR TITLE
Added dc-host option to some example scripts

### DIFF
--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -44,12 +44,14 @@ class GetADUsers:
         self.__username = username
         self.__password = password
         self.__domain = domain
+        self.__target = None
         self.__lmhash = ''
         self.__nthash = ''
         self.__aesKey = cmdLineOptions.aesKey
         self.__doKerberos = cmdLineOptions.k
-        self.__target = None
-        self.__kdcHost = cmdLineOptions.dc_ip
+        #[!] in this script the value of -dc-ip option is self.__kdcIP and the value of -dc-host option is self.__kdcHost
+        self.__kdcIP = cmdLineOptions.dc_ip
+        self.__kdcHost = cmdLineOptions.dc_host
         self.__requestUser = cmdLineOptions.user
         self.__all = cmdLineOptions.all
         if cmdLineOptions.hashes is not None:
@@ -69,18 +71,21 @@ class GetADUsers:
         self.__colLen = [20, 30, 19, 19]
         self.__outputFormat = ' '.join(['{%d:%ds} ' % (num, width) for num, width in enumerate(self.__colLen)])
 
-
-
-    def getMachineName(self):
-        if self.__kdcHost is not None:
-            s = SMBConnection(self.__kdcHost, self.__kdcHost)
-        else:
-            s = SMBConnection(self.__domain, self.__domain)
+    def getMachineName(self, target):
         try:
+            s = SMBConnection(target, target)
             s.login('', '')
+        except OSError as e:
+            if str(e).find('timed out') > 0:
+                raise Exception('The connection is timed out. '
+                                'Probably 445/TCP port is closed. '
+                                'Try to specify corresponding NetBIOS name or FQDN '
+                                'as the value of the -dc-host option')
+            else:
+                raise
         except Exception:
             if s.getServerName() == '':
-                raise Exception('Error while anonymous logging into %s' % self.__domain)
+                raise Exception('Error while anonymous logging into %s' % target)
         else:
             s.logoff()
         return s.getServerName()
@@ -124,32 +129,38 @@ class GetADUsers:
             pass
 
     def run(self):
-        if self.__doKerberos:
-            self.__target = self.getMachineName()
+        if self.__kdcHost is not None:
+            self.__target = self.__kdcHost
         else:
-            if self.__kdcHost is not None:
-                self.__target = self.__kdcHost
+            if self.__kdcIP is not None:
+                self.__target = self.__kdcIP
             else:
                 self.__target = self.__domain
 
+            if self.__doKerberos:
+                logging.info('Getting machine hostname')
+                self.__target = self.getMachineName(self.__target)
+
         # Connect to LDAP
         try:
-            ldapConnection = ldap.LDAPConnection('ldap://%s'%self.__target, self.baseDN, self.__kdcHost)
+            ldapConnection = ldap.LDAPConnection('ldap://%s' % self.__target, self.baseDN, self.__kdcIP)
             if self.__doKerberos is not True:
                 ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
             else:
                 ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
-                                             self.__aesKey, kdcHost=self.__kdcHost)
+                                             self.__aesKey, kdcHost=self.__kdcIP)
         except ldap.LDAPSessionError as e:
             if str(e).find('strongerAuthRequired') >= 0:
                 # We need to try SSL
-                ldapConnection = ldap.LDAPConnection('ldaps://%s' % self.__target, self.baseDN, self.__kdcHost)
+                ldapConnection = ldap.LDAPConnection('ldaps://%s' % self.__target, self.baseDN, self.__kdcIP)
                 if self.__doKerberos is not True:
                     ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
                 else:
                     ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
-                                                 self.__aesKey, kdcHost=self.__kdcHost)
+                                                 self.__aesKey, kdcHost=self.__kdcIP)
             else:
+                if self.__kdcIP is not None and self.__kdcHost is not None:
+                    logging.critical("If the credentials are valid, check the hostname and IP address of KDC. They must match exactly each other")
                 raise
 
         logging.info('Querying %s for information about domain.' % self.__target)
@@ -185,7 +196,7 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser(add_help = True, description = "Queries target domain for users data")
 
-    parser.add_argument('target', action='store', help='domain/username[:password]')
+    parser.add_argument('target', action='store', help='domain[/username[:password]]')
     parser.add_argument('-user', action='store', metavar='username', help='Requests data for specific user ')
     parser.add_argument('-all', action='store_true', help='Return all users, including those with no email '
                                                            'addresses and disabled accounts. When used with -user it '
@@ -194,7 +205,6 @@ if __name__ == '__main__':
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
 
     group = parser.add_argument_group('authentication')
-
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
     group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful for -k)')
     group.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file '
@@ -203,9 +213,14 @@ if __name__ == '__main__':
                                                        'line')
     group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication '
                                                                             '(128 or 256 bits)')
-    group.add_argument('-dc-ip', action='store',metavar = "ip address",  help='IP Address of the domain controller. If '
+
+    group = parser.add_argument_group('connection')
+    group.add_argument('-dc-ip', action='store', metavar='ip address', help='IP Address of the domain controller. If '
                                                                               'ommited it use the domain part (FQDN) '
                                                                               'specified in the target parameter')
+    group.add_argument('-dc-host', action='store', metavar='hostname', help='Hostname of the domain controller to use. '
+                                                                              'If ommited, the domain part (FQDN) '
+                                                                              'specified in the account parameter will be used')
 
     if len(sys.argv)==1:
         parser.print_help()

--- a/examples/GetADUsers.py
+++ b/examples/GetADUsers.py
@@ -35,7 +35,7 @@ from impacket.dcerpc.v5.samr import UF_ACCOUNTDISABLE
 from impacket.examples import logger
 from impacket.examples.utils import parse_credentials
 from impacket.ldap import ldap, ldapasn1
-from impacket.smbconnection import SMBConnection
+from impacket.smbconnection import SMBConnection, SessionError
 
 
 class GetADUsers:
@@ -77,10 +77,14 @@ class GetADUsers:
             s.login('', '')
         except OSError as e:
             if str(e).find('timed out') > 0:
-                raise Exception('The connection is timed out. '
-                                'Probably 445/TCP port is closed. '
-                                'Try to specify corresponding NetBIOS name or FQDN '
-                                'as the value of the -dc-host option')
+                raise Exception('The connection is timed out. Probably 445/TCP port is closed. Try to specify '
+                                'corresponding NetBIOS name or FQDN as the value of the -dc-host option')
+            else:
+                raise
+        except SessionError as e:
+            if str(e).find('STATUS_NOT_SUPPORTED') > 0:
+                raise Exception('The SMB request is not supported. Probably NTLM is disabled. Try to specify '
+                                'corresponding NetBIOS name or FQDN as the value of the -dc-host option')
             else:
                 raise
         except Exception:
@@ -159,8 +163,13 @@ class GetADUsers:
                     ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
                                                  self.__aesKey, kdcHost=self.__kdcIP)
             else:
-                if self.__kdcIP is not None and self.__kdcHost is not None:
-                    logging.critical("If the credentials are valid, check the hostname and IP address of KDC. They must match exactly each other")
+                if str(e).find('NTLMAuthNegotiate') >= 0:
+                    logging.critical("NTLM negotiation failed. Probably NTLM is disabled. Try to use Kerberos "
+                                     "authentication instead.")
+                else:
+                    if self.__kdcIP is not None and self.__kdcHost is not None:
+                        logging.critical("If the credentials are valid, check the hostname and IP address of KDC. They "
+                                         "must match exactly each other.")
                 raise
 
         logging.info('Querying %s for information about domain.' % self.__target)
@@ -258,4 +267,4 @@ if __name__ == '__main__':
         if logging.getLogger().level == logging.DEBUG:
             import traceback
             traceback.print_exc()
-        print((str(e)))
+        logging.error(str(e))

--- a/examples/findDelegation.py
+++ b/examples/findDelegation.py
@@ -57,12 +57,15 @@ class FindDelegation:
         self.__username = username
         self.__password = password
         self.__domain = user_domain
+        self.__target = None
         self.__targetDomain = target_domain
         self.__lmhash = ''
         self.__nthash = ''
         self.__aesKey = cmdLineOptions.aesKey
         self.__doKerberos = cmdLineOptions.k
-        self.__kdcHost = cmdLineOptions.dc_ip
+        #[!] in this script the value of -dc-ip option is self.__kdcIP and the value of -dc-host option is self.__kdcHost
+        self.__kdcIP = cmdLineOptions.dc_ip
+        self.__kdcHost = cmdLineOptions.dc_host
         if cmdLineOptions.hashes is not None:
             self.__lmhash, self.__nthash = cmdLineOptions.hashes.split(':')
 
@@ -73,61 +76,67 @@ class FindDelegation:
             self.baseDN += 'dc=%s,' % i
         # Remove last ','
         self.baseDN = self.baseDN[:-1]
-        # We can't set the KDC to a custom IP when requesting things cross-domain
+        # We can't set the KDC to a custom IP or Hostname when requesting things cross-domain
         # because then the KDC host will be used for both
         # the initial and the referral ticket, which breaks stuff.
-        if user_domain != target_domain and self.__kdcHost:
-            logging.warning('DC ip will be ignored because of cross-domain targeting.')
+        if user_domain != self.__targetDomain and (self.__kdcIP or self.__kdcHost):
+            logging.warning('KDC IP address and hostname will be ignored because of cross-domain targeting.')
+            self.__kdcIP = None
             self.__kdcHost = None
 
-    def getMachineName(self):
-        if self.__kdcHost is not None and self.__targetDomain == self.__domain:
-            s = SMBConnection(self.__kdcHost, self.__kdcHost)
-        else:
-            s = SMBConnection(self.__targetDomain, self.__targetDomain)
+    def getMachineName(self, target):
         try:
+            s = SMBConnection(target, target)
             s.login('', '')
+        except OSError as e:
+            if str(e).find('timed out') > 0:
+                raise Exception('The connection is timed out. '
+                                'Probably 445/TCP port is closed. '
+                                'Try to specify corresponding NetBIOS name or FQDN '
+                                'as the value of the -dc-host option')
+            else:
+                raise
         except Exception:
             if s.getServerName() == '':
-                raise Exception('Error while anonymous logging into %s')
+                raise Exception('Error while anonymous logging into %s' % target)
         else:
-            try:
-                s.logoff()
-            except Exception:
-                # We don't care about exceptions here as we already have the required
-                # information. This also works around the current SMB3 bug
-                pass
+            s.logoff()
         return "%s.%s" % (s.getServerName(), s.getServerDNSDomainName())
     
 
     def run(self):
-
-        if self.__doKerberos:
-            target = self.getMachineName()
+        if self.__kdcHost is not None and self.__targetDomain == self.__domain:
+            self.__target = self.__kdcHost
         else:
-            if self.__kdcHost is not None and self.__targetDomain == self.__domain:
-                target = self.__kdcHost
+            if self.__kdcIP is not None and self.__targetDomain == self.__domain:
+                self.__target = self.__kdcIP
             else:
-                target = self.__targetDomain
+                self.__target = self.__targetDomain
+
+            if self.__doKerberos:
+                logging.info('Getting machine hostname')
+                self.__target = self.getMachineName(self.__target)
 
         # Connect to LDAP
         try:
-            ldapConnection = ldap.LDAPConnection('ldap://%s' % target, self.baseDN, self.__kdcHost)
+            ldapConnection = ldap.LDAPConnection('ldap://%s' % self.__target, self.baseDN, self.__kdcIP)
             if self.__doKerberos is not True:
                 ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
             else:
                 ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
-                                             self.__aesKey, kdcHost=self.__kdcHost)
+                                             self.__aesKey, kdcHost=self.__kdcIP)
         except ldap.LDAPSessionError as e:
             if str(e).find('strongerAuthRequired') >= 0:
                 # We need to try SSL
-                ldapConnection = ldap.LDAPConnection('ldaps://%s' % target, self.baseDN, self.__kdcHost)
+                ldapConnection = ldap.LDAPConnection('ldaps://%s' % self.__target, self.baseDN, self.__kdcIP)
                 if self.__doKerberos is not True:
                     ldapConnection.login(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash)
                 else:
                     ldapConnection.kerberosLogin(self.__username, self.__password, self.__domain, self.__lmhash, self.__nthash,
-                                                 self.__aesKey, kdcHost=self.__kdcHost)
+                                                 self.__aesKey, kdcHost=self.__kdcIP)
             else:
+                if self.__kdcIP is not None and self.__kdcHost is not None:
+                    logging.critical("If the credentials are valid, check the hostname and IP address of KDC. They must match exactly each other")
                 raise
 
         searchFilter = "(&(|(UserAccountControl:1.2.840.113556.1.4.803:=16777216)(UserAccountControl:1.2.840.113556.1.4.803:=" \
@@ -230,20 +239,18 @@ class FindDelegation:
 
 # Process command-line arguments.
 if __name__ == '__main__':
-    # Init the example's logger theme
-    logger.init()
     print(version.BANNER)
 
     parser = argparse.ArgumentParser(add_help = True, description = "Queries target domain for delegation relationships ")
 
-    parser.add_argument('target', action='store', help='domain/username[:password]')
+    parser.add_argument('target', action='store', help='domain[/username[:password]]')
     parser.add_argument('-target-domain', action='store', help='Domain to query/request if different than the domain of the user. '
                                                                'Allows for retrieving delegation info across trusts.')
 
+    parser.add_argument('-ts', action='store_true', help='Adds timestamp to every logging output')
     parser.add_argument('-debug', action='store_true', help='Turn DEBUG output ON')
 
     group = parser.add_argument_group('authentication')
-
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
     group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful for -k)')
     group.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file '
@@ -252,16 +259,24 @@ if __name__ == '__main__':
                                                        'line')
     group.add_argument('-aesKey', action="store", metavar = "hex key", help='AES key to use for Kerberos Authentication '
                                                                             '(128 or 256 bits)')
-    group.add_argument('-dc-ip', action='store',metavar = "ip address",  help='IP Address of the domain controller. If '
+
+    group = parser.add_argument_group('connection')
+    group.add_argument('-dc-ip', action='store', metavar='ip address', help='IP Address of the domain controller. If '
                                                                               'ommited it use the domain part (FQDN) '
                                                                               'specified in the target parameter. Ignored'
                                                                               'if -target-domain is specified.')
+    group.add_argument('-dc-host', action='store', metavar='hostname', help='Hostname of the domain controller to use. '
+                                                                              'If ommited, the domain part (FQDN) '
+                                                                              'specified in the account parameter will be used')
 
     if len(sys.argv)==1:
         parser.print_help()
         sys.exit(1)
 
     options = parser.parse_args()
+
+    # Init the example's logger theme
+    logger.init(options.ts)
 
     if options.debug is True:
         logging.getLogger().setLevel(logging.DEBUG)

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -552,9 +552,17 @@ class RAISECHILD:
 
     @staticmethod
     def getMachineName(machineIP):
-        s = SMBConnection(machineIP, machineIP)
         try:
-            s.login('','')
+            s = SMBConnection(machineIP, machineIP)
+            s.login('', '')
+        except OSError as e:
+            if str(e).find('timed out') > 0:
+                raise Exception('The connection is timed out. '
+                                'Probably 445/TCP port is closed. '
+                                'Try to specify corresponding NetBIOS name or FQDN '
+                                'instead of IP address')
+            else:
+                raise
         except Exception:
             logging.debug('Error while anonymous logging into %s' % machineIP)
         else:
@@ -563,9 +571,17 @@ class RAISECHILD:
 
     @staticmethod
     def getDNSMachineName(machineIP):
-        s = SMBConnection(machineIP, machineIP)
         try:
-            s.login('','')
+            s = SMBConnection(machineIP, machineIP)
+            s.login('', '')
+        except OSError as e:
+            if str(e).find('timed out') > 0:
+                raise Exception('The connection is timed out. '
+                                'Probably 445/TCP port is closed. '
+                                'Try to specify corresponding NetBIOS name or FQDN '
+                                'instead of IP address')
+            else:
+                raise
         except Exception:
             logging.debug('Error while anonymous logging into %s' % machineIP)
         else:
@@ -1222,7 +1238,6 @@ class RAISECHILD:
                 executer.run(self.__target)
 
 if __name__ == '__main__':
-
     print(version.BANNER)
 
     parser = argparse.ArgumentParser(add_help = True, description = "Privilege Escalation from a child domain up to its "
@@ -1240,7 +1255,6 @@ if __name__ == '__main__':
                         'dump credentials. Administrator (500) by default.')
 
     group = parser.add_argument_group('authentication')
-
     group.add_argument('-hashes', action="store", metavar = "LMHASH:NTHASH", help='NTLM hashes, format is LMHASH:NTHASH')
     group.add_argument('-no-pass', action="store_true", help='don\'t ask for password (useful for -k)')
     group.add_argument('-k', action="store_true", help='Use Kerberos authentication. Grabs credentials from ccache file '
@@ -1305,4 +1319,4 @@ if __name__ == '__main__':
         logging.critical(str(e))
         if hasattr(e, 'error_code'):
             if e.error_code == 0xc0000073:
-                logging.info("Account not found in domain. (RID:%s)", options.targetRID)
+                logging.info("Account not found in domain. (RID:%s)" % options.targetRID)

--- a/examples/raiseChild.py
+++ b/examples/raiseChild.py
@@ -557,10 +557,14 @@ class RAISECHILD:
             s.login('', '')
         except OSError as e:
             if str(e).find('timed out') > 0:
-                raise Exception('The connection is timed out. '
-                                'Probably 445/TCP port is closed. '
-                                'Try to specify corresponding NetBIOS name or FQDN '
-                                'instead of IP address')
+                raise Exception('The connection is timed out. Probably 445/TCP port is closed. Try to specify '
+                                'corresponding NetBIOS name or FQDN instead of IP address')
+            else:
+                raise
+        except SessionError as e:
+            if str(e).find('STATUS_NOT_SUPPORTED') > 0:
+                raise Exception('The SMB request is not supported. Probably NTLM is disabled. Try to specify '
+                                'corresponding NetBIOS name or FQDN as the value of the -dc-host option.')
             else:
                 raise
         except Exception:
@@ -576,10 +580,14 @@ class RAISECHILD:
             s.login('', '')
         except OSError as e:
             if str(e).find('timed out') > 0:
-                raise Exception('The connection is timed out. '
-                                'Probably 445/TCP port is closed. '
-                                'Try to specify corresponding NetBIOS name or FQDN '
-                                'instead of IP address')
+                raise Exception('The connection is timed out. Probably 445/TCP port is closed. Try to specify '
+                                'corresponding NetBIOS name or FQDN instead of IP address.')
+            else:
+                raise
+        except SessionError as e:
+            if str(e).find('STATUS_NOT_SUPPORTED') > 0:
+                raise Exception('The SMB request is not supported. Probably NTLM is disabled. Try to specify '
+                                'corresponding NetBIOS name or FQDN as the value of the -dc-host option.')
             else:
                 raise
         except Exception:

--- a/examples/reg.py
+++ b/examples/reg.py
@@ -493,7 +493,7 @@ class RegHandler:
                 print("Unknown Type 0x%x!" % valueType)
                 hexdump(valueData)
         except Exception as e:
-            logging.debug('Exception thrown when printing reg value %s', str(e))
+            logging.debug('Exception thrown when printing reg value %s' % str(e))
             print('Invalid data')
             pass
 

--- a/examples/smbrelayx.py
+++ b/examples/smbrelayx.py
@@ -141,7 +141,7 @@ class doAttack(Thread):
             try:
                 if self.__command is not None:
                     remoteOps._RemoteOperations__executeRemote(self.__command)
-                    logging.info("Executed specified command on host: %s", self.__SMBConnection.getRemoteHost())
+                    logging.info("Executed specified command on host: %s" % self.__SMBConnection.getRemoteHost())
                     self.__answerTMP = b''
                     self.__SMBConnection.getFile('ADMIN$', 'Temp\\__output', self.__answer)
                     logging.debug('Raw answer %r' % self.__answerTMP)
@@ -161,7 +161,7 @@ class doAttack(Thread):
                     samFileName = remoteOps.saveSAM()
                     samHashes = SAMHashes(samFileName, bootKey, isRemote = True)
                     samHashes.dump()
-                    logging.info("Done dumping SAM hashes for host: %s", self.__SMBConnection.getRemoteHost())
+                    logging.info("Done dumping SAM hashes for host: %s" % self.__SMBConnection.getRemoteHost())
             except Exception as e:
                 logging.debug('Exception:', exc_info=True)
                 ATTACKED_HOSTS.remove(self.__SMBConnection.getRemoteHost())


### PR DESCRIPTION
Some example scripts using Kerberos authentication don't work when the SMB protocol ( 445/TCP port) is blocked/filtered or the NTLM authentication is disabled.

This PR adds a new option `dc-host` to connect to specific KDC using its FQDN or NetBIOS name. It includes:

* Added option -dc-host to `GetADUsers.py`, `GetNPUsers.py`, `GetUserSPNs.py` and `findDelegation.py` example scripts.
* Added SMB session error handling in getMachineName() (SMB blocked).
* Added LDAP session error handling in NTLM authentication (NTLM disabled).

It should fixes #1206.

Based on @rmaksimov work. Thanks!