### PR TITLE
Correctly include `authtime` and `etype` in ticket conveter

### DIFF
--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -693,7 +693,7 @@ class CCache:
 
         credential['time'] = Times()
 
-        credential['time']['authtime'] = self.toTimeStamp(types.KerberosTime.from_asn1(krbCredInfo['starttime']))
+        credential['time']['authtime'] = self.toTimeStamp(types.KerberosTime.from_asn1(krbCredInfo['authtime']))
         credential['time']['starttime'] = self.toTimeStamp(types.KerberosTime.from_asn1(krbCredInfo['starttime']))
         credential['time']['endtime'] = self.toTimeStamp(types.KerberosTime.from_asn1(krbCredInfo['endtime']))
         credential['time']['renew_till'] = self.toTimeStamp(types.KerberosTime.from_asn1(krbCredInfo['renew-till']))
@@ -731,6 +731,7 @@ class CCache:
 
         krbCredInfo['flags'] = credential['tktflags']
 
+        krbCredInfo['authtime'] = KerberosTime.to_asn1(datetime.utcfromtimestamp(credential['time']['authtime']))
         krbCredInfo['starttime'] = KerberosTime.to_asn1(datetime.utcfromtimestamp(credential['time']['starttime']))
         krbCredInfo['endtime'] = KerberosTime.to_asn1(datetime.utcfromtimestamp(credential['time']['endtime']))
         krbCredInfo['renew-till'] = KerberosTime.to_asn1(datetime.utcfromtimestamp(credential['time']['renew_till']))
@@ -751,7 +752,7 @@ class CCache:
         krbCred['msg-type'] = 22
 
         krbCred['enc-part'] = noValue
-        krbCred['enc-part']['etype'] = 0
+        krbCred['enc-part']['etype'] = credential['key']['keytype']
         krbCred['enc-part']['cipher'] = encoder.encode(encKrbCredPart)
 
         ticket = decoder.decode(credential.ticket['data'], asn1Spec=Ticket())[0]


### PR DESCRIPTION
Couple of minor changes to the ticket converter, I noticed that `authtime` was missing and `etype` was set to 0 on a ticket I was converting to the kirbi format so I've added changes here to pull those out of the ccache credential

# Verification steps
- [ ] Generate a ccache file e.g. `./ticketer.py -nthash <krbtgt/service nthash> -domain-sid <your domain SID> -domain <your domain FQDN> baduser`
- [ ] Convert to kirbi format e.g. `./ticketConverter.py baduser.ccache baduser.kirbi`
- [ ] Check the contents to see that the kirbi file has the same authtime/etype values as the ccache file