### PR TITLE
Add new Kerberos error codes

### DIFF
--- a/impacket/krb5/constants.py
+++ b/impacket/krb5/constants.py
@@ -191,113 +191,122 @@ class NameTypes(Enum):
 
 # 7.5.9.  Error Codes
 class ErrorCodes(Enum):
-    KDC_ERR_NONE                           = 0  # No error
-    KDC_ERR_NAME_EXP                       = 1  # Client's entry in database
-                                                # has expired
-    KDC_ERR_SERVICE_EXP                    = 2  # Server's entry in database
-                                                # has expired
-    KDC_ERR_BAD_PVNO                       = 3  # Requested protocol version
-                                                # number not supported
-    KDC_ERR_C_OLD_MAST_KVNO                = 4  # Client's key encrypted in
-                                                # old master key
-    KDC_ERR_S_OLD_MAST_KVNO                = 5  # Server's key encrypted in
-                                                # old master key
-    KDC_ERR_C_PRINCIPAL_UNKNOWN            = 6  # Client not found in
-                                                # Kerberos database
-    KDC_ERR_S_PRINCIPAL_UNKNOWN            = 7  # Server not found in
-                                                # Kerberos database
-    KDC_ERR_PRINCIPAL_NOT_UNIQUE           = 8  # Multiple principal entries
-                                                # in database
-    KDC_ERR_NULL_KEY                       = 9  # The client or server has a
-                                                # null key
-    KDC_ERR_CANNOT_POSTDATE               = 10  # Ticket not eligible for
-                                                # postdating
-    KDC_ERR_NEVER_VALID                   = 11  # Requested starttime is
-                                                # later than end time
-    KDC_ERR_POLICY                        = 12  # KDC policy rejects request
-    KDC_ERR_BADOPTION                     = 13  # KDC cannot accommodate
-                                                # requested option
-    KDC_ERR_ETYPE_NOSUPP                  = 14  # KDC has no support for
-                                                # encryption type
-    KDC_ERR_SUMTYPE_NOSUPP                = 15  # KDC has no support for
-                                                # checksum type
-    KDC_ERR_PADATA_TYPE_NOSUPP            = 16  # KDC has no support for
-                                                # padata type
-    KDC_ERR_TRTYPE_NOSUPP                 = 17  # KDC has no support for
-                                                # transited type
-    KDC_ERR_CLIENT_REVOKED                = 18  # Clients credentials have
-                                                # been revoked
-    KDC_ERR_SERVICE_REVOKED               = 19  # Credentials for server have
-                                                # been revoked
-    KDC_ERR_TGT_REVOKED                   = 20  # TGT has been revoked
-    KDC_ERR_CLIENT_NOTYET                 = 21  # Client not yet valid; try
-                                                # again later
-    KDC_ERR_SERVICE_NOTYET                = 22  # Server not yet valid; try
-                                                # again later
-    KDC_ERR_KEY_EXPIRED                   = 23  # Password has expired;
-                                                # change password to reset
-    KDC_ERR_PREAUTH_FAILED                = 24  # Pre-authentication
-                                                # information was invalid
-    KDC_ERR_PREAUTH_REQUIRED              = 25  # Additional pre-
-                                                # authentication required
-    KDC_ERR_SERVER_NOMATCH                = 26  # Requested server and ticket
-                                                # don't match
-    KDC_ERR_MUST_USE_USER2USER            = 27  # Server principal valid for
-                                                # user2user only
-    KDC_ERR_PATH_NOT_ACCEPTED             = 28  # KDC Policy rejects
-                                                # transited path
-    KDC_ERR_SVC_UNAVAILABLE               = 29  # A service is not available
-    KRB_AP_ERR_BAD_INTEGRITY              = 31  # Integrity check on
-                                                # decrypted field failed
-    KRB_AP_ERR_TKT_EXPIRED                = 32  # Ticket expired
-    KRB_AP_ERR_TKT_NYV                    = 33  # Ticket not yet valid
-    KRB_AP_ERR_REPEAT                     = 34  # Request is a replay
-    KRB_AP_ERR_NOT_US                     = 35  # The ticket isn't for us
-    KRB_AP_ERR_BADMATCH                   = 36  # Ticket and authenticator
-                                                # don't match
-    KRB_AP_ERR_SKEW                       = 37  # Clock skew too great
-    KRB_AP_ERR_BADADDR                    = 38  # Incorrect net address
-    KRB_AP_ERR_BADVERSION                 = 39  # Protocol version mismatch
-    KRB_AP_ERR_MSG_TYPE                   = 40  # Invalid msg type
-    KRB_AP_ERR_MODIFIED                   = 41  # Message stream modified
-    KRB_AP_ERR_BADORDER                   = 42  # Message out of order
-    KRB_AP_ERR_BADKEYVER                  = 44  # Specified version of key is
-                                                # not available
-    KRB_AP_ERR_NOKEY                      = 45  # Service key not available
-    KRB_AP_ERR_MUT_FAIL                   = 46  # Mutual authentication
-                                                # failed
-    KRB_AP_ERR_BADDIRECTION               = 47  # Incorrect message direction
-    KRB_AP_ERR_METHOD                     = 48  # Alternative authentication
-                                                # method required
-    KRB_AP_ERR_BADSEQ                     = 49  # Incorrect sequence number
-                                                # in message
-    KRB_AP_ERR_INAPP_CKSUM                = 50  # Inappropriate type of
-                                                # checksum in message
-    KRB_AP_PATH_NOT_ACCEPTED              = 51  # Policy rejects transited
-                                                # path
-    KRB_ERR_RESPONSE_TOO_BIG              = 52  # Response too big for UDP;
-                                                # retry with TCP
-    KRB_ERR_GENERIC                       = 60  # Generic error (description
-                                                # in e-text)
-    KRB_ERR_FIELD_TOOLONG                 = 61  # Field is too long for this
-                                                # implementation
-    KDC_ERROR_CLIENT_NOT_TRUSTED          = 62  # Reserved for PKINIT
-    KDC_ERROR_KDC_NOT_TRUSTED             = 63  # Reserved for PKINIT
-    KDC_ERROR_INVALID_SIG                 = 64  # Reserved for PKINIT
-    KDC_ERR_KEY_TOO_WEAK                  = 65  # Reserved for PKINIT
-    KDC_ERR_CERTIFICATE_MISMATCH          = 66  # Reserved for PKINIT
-    KRB_AP_ERR_NO_TGT                     = 67  # No TGT available to
-                                                # validate USER-TO-USER
-    KDC_ERR_WRONG_REALM                   = 68  # Reserved for future use
-    KRB_AP_ERR_USER_TO_USER_REQUIRED      = 69  # Ticket must be for
-                                                # USER-TO-USER
-    KDC_ERR_CANT_VERIFY_CERTIFICATE       = 70  # Reserved for PKINIT
-    KDC_ERR_INVALID_CERTIFICATE           = 71  # Reserved for PKINIT
-    KDC_ERR_REVOKED_CERTIFICATE           = 72  # Reserved for PKINIT
-    KDC_ERR_REVOCATION_STATUS_UNKNOWN     = 73  # Reserved for PKINIT
-    KDC_ERR_REVOCATION_STATUS_UNAVAILABLE = 74  # Reserved for PKINIT
-    KDC_ERR_CLIENT_NAME_MISMATCH          = 75  # Reserved for PKINIT
-    KDC_ERR_KDC_NAME_MISMATCH             = 76  # Reserved for PKINIT
+    KDC_ERR_NONE                                 = 0  # No error
+    KDC_ERR_NAME_EXP                             = 1  # Client's entry in database
+                                                      # has expired
+    KDC_ERR_SERVICE_EXP                          = 2  # Server's entry in database
+                                                      # has expired
+    KDC_ERR_BAD_PVNO                             = 3  # Requested protocol version
+                                                      # number not supported
+    KDC_ERR_C_OLD_MAST_KVNO                      = 4  # Client's key encrypted in
+                                                      # old master key
+    KDC_ERR_S_OLD_MAST_KVNO                      = 5  # Server's key encrypted in
+                                                      # old master key
+    KDC_ERR_C_PRINCIPAL_UNKNOWN                  = 6  # Client not found in
+                                                      # Kerberos database
+    KDC_ERR_S_PRINCIPAL_UNKNOWN                  = 7  # Server not found in
+                                                      # Kerberos database
+    KDC_ERR_PRINCIPAL_NOT_UNIQUE                 = 8  # Multiple principal entries
+                                                      # in database
+    KDC_ERR_NULL_KEY                             = 9  # The client or server has a
+                                                      # null key
+    KDC_ERR_CANNOT_POSTDATE                     = 10  # Ticket not eligible for
+                                                      # postdating
+    KDC_ERR_NEVER_VALID                         = 11  # Requested starttime is
+                                                      # later than end time
+    KDC_ERR_POLICY                              = 12  # KDC policy rejects request
+    KDC_ERR_BADOPTION                           = 13  # KDC cannot accommodate
+                                                      # requested option
+    KDC_ERR_ETYPE_NOSUPP                        = 14  # KDC has no support for
+                                                      # encryption type
+    KDC_ERR_SUMTYPE_NOSUPP                      = 15  # KDC has no support for
+                                                      # checksum type
+    KDC_ERR_PADATA_TYPE_NOSUPP                  = 16  # KDC has no support for
+                                                      # padata type
+    KDC_ERR_TRTYPE_NOSUPP                       = 17  # KDC has no support for
+                                                      # transited type
+    KDC_ERR_CLIENT_REVOKED                      = 18  # Clients credentials have
+                                                      # been revoked
+    KDC_ERR_SERVICE_REVOKED                     = 19  # Credentials for server have
+                                                      # been revoked
+    KDC_ERR_TGT_REVOKED                         = 20  # TGT has been revoked
+    KDC_ERR_CLIENT_NOTYET                       = 21  # Client not yet valid; try
+                                                      # again later
+    KDC_ERR_SERVICE_NOTYET                      = 22  # Server not yet valid; try
+                                                      # again later
+    KDC_ERR_KEY_EXPIRED                         = 23  # Password has expired;
+                                                      # change password to reset
+    KDC_ERR_PREAUTH_FAILED                      = 24  # Pre-authentication
+                                                      # information was invalid
+    KDC_ERR_PREAUTH_REQUIRED                    = 25  # Additional pre-
+                                                      # authentication required
+    KDC_ERR_SERVER_NOMATCH                      = 26  # Requested server and ticket
+                                                      # don't match
+    KDC_ERR_MUST_USE_USER2USER                  = 27  # Server principal valid for
+                                                      # user2user only
+    KDC_ERR_PATH_NOT_ACCEPTED                   = 28  # KDC Policy rejects
+                                                      # transited path
+    KDC_ERR_SVC_UNAVAILABLE                     = 29  # A service is not available
+    KRB_AP_ERR_BAD_INTEGRITY                    = 31  # Integrity check on
+                                                      # decrypted field failed
+    KRB_AP_ERR_TKT_EXPIRED                      = 32  # Ticket expired
+    KRB_AP_ERR_TKT_NYV                          = 33  # Ticket not yet valid
+    KRB_AP_ERR_REPEAT                           = 34  # Request is a replay
+    KRB_AP_ERR_NOT_US                           = 35  # The ticket isn't for us
+    KRB_AP_ERR_BADMATCH                         = 36  # Ticket and authenticator
+                                                      # don't match
+    KRB_AP_ERR_SKEW                             = 37  # Clock skew too great
+    KRB_AP_ERR_BADADDR                          = 38  # Incorrect net address
+    KRB_AP_ERR_BADVERSION                       = 39  # Protocol version mismatch
+    KRB_AP_ERR_MSG_TYPE                         = 40  # Invalid msg type
+    KRB_AP_ERR_MODIFIED                         = 41  # Message stream modified
+    KRB_AP_ERR_BADORDER                         = 42  # Message out of order
+    KRB_AP_ERR_BADKEYVER                        = 44  # Specified version of key is
+                                                      # not available
+    KRB_AP_ERR_NOKEY                            = 45  # Service key not available
+    KRB_AP_ERR_MUT_FAIL                         = 46  # Mutual authentication
+                                                      # failed
+    KRB_AP_ERR_BADDIRECTION                     = 47  # Incorrect message direction
+    KRB_AP_ERR_METHOD                           = 48  # Alternative authentication
+                                                      # method required
+    KRB_AP_ERR_BADSEQ                           = 49  # Incorrect sequence number
+                                                      # in message
+    KRB_AP_ERR_INAPP_CKSUM                      = 50  # Inappropriate type of
+                                                      # checksum in message
+    KRB_AP_PATH_NOT_ACCEPTED                    = 51  # Policy rejects transited
+                                                      # path
+    KRB_ERR_RESPONSE_TOO_BIG                    = 52  # Response too big for UDP;
+                                                      # retry with TCP
+    KRB_ERR_GENERIC                             = 60  # Generic error (description
+                                                      # in e-text)
+    KRB_ERR_FIELD_TOOLONG                       = 61  # Field is too long for this
+                                                      # implementation
+    KDC_ERROR_CLIENT_NOT_TRUSTED                = 62  # Reserved for PKINIT
+    KDC_ERROR_KDC_NOT_TRUSTED                   = 63  # Reserved for PKINIT
+    KDC_ERROR_INVALID_SIG                       = 64  # Reserved for PKINIT
+    KDC_ERR_KEY_TOO_WEAK                        = 65  # Reserved for PKINIT
+    KDC_ERR_CERTIFICATE_MISMATCH                = 66  # Reserved for PKINIT
+    KRB_AP_ERR_NO_TGT                           = 67  # No TGT available to
+                                                      # validate USER-TO-USER
+    KDC_ERR_WRONG_REALM                         = 68  # Reserved for future use
+    KRB_AP_ERR_USER_TO_USER_REQUIRED            = 69  # Ticket must be for
+                                                      # USER-TO-USER
+    KDC_ERR_CANT_VERIFY_CERTIFICATE             = 70  # Reserved for PKINIT
+    KDC_ERR_INVALID_CERTIFICATE                 = 71  # Reserved for PKINIT
+    KDC_ERR_REVOKED_CERTIFICATE                 = 72  # Reserved for PKINIT
+    KDC_ERR_REVOCATION_STATUS_UNKNOWN           = 73  # Reserved for PKINIT
+    KDC_ERR_REVOCATION_STATUS_UNAVAILABLE       = 74  # Reserved for PKINIT
+    KDC_ERR_CLIENT_NAME_MISMATCH                = 75  # Reserved for PKINIT
+    KDC_ERR_KDC_NAME_MISMATCH                   = 76  # Reserved for PKINIT
+    KDC_ERR_INCONSISTENT_KEY_PURPOSE            = 77  # Reserved for PKINIT
+    KDC_ERR_DIGEST_IN_CERT_NOT_ACCEPTED         = 78  # Reserved for PKINIT
+    KDC_ERR_PA_CHECKSUM_MUST_BE_INCLUDED        = 79  # Reserved for PKINIT
+    KDC_ERR_DIGEST_IN_SIGNED_DATA_NOT_ACCEPTED  = 80  # Reserved for PKINIT
+    KDC_ERR_PUBLIC_KEY_ENCRYPTION_NOT_SUPPORTED = 81  # Reserved for PKINIT
+    KDC_ERR_PREAUTH_EXPIRED                     = 90  # Pre-authentication has expired
+    KDC_ERR_MORE_PREAUTH_DATA_REQUIRED          = 91  # Additional pre-authentication data is required
+    KDC_ERR_PREAUTH_BAD_AUTHENTICATION_SET      = 92  # KDC cannot accommodate requested pre-authentication data element
+    KDC_ERR_UNKNOWN_CRITICAL_FAST_OPTIONS       = 93  # Reserved for PKINIT
  
 ERROR_MESSAGES = {
     0  : ('KDC_ERR_NONE', 'No error'),
@@ -368,6 +377,15 @@ ERROR_MESSAGES = {
     74 : ('KDC_ERR_REVOCATION_STATUS_UNAVAILABLE', 'Reserved for PKINIT'),
     75 : ('KDC_ERR_CLIENT_NAME_MISMATCH', 'Reserved for PKINIT'),
     76 : ('KDC_ERR_KDC_NAME_MISMATCH', 'Reserved for PKINIT'),
+    77 : ('KDC_ERR_INCONSISTENT_KEY_PURPOSE', 'Certificate cannot be used for PKINIT client authentication'),
+    78 : ('KDC_ERR_DIGEST_IN_CERT_NOT_ACCEPTED', 'Digest algorithm for the public key in the certificate is not acceptable by the KDC'),
+    79 : ('KDC_ERR_PA_CHECKSUM_MUST_BE_INCLUDED', 'The paChecksum filed in the request is not present'),
+    80 : ('KDC_ERR_DIGEST_IN_SIGNED_DATA_NOT_ACCEPTED', 'The digest algorithm used by the id-pkinit-authData is not acceptable by the KDC'),
+    81 : ('KDC_ERR_PUBLIC_KEY_ENCRYPTION_NOT_SUPPORTED', 'The KDC does not support the public key encryption key delivery method'),
+    90 : ('KDC_ERR_PREAUTH_EXPIRED', 'Pre-authentication has expired'),
+    91 : ('KDC_ERR_MORE_PREAUTH_DATA_REQUIRED', 'Additional pre-authentication data is required'),
+    92 : ('KDC_ERR_PREAUTH_BAD_AUTHENTICATION_SET', 'KDC cannot accommodate requested pre-authentication data element'),
+    93 : ('KDC_ERR_UNKNOWN_CRITICAL_FAST_OPTIONS', 'Unknown critical option'),
 }
  
 class TicketFlags(Enum):


### PR DESCRIPTION
Added new error codes for Kerberos authentication as specified in [RFC 4556](https://datatracker.ietf.org/doc/html/rfc4556) (PKINIT, 77-81) and [RFC 6113](https://datatracker.ietf.org/doc/html/rfc6113.html) (Pre-authentication, 90-93)