### PR TITLE
Enforce minimum of 32 bit flags length

### DIFF
--- a/impacket/krb5/ccache.py
+++ b/impacket/krb5/ccache.py
@@ -729,7 +729,7 @@ class CCache:
         krbCredInfo['pname']['name-type'] = principal.header['name_type']
         seq_set_iter(krbCredInfo['pname'], 'name-string', (principal.components[0].fields['data'],))
 
-        krbCredInfo['flags'] = credential['tktflags']
+        krbCredInfo['flags'] = format(credential['tktflags'], 'b').zfill(32)
 
         krbCredInfo['starttime'] = KerberosTime.to_asn1(datetime.utcfromtimestamp(credential['time']['starttime']))
         krbCredInfo['endtime'] = KerberosTime.to_asn1(datetime.utcfromtimestamp(credential['time']['endtime']))


### PR DESCRIPTION
Currrently during conversion from ccache to kirbi formats the `flags` field can come out as less than the 32 bits specified by the spec, this PR forces that it's a minimum of 32 bits
https://datatracker.ietf.org/doc/html/rfc4120#section-5.2.8

> KerberosFlags   ::= BIT STRING (SIZE (32..MAX))
                       -- minimum number of bits shall be sent,
                       -- but no fewer than 32
             
