### PR TITLE
added SSLKEYLOGFILE support for HTTPSRelayClient to decrypt relay

### DIFF
--- a/impacket/examples/ntlmrelayx/clients/httprelayclient.py
+++ b/impacket/examples/ntlmrelayx/clients/httprelayclient.py
@@ -28,6 +28,8 @@ from impacket.examples.ntlmrelayx.clients import ProtocolClient
 from impacket.nt_errors import STATUS_SUCCESS, STATUS_ACCESS_DENIED
 from impacket.ntlm import NTLMAuthChallenge
 from impacket.spnego import SPNEGO_NegTokenResp
+import os
+import sslkeylog
 
 PROTOCOL_CLIENT_CLASSES = ["HTTPRelayClient","HTTPSRelayClient"]
 
@@ -121,6 +123,7 @@ class HTTPSRelayClient(HTTPRelayClient):
     PLUGIN_NAME = "HTTPS"
 
     def __init__(self, serverConfig, target, targetPort = 443, extendedSecurity=True ):
+        sslkeylog.set_keylog(os.environ.get('SSLKEYLOGFILE'))
         HTTPRelayClient.__init__(self, serverConfig, target, targetPort, extendedSecurity)
 
     def initConnection(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+sslkeylog
 future
 six
 charset_normalizer


### PR DESCRIPTION
Allows the HTTPSRelayClient to respect the "SSLKEYLOGFILE" environmental variable and log the TLS keys to a file, allowing the user to view decrypted traffic in Wireshark. This is helpful for troubleshooting failing relays. 