### PR TITLE
Changed the setting up for new SSL connections

### DIFF
--- a/examples/getST.py
+++ b/examples/getST.py
@@ -13,7 +13,7 @@
 #   the -impersonate switch to request the ticket on behalf other user (it will use S4U2Self/S4U2Proxy to
 #   request the ticket.)
 #
-#   Similar feature has been implemented already by Benjamin Delphi (@gentilkiwi) in Kekeo (s4u)
+#   Similar feature has been implemented already by Benjamin Delpy (@gentilkiwi) in Kekeo (s4u)
 #
 #   Examples:
 #       ./getST.py -hashes lm:nt -spn cifs/contoso-dc contoso.com/user

--- a/examples/rdp_check.py
+++ b/examples/rdp_check.py
@@ -409,8 +409,8 @@ if __name__ == '__main__':
        # a self-signed X.509 certificate.
 
        # Switching to TLS now
-       ctx = SSL.Context(SSL.TLSv1_2_METHOD)
-       ctx.set_cipher_list(b'RC4,AES')
+       ctx = SSL.Context(SSL.TLS_METHOD)
+       ctx.set_cipher_list('ALL:@SECLEVEL=0'.encode('utf-8'))
        tls = SSL.Connection(ctx,s)
        tls.set_connect_state()
        tls.do_handshake()
@@ -446,7 +446,6 @@ if __name__ == '__main__':
        buff = tls.recv(4096)
        ts_request.fromString(buff)
 
-   
        # 3. The client encrypts the public key it received from the server (contained 
        # in the X.509 certificate) in the TLS handshake from step 1, by using the 
        # confidentiality support of SPNEGO. The public key that is encrypted is the 

--- a/examples/rdp_check.py
+++ b/examples/rdp_check.py
@@ -411,6 +411,9 @@ if __name__ == '__main__':
        # Switching to TLS now
        ctx = SSL.Context(SSL.TLS_METHOD)
        ctx.set_cipher_list('ALL:@SECLEVEL=0'.encode('utf-8'))
+       SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION = 0x00040000
+       ctx.set_options(SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION)
+       ctx.set_options(SSL.OP_DONT_INSERT_EMPTY_FRAGMENTS)
        tls = SSL.Connection(ctx,s)
        tls.set_connect_state()
        tls.do_handshake()

--- a/examples/rdp_check.py
+++ b/examples/rdp_check.py
@@ -466,11 +466,9 @@ if __name__ == '__main__':
        # Get server public key
        server_cert =  tls.get_peer_certificate()
        pkey = server_cert.get_pubkey()
-       dump = crypto.dump_privatekey(crypto.FILETYPE_ASN1, pkey)
-
-       # Fix up due to PyOpenSSL lack for exporting public keys
-       dump = dump[7:]
-       dump = b'\x30'+ asn1encode(dump)
+       dump = crypto.dump_publickey(crypto.FILETYPE_ASN1, pkey)
+       # Parsing the key from ASN1 encoded
+       dump = dump[24:]
 
        cipher = SPNEGOCipher(type3['flags'], exportedSessionKey)
        signature, cripted_key = cipher.encrypt(dump)

--- a/impacket/examples/ntlmrelayx/clients/mssqlrelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/mssqlrelayclient.py
@@ -50,8 +50,8 @@ class MYMSSQL(MSSQL):
             LOG.debug("Encryption required, switching to TLS")
 
             # Switching to TLS now
-            ctx = SSL.Context(SSL.TLSv1_METHOD)
-            ctx.set_cipher_list('RC4, AES256')
+            ctx = SSL.Context(SSL.TLS_METHOD)
+            ctx.set_cipher_list('ALL:@SECLEVEL=0'.encode('utf-8'))
             tls = SSL.Connection(ctx,None)
             tls.set_connect_state()
             while True:

--- a/impacket/examples/ntlmrelayx/utils/ssl.py
+++ b/impacket/examples/ntlmrelayx/utils/ssl.py
@@ -55,7 +55,8 @@ class SSLServerMixin(object):
         # Create a context, we don't really care about the SSL/TLS
         # versions used since it is only intended for local use and thus
         # doesn't have to be super-secure
-        ctx = SSL.Context(SSL.SSLv23_METHOD)
+        ctx = SSL.Context(SSL.TLS_METHOD)
+        ctx.set_cipher_list('ALL:@SECLEVEL=0'.encode('utf-8'))
         try:
             ctx.use_privatekey_file(cert)
             ctx.use_certificate_file(cert)

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -116,7 +116,7 @@ class LDAPConnection:
         else:
             # Switching to TLS now
             ctx = SSL.Context(SSL.TLS_METHOD)
-            # ctx.set_cipher_list('RC4')
+            ctx.set_cipher_list('ALL:@SECLEVEL=0'.encode('utf-8'))
             self._socket = SSL.Connection(ctx, self._socket)
             self._socket.connect(sa)
             self._socket.do_handshake()

--- a/impacket/ldap/ldap.py
+++ b/impacket/ldap/ldap.py
@@ -117,6 +117,8 @@ class LDAPConnection:
             # Switching to TLS now
             ctx = SSL.Context(SSL.TLS_METHOD)
             ctx.set_cipher_list('ALL:@SECLEVEL=0'.encode('utf-8'))
+            SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION = 0x00040000
+            ctx.set_options(SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION)
             self._socket = SSL.Connection(ctx, self._socket)
             self._socket.connect(sa)
             self._socket.do_handshake()

--- a/impacket/mqtt.py
+++ b/impacket/mqtt.py
@@ -244,7 +244,8 @@ class MQTTConnection:
         s.connect((self._targetHost, int(self._targetPort)))
 
         if self._isSSL is True:
-            ctx = SSL.Context(SSL.TLSv1_METHOD)
+            ctx = SSL.Context(SSL.TLS_METHOD)
+            ctx.set_cipher_list('ALL:@SECLEVEL=0'.encode('utf-8'))
             self._socket = SSL.Connection(ctx, s)
             self._socket.set_connect_state()
             self._socket.do_handshake()

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -664,7 +664,7 @@ class MSSQL:
 
             # Switching to TLS now
             ctx = SSL.Context(SSL.TLS_METHOD)
-            ctx.set_cipher_list('RC4, AES256')
+            ctx.set_cipher_list('ALL:@SECLEVEL=0'.encode('utf-8'))
             tls = SSL.Connection(ctx,None)
             tls.set_connect_state()
             while True:
@@ -873,7 +873,7 @@ class MSSQL:
 
             # Switching to TLS now
             ctx = SSL.Context(SSL.TLS_METHOD)
-            ctx.set_cipher_list('RC4, AES256')
+            ctx.set_cipher_list('ALL:@SECLEVEL=0'.encode('utf-8'))
             tls = SSL.Connection(ctx,None)
             tls.set_connect_state()
             while True:

--- a/impacket/tds.py
+++ b/impacket/tds.py
@@ -663,7 +663,7 @@ class MSSQL:
             LOG.info("Encryption required, switching to TLS")
 
             # Switching to TLS now
-            ctx = SSL.Context(SSL.TLSv1_2_METHOD)
+            ctx = SSL.Context(SSL.TLS_METHOD)
             ctx.set_cipher_list('RC4, AES256')
             tls = SSL.Connection(ctx,None)
             tls.set_connect_state()
@@ -872,7 +872,7 @@ class MSSQL:
             LOG.info("Encryption required, switching to TLS")
 
             # Switching to TLS now
-            ctx = SSL.Context(SSL.TLSv1_2_METHOD)
+            ctx = SSL.Context(SSL.TLS_METHOD)
             ctx.set_cipher_list('RC4, AES256')
             tls = SSL.Connection(ctx,None)
             tls.set_connect_state()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ six
 chardet
 pyasn1>=0.2.3
 pycryptodomex
-pyOpenSSL>=0.16.2
+pyOpenSSL>=21.0.0
 ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6
 ldapdomaindump>=0.9.0
 flask>=1.0

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(
     scripts=glob.glob(os.path.join('examples', '*.py')),
     data_files=data_files,
     install_requires=['pyasn1>=0.2.3', 'pycryptodomex', 'pyOpenSSL>=21.0.0', 'six', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6',
-                      'ldapdomaindump>=0.9.0', 'flask>=1.0', 'future', 'chardet', 'dsinternals'],
+                      'ldapdomaindump>=0.9.0', 'flask>=1.0', 'future', 'charset_normalizer', 'dsinternals'],
     extras_require={'pyreadline:sys_platform=="win32"': [],
                     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
               'impacket.examples.ntlmrelayx.attacks', 'impacket.examples.ntlmrelayx.attacks.httpattacks'],
     scripts=glob.glob(os.path.join('examples', '*.py')),
     data_files=data_files,
-    install_requires=['pyasn1>=0.2.3', 'pycryptodomex', 'pyOpenSSL>=0.16.2', 'six', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6',
+    install_requires=['pyasn1>=0.2.3', 'pycryptodomex', 'pyOpenSSL>=21.0.0', 'six', 'ldap3>=2.5,!=2.5.2,!=2.5.0,!=2.6',
                       'ldapdomaindump>=0.9.0', 'flask>=1.0', 'future', 'chardet', 'dsinternals'],
     extras_require={'pyreadline:sys_platform=="win32"': [],
                     },


### PR DESCRIPTION
This PR includes:

* Modified the SSL context setting. Using TLS_METHOD the protocol version used will be negotiated to the highest version mutually supported by the client and the server
* Modified cipher list setting. Defining 'ALL:@SECLEVEL=0' enables compatibility with previous versions.
* Updated pyOpenSSL requirement to >=v21.0.0. This version included the TLS_METHOD definition.

It should fixes #429 and #856. 

More test is needed.

Thanks @mpgn and @CT-H00K!