### PR TITLE
Patch SessionKey Derivation function for CALG_SHA1 hashAlgo

### DIFF
--- a/examples/dpapi.py
+++ b/examples/dpapi.py
@@ -491,6 +491,8 @@ class DPAPI:
                     fp2.close()
                 elif self.options.entropy is not None:
                     entropy = b(self.options.entropy)
+                elif self.options.entropy_hex is not None:
+                    entropy = unhexlify(self.options.entropy_hex)
                 else:
                     entropy = None
 
@@ -567,6 +569,7 @@ if __name__ == '__main__':
     unprotect.add_argument('-key', action='store', required=False, help='Key used for decryption')
     unprotect.add_argument('-entropy', action='store', default=None, required=False, help='String with extra entropy needed for decryption')
     unprotect.add_argument('-entropy-file', action='store', default=None, required=False, help='File with binary entropy contents (overwrites -entropy)')
+    unprotect.add_argument('-entropy-hex', action='store', default=None, required=False, help='Hex string with entropy (overwrites -entropy)')
 
     options = parser.parse_args()
 


### PR DESCRIPTION
This PR patches the sessionkey derivation function for DPAPI module when we use CALG_SHA1 hashing algorithm for HMAC with additional entropy.

> Ref to mimikatz specified function - [kull_m_dpapi_hmac_sha1_incorrect](https://github.com/gentilkiwi/mimikatz/blob/b401761f30d6f714340cc6fb7f6aefe5c690d8a5/modules/kull_m_dpapi.c#L495) for key derivation.

For example lets try to decrypt KeePass `ProtectedUserKey.bin` file. It is the UNPROTECT BLOB file that is generated by KeePass when we use WUA for database enryption. KeePass uses additional binary entropy (`DE135B5F18A34670B2572429698898E6` in hex) for CryptProtectData function.

![keepass_files](https://user-images.githubusercontent.com/39065143/180461945-1fc8e6ec-6655-49e4-bc31-957b210f4670.png)
_(keepass files content)_

![ProtectedUserKey](https://user-images.githubusercontent.com/39065143/180462112-8d58b568-3457-4d99-ba32-61c5a3f6abb3.png)
_(BLOB info for ProtectedUserKey.bin file)_

**BEFORE PATCH** (original)

![try_to_decrypt](https://user-images.githubusercontent.com/39065143/180462432-3b907942-ee88-4b67-b6be-8862d831efe0.png)
_(failed decryption attempt)_

**AFTER PATCH** (modified)

![success_decryption](https://user-images.githubusercontent.com/39065143/180462976-d12f3265-8851-4b9e-8801-f13468d9c558.png)
_(success decryption)_

Also was added support for specifying **hex entropy** with the CLI interface (`-entropy-hex` option)
![entropy_hex_cli](https://user-images.githubusercontent.com/39065143/180463491-f6e2a5fd-93b9-4214-a312-fdae41ed2b5d.png)
_(entropy-hex option example)_

